### PR TITLE
Fix code scanning alert no. 3: Information exposure through a stack trace

### DIFF
--- a/src/utils/api/routes/schedule/schedule.ts
+++ b/src/utils/api/routes/schedule/schedule.ts
@@ -49,7 +49,8 @@ ScheduleRouter.post('/schedule/daily/all', async (ctx) => {
 		ctx.status = 200;
 	} catch (err) {
 		console.error(err);
-		ctx.body = err;
+		ctx.body = { message: 'An error occurred while processing your request.' };
+		ctx.status = 500;
 	}
 });
 


### PR DESCRIPTION
Fixes [https://github.com/fearandesire/Pluto-Betting-Bot/security/code-scanning/3](https://github.com/fearandesire/Pluto-Betting-Bot/security/code-scanning/3)

To fix the problem, we need to ensure that the stack trace and other sensitive information contained in the error object `err` are not exposed to the end user. Instead, we should log the error on the server and send a generic error message to the client. This can be achieved by modifying the catch block to log the error and set a generic error message in `ctx.body`.

**Steps to fix:**
1. Modify the catch block to log the error using `console.error`.
2. Set a generic error message in `ctx.body` to avoid exposing the stack trace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
