### PR TITLE
Refactor Game Channel Scheduling

### DIFF
--- a/utils/bot_res/dateUtils.js
+++ b/utils/bot_res/dateUtils.js
@@ -1,0 +1,51 @@
+/**
+ * Parses a cron string and checks if the date is within the current day and in the past.
+ * @param {string} cronString - The cron string to parse.
+ * @returns {boolean} True if the date is within the current day and in the past, false otherwise.
+ */
+export function isDateTodayAndPast(cronString) {
+	const [minute, hour, day, month] = cronString
+		.split(' ')
+		.map(Number)
+	const now = new Date()
+	const gameDate = new Date(
+		now.getFullYear(),
+		month - 1,
+		day,
+		hour,
+		minute,
+	)
+
+	return (
+		gameDate.toDateString() === now.toDateString() &&
+		gameDate < now
+	)
+}
+
+/**
+ * Checks if the time represented by a cron string is within one hour of the current time.
+ * @param {string} cronString - The cron string to parse.
+ * @returns {boolean} True if the time is within one hour of the current time, false otherwise.
+ */
+export function isWithinOneHour(cronString) {
+	const [minute, hour, day, month] = cronString
+		.split(' ')
+		.map(Number)
+	const now = new Date()
+	const gameDate = new Date(
+		now.getFullYear(),
+		month - 1,
+		day,
+		hour,
+		minute,
+	)
+
+	const oneHourInMilliseconds = 60 * 60 * 1000
+	const timeDifference =
+		gameDate.getTime() - now.getTime()
+
+	return (
+		timeDifference >= 0 &&
+		timeDifference <= oneHourInMilliseconds
+	)
+}

--- a/utils/bot_res/locateChan.js
+++ b/utils/bot_res/locateChan.js
@@ -2,13 +2,17 @@ import { SapDiscClient } from '#main'
 import { server_ID } from '#env'
 
 export default async function locateChannel(channelName) {
-    const guild = SapDiscClient.guilds.cache.get(
-        `${server_ID}`,
-    )
-    const gameChan = guild.channels.cache.find(
-        (GC) =>
-            GC.name.toLowerCase() ===
-            channelName.toLowerCase(),
-    )
-    return gameChan
+	const guild = await SapDiscClient.guilds.cache.get(
+		`${server_ID}`,
+	)
+	const gameChan =
+		(await guild.channels.cache.find(
+			(GC) =>
+				GC.name.toLowerCase() ===
+				channelName.toLowerCase(),
+		)) || null
+	if (!gameChan) {
+		return false
+	}
+	return true
 }

--- a/utils/db/gameSchedule/clearScheduled.js
+++ b/utils/db/gameSchedule/clearScheduled.js
@@ -12,7 +12,7 @@ export default async function clearScheduled() {
 		color: `yellow`,
 		status: `processing`,
 	})
-	const clear = await Cache()
+	const clearIds = await Cache()
 		.remove(`scheduledIds`)
 		.then((res) => {
 			if (res) {
@@ -21,10 +21,12 @@ export default async function clearScheduled() {
 			return false
 		})
 
+	await Cache().remove(`scheduled_games`)
+
 	await logClr({
 		text: `Cleared scheduled games`,
 		color: `green`,
 		status: `done`,
 	})
-	return clear
+	return clearIds
 }

--- a/utils/db/gameSchedule/cronScheduleGames.js
+++ b/utils/db/gameSchedule/cronScheduleGames.js
@@ -1,167 +1,126 @@
 /* eslint-disable camelcase */
 import _ from 'lodash'
-import {
-	parseISO,
-	isWithinInterval,
-	addHours,
-	isPast,
-} from 'date-fns'
 import Promise from 'bluebird'
 import { SPORT } from '#env'
 import { getShortName } from '../../bot_res/getShortName.js'
 import { scheduleChannels } from './scheduleChannels.js'
-import IsoManager from '#iso'
 import locateChannel from '../../bot_res/locateChan.js'
 import Cache from '#rCache'
 import logClr from '#colorConsole'
 import PlutoLogger from '#PlutoLogger'
 import parseScheduled from '../../bot_res/parseScheduled.js'
-import { filterGamesArr } from './schedChanFilter.js'
 import { MatchupManager } from '#MatchupManager'
+import {
+	isDateTodayAndPast,
+	isWithinOneHour,
+} from '../../bot_res/dateUtils.js'
+import IsoManager from '#iso'
 
 /**
- *
- *  @summary Generate Cron Jobs for Game Channel creation
- *  @description Captures games that are wtihin today to be scheduled
- * If there's games that are within the current day & have yet to have a game channel created, they will be created
- * Game channels are scheduled to be by default 1 hour ahead of the game.
- * If we are within 1 hour or already past (game started), this module will create the channels right now
- *
- * Overall, responsible for
- * - Scheduling the creation of game channels
- * - Sending notification to log channel what channels have been scheduled for the day
+ * @summary Generate Cron Jobs for Game Channel creation
+ * @description Uses `cronstart` for scheduling game channels.
+ * Ensures that channels for today's games are created.
  */
-
 export default async function cronScheduleGames() {
-	const scheduledTally = []
 	const scheduledIds = []
-	const gamesArr = await MatchupManager.getUpcoming()
-	const filterGames = await filterGamesArr({
-		gamesArr,
-		SPORT,
-	})
+	const scheduledContainer = []
+	const gamesArr = await MatchupManager.getAllMatchups()
 
-	await Promise.map(
-		filterGames,
-		async (game) => {
-			if (game.completed) {
-				return
+	for await (const game of gamesArr) {
+		const hTeamShortName = await getShortName(
+			game.teamone,
+		)
+		const aTeamShortName = await getShortName(
+			game.teamtwo,
+		)
+		const matchupStr = `${hTeamShortName}-vs-${aTeamShortName}`
+
+		const isCompleted = game.complete || false
+		const scheduledCache =
+			(await Cache().get(`scheduled_games`)) || []
+		let isScheduled
+		if (!_.isEmpty(scheduledCache)) {
+			isScheduled = _.find(scheduledCache, {
+				gameid: game.id,
+			})
+		} else {
+			isScheduled = false
+		}
+		const chanExist = await locateChannel(matchupStr)
+		const resolveChanExist = await Promise.resolve(
+			chanExist,
+		)
+
+		const todaysPriorGame = isDateTodayAndPast(
+			game.cronstart,
+		)
+		const isFutureGame =
+			new Date() < new Date(game.start)
+
+		const createNow = await isWithinOneHour(
+			game.cronstart,
+		)
+		if (
+			(!isCompleted &&
+				!isScheduled &&
+				!resolveChanExist &&
+				todaysPriorGame) ||
+			isFutureGame
+		) {
+			let cronTime = game.cronstart
+			let queueEarly = true
+			if (createNow) {
+				cronTime = new IsoManager(game.start)
+					.cronRightNow
+				queueEarly = false
 			}
-			const isoManager = new IsoManager(game.start)
-			let cronTime = null
-			const parsedGameDate = parseISO(game.start)
-			const now = new Date()
-			const oneHourFromNow = addHours(now, 1)
-
-			const homeTeam = await getShortName(
-				game.teamone,
-			)
-			const awayTeam = await getShortName(
-				game.teamtwo,
-			)
-
-			let matchupStr
-			if (SPORT === 'nba') {
-				matchupStr = `${awayTeam}-vs-${homeTeam}`
-			} else {
-				matchupStr = `${awayTeam}-at-${homeTeam}`
-			}
-			// Don't schedule channels that already exist
-			const chanExist = await locateChannel(
-				matchupStr,
-			)
-			const gameInfo = `${game.teamone} vs ${game.teamtwo}\n${game.id}`
-			if (chanExist) {
-				await logClr({
-					text: `Skipped scheduling game due to the channel existing already \n${gameInfo}`,
-					color: `yellow`,
-					status: `done`,
-				})
-				return
-			}
-
-			/**
-			 * Checks if the game with the given id is already scheduled.
-			 * @return {boolean} True if the game is already scheduled, false otherwise.
-			 */
-			const checkIfScheduled = async () => {
-				const scheduled_gameIds = await Cache().get(
-					`scheduledIds`,
-				)
-				if (
-					!scheduled_gameIds ||
-					_.isEmpty(scheduled_gameIds)
-				) {
-					return false
-				}
-				return _.includes(
-					scheduled_gameIds,
-					game.id,
-				)
-			}
-
-			const isScheduled = await checkIfScheduled()
-
-			if (isScheduled) {
-				await logClr({
-					text: `Skipped game as it was already scheduled. => ${game.id}`,
-					color: `green`,
-					status: `done`,
-				})
-				return
-			}
-
-			const hourOrLess = isWithinInterval(
-				parsedGameDate,
-				{
-					start: now,
-					end: oneHourFromNow,
-				},
-			)
-			let queue1HEarly = false
-			const past = isPast(parsedGameDate)
-			if (hourOrLess || past) {
-				// ? Game ISO time is within an hour
-				// ? Create Cron set to exactly 1 minute from the current time
-				cronTime = isoManager.cronRightNow
-			} else {
-				// ? Game ISO time is beyond 1 hour
-				queue1HEarly = true
-				cronTime = isoManager.cron
-			}
-			await scheduleChannels(
-				game.teamone,
-				game.teamtwo,
-				{
-					cronStartTime: cronTime,
-					legible: isoManager.legible,
-					gameid: game.id,
-					queue1HEarly,
-				},
-			)
-			await scheduledTally.push({
+			await scheduledContainer.push({
 				home_team: game.teamone,
 				away_team: game.teamtwo,
-				start: isoManager.timeOnly,
-				day: isoManager.dayName,
-				date: game.start,
+				cronStartTime: cronTime,
+				legible: game.legiblestart,
+				gameid: game.id,
+				queue1HEarly: queueEarly,
+			})
+			await scheduledCache.push({
+				home_team: game.teamone,
+				away_team: game.teamtwo,
+				cronstart: cronTime,
+				start: game.legiblestart,
+				date: game.dateofmatchup,
+				gameid: game.id,
 			})
 			await scheduledIds.push(game.id)
-		},
-		{ concurrency: 1 },
-	)
-
-	if (!_.isEmpty(scheduledTally)) {
-		await Cache().set(`scheduled`, scheduledTally)
-		await Cache().set(`scheduledIds`, scheduledIds)
+			await Cache().set(
+				`scheduled_games`,
+				scheduledCache,
+			)
+		}
 	}
-	// ? Tally is at 0 if no new games were scheduled. This means the app likely still has games for the week scheduled.
+
+	for await (const match of scheduledContainer) {
+		await scheduleChannels(
+			match.home_team,
+			match.away_team,
+			{
+				cronStartTime: match.cronStartTime,
+				queue1HEarly: match.queue1HEarly,
+				gameId: match.gameid,
+			},
+		)
+	}
+
+	const schCache = await Cache().get(`scheduled_games`)
+	if (schCache.length > 0) {
+		const emb = await parseScheduled(schCache, SPORT)
+		await PlutoLogger.sendEmbed(emb)
+	}
+
 	await logClr({
-		text: `# of New Scheduled Games: ${scheduledTally.length}`,
-		color: `green`,
-		status: `done`,
+		text: `# of New Scheduled Games: ${schCache.length}`,
+		color: 'green',
+		status: 'done',
 	})
-	const emb = await parseScheduled(scheduledTally, SPORT)
-	await PlutoLogger.sendEmbed(emb)
+
 	return true
 }

--- a/utils/scheduled/dailyModules.js
+++ b/utils/scheduled/dailyModules.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird'
-import { Log, LIVEMATCHUPS } from '#config'
-import { db } from '#db'
+import { Log } from '#config'
 import {
 	init_Cron_Completed,
 	init_Cron_Chan_Scheduler,


### PR DESCRIPTION
Streamline Game Channel Scheduling via using Cron in the entire process

Game start times are parsed into Cron Strings already. This PR will utilize this fact to further identify and schedule games, instead of using the ISO string that was created. The server is configured to a timezone that allows this to make sense and perform as it should.

This PR also creates an isolated module to handle Cron times to execute the above mentioned.