### PR TITLE
fix(logging): address four code-review issues from PR #559

### DIFF
--- a/src/utils/game/handle-gm.ts
+++ b/src/utils/game/handle-gm.ts
@@ -1,0 +1,71 @@
+import type { SportsServing } from '@pluto-khronos/types'
+import { teamResolver } from 'resolve-team'
+import { createLogger } from '../logging/WinstonLogger.js'
+
+const log = createLogger({ component: 'game', handler: 'handle-gm' })
+
+export interface LocatedTeam {
+	name: string
+	sport: SportsServing
+}
+
+/**
+ * Handles game-management operations: resolving team identities,
+ * validating game state, and co-ordinating match-lifecycle events.
+ */
+export class GmHandler {
+	/**
+	 * Resolve a raw team string (abbreviation, nickname, or full name) to a
+	 * canonical team record for the given sport.
+	 *
+	 * @throws {Error} When the team cannot be resolved.
+	 */
+	async locateTeam(
+		rawTeam: string,
+		sport: SportsServing,
+	): Promise<LocatedTeam> {
+		try {
+			const resolved = await teamResolver.resolve(rawTeam, {
+				sport,
+				full: true,
+			})
+
+			if (!resolved || !resolved.name) {
+				throw new Error(`Team "${rawTeam}" could not be resolved for sport "${sport}"`)
+			}
+
+			log.info('Team located', {
+				event: 'game.team_located',
+				rawTeam,
+				sport,
+				resolvedName: resolved.name,
+			})
+
+			return { name: resolved.name, sport }
+		} catch (error) {
+			log.error('GmHandler.locateTeam: Failed to locate team', {
+				event: 'game.team_locate_failed',
+				rawTeam,
+				sport,
+				error,
+			})
+			throw error
+		}
+	}
+
+	/**
+	 * Validate that a pair of team names are distinct and non-empty.
+	 *
+	 * @throws {Error} When home and away resolve to the same team.
+	 */
+	validateMatchup(homeTeam: string, awayTeam: string): void {
+		if (!homeTeam || !awayTeam) {
+			throw new Error('Both home and away team names are required')
+		}
+		if (homeTeam.toLowerCase() === awayTeam.toLowerCase()) {
+			throw new Error(`Home and away teams must differ — got "${homeTeam}" for both`)
+		}
+	}
+}
+
+export const gmHandler = new GmHandler()

--- a/src/utils/game/player/compare.ts
+++ b/src/utils/game/player/compare.ts
@@ -1,0 +1,229 @@
+import type { OverallStatsDto } from '../../../openapi/khronos/index.js'
+import StatsWraps from '../../api/Khronos/stats/stats-wrapper.js'
+import { createLogger } from '../../logging/WinstonLogger.js'
+
+const log = createLogger({ component: 'game', handler: 'player-compare' })
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface CompareOptions {
+	userId1: string
+	userId2: string
+	username1: string
+	username2: string
+}
+
+export type StatWinner = 1 | 2 | 'tie'
+
+export interface StatComparison {
+	label: string
+	value1: string
+	value2: string
+	winner: StatWinner
+}
+
+export interface CompareResult {
+	username1: string
+	username2: string
+	overallWinner: string | 'tie'
+	stats: StatComparison[]
+	score: { player1: number; player2: number }
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+function fmtCount(n: number): string {
+	return n === 0 ? 'N/A' : n.toLocaleString()
+}
+
+function fmtMoney(n: number): string {
+	return n === 0 ? 'N/A' : `$${n.toLocaleString()}`
+}
+
+function fmtPct(n: number): string {
+	return n === 0 ? 'N/A' : `${n.toFixed(1)}%`
+}
+
+// ---------------------------------------------------------------------------
+// Stat descriptors
+// ---------------------------------------------------------------------------
+
+interface StatDescriptor {
+	label: string
+	extract: (dto: OverallStatsDto) => number
+	format: (n: number) => string
+	/** Higher value wins when true; lower value wins when false. */
+	higherIsBetter: boolean
+}
+
+const STAT_DESCRIPTORS: StatDescriptor[] = [
+	{
+		label: 'Total Bets',
+		extract: (d) => d.totalBets,
+		format: fmtCount,
+		higherIsBetter: true,
+	},
+	{
+		label: 'Wins',
+		extract: (d) => d.totalWins,
+		format: fmtCount,
+		higherIsBetter: true,
+	},
+	{
+		label: 'Losses',
+		extract: (d) => d.totalLosses,
+		format: fmtCount,
+		higherIsBetter: false,
+	},
+	{
+		label: 'Win Rate',
+		extract: (d) => d.winRate,
+		format: fmtPct,
+		higherIsBetter: true,
+	},
+	{
+		label: 'Highest Bet',
+		extract: (d) => d.highestBetAmount,
+		format: fmtMoney,
+		higherIsBetter: true,
+	},
+	{
+		label: 'Total Won',
+		extract: (d) => d.profitLossSummary.totalWon,
+		format: fmtMoney,
+		higherIsBetter: true,
+	},
+	{
+		label: 'Total Lost',
+		extract: (d) => d.profitLossSummary.totalLost,
+		format: fmtMoney,
+		higherIsBetter: false,
+	},
+	{
+		label: 'Net Profit',
+		extract: (d) => d.profitLossSummary.netProfit,
+		format: fmtMoney,
+		higherIsBetter: true,
+	},
+]
+
+// ---------------------------------------------------------------------------
+// Core comparison logic
+// ---------------------------------------------------------------------------
+
+function compareStatPair(
+	descriptor: StatDescriptor,
+	dto1: OverallStatsDto,
+	dto2: OverallStatsDto,
+): StatComparison {
+	const v1 = descriptor.extract(dto1)
+	const v2 = descriptor.extract(dto2)
+
+	let winner: StatWinner
+	if (v1 === v2) {
+		winner = 'tie'
+	} else if (descriptor.higherIsBetter) {
+		winner = v1 > v2 ? 1 : 2
+	} else {
+		winner = v1 < v2 ? 1 : 2
+	}
+
+	return {
+		label: descriptor.label,
+		value1: descriptor.format(v1),
+		value2: descriptor.format(v2),
+		winner,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export class PlayerCompare {
+	private readonly statsWraps = new StatsWraps()
+
+	/**
+	 * Fetch stats for both players and produce a head-to-head comparison.
+	 */
+	async compare(options: CompareOptions): Promise<CompareResult> {
+		const { userId1, userId2, username1, username2 } = options
+
+		const [dto1, dto2] = await Promise.all([
+			this.statsWraps.getOverallStats({ userId: userId1 }),
+			this.statsWraps.getOverallStats({ userId: userId2 }),
+		])
+
+		log.info('Comparing players', {
+			event: 'player.compare_start',
+			userId1,
+			userId2,
+		})
+
+		const stats = this.buildStatComparisons(dto1, dto2)
+		const score = this.tallyScore(stats)
+		const overallWinner = this.resolveOverallWinner(score, username1, username2)
+
+		log.info('Player comparison complete', {
+			event: 'player.compare_complete',
+			userId1,
+			userId2,
+			score,
+			overallWinner,
+		})
+
+		return { username1, username2, overallWinner, stats, score }
+	}
+
+	private buildStatComparisons(
+		dto1: OverallStatsDto,
+		dto2: OverallStatsDto,
+	): StatComparison[] {
+		const comparisons: StatComparison[] = []
+
+		for (const descriptor of STAT_DESCRIPTORS) {
+			const result = compareStatPair(descriptor, dto1, dto2)
+
+			// debug — one line per stat pair; kept out of production transports
+			// by the configured log level (info in prod, debug in dev/test).
+			log.debug('Stat pair compared', {
+				label: descriptor.label,
+				value1: result.value1,
+				value2: result.value2,
+				winner: result.winner,
+			})
+
+			comparisons.push(result)
+		}
+
+		return comparisons
+	}
+
+	private tallyScore(
+		stats: StatComparison[],
+	): { player1: number; player2: number } {
+		let p1 = 0
+		let p2 = 0
+		for (const s of stats) {
+			if (s.winner === 1) p1++
+			else if (s.winner === 2) p2++
+		}
+		return { player1: p1, player2: p2 }
+	}
+
+	private resolveOverallWinner(
+		score: { player1: number; player2: number },
+		username1: string,
+		username2: string,
+	): string | 'tie' {
+		if (score.player1 > score.player2) return username1
+		if (score.player2 > score.player1) return username2
+		return 'tie'
+	}
+}
+
+export const playerCompare = new PlayerCompare()

--- a/src/utils/guild/webhook-manager.ts
+++ b/src/utils/guild/webhook-manager.ts
@@ -1,0 +1,98 @@
+import {
+	type TextChannel,
+	type Webhook,
+	type WebhookCreateOptions,
+} from 'discord.js'
+import { createLogger } from '../logging/WinstonLogger.js'
+
+const log = createLogger({ component: 'guild', handler: 'webhook-manager' })
+
+const WEBHOOK_NAME = 'Pluto'
+
+/**
+ * Manages Discord webhooks for a channel, creating one when none owned by the
+ * bot exists yet and caching subsequent look-ups.
+ */
+export class WebhookManager {
+	private readonly cache = new Map<string, Webhook>()
+
+	/**
+	 * Return the bot-owned webhook for `channel`, creating it if necessary.
+	 * The result is cached by channel ID so repeated calls within a session
+	 * avoid redundant API round-trips.
+	 */
+	async getOrCreate(
+		channel: TextChannel,
+		options: Partial<WebhookCreateOptions> = {},
+	): Promise<Webhook> {
+		const cached = this.cache.get(channel.id)
+		if (cached) return cached
+
+		try {
+			const webhooks = await channel.fetchWebhooks()
+			const clientId = channel.client.user?.id
+			const existing = clientId
+				? webhooks.find((wh) => wh.owner?.id === clientId)
+				: null
+
+			if (existing) {
+				this.cache.set(channel.id, existing)
+				log.info('Located existing webhook', {
+					event: 'webhook.found',
+					channelId: channel.id,
+					webhookId: existing.id,
+				})
+				return existing
+			}
+
+			const created = await channel.createWebhook({
+				name: WEBHOOK_NAME,
+				...options,
+			})
+			this.cache.set(channel.id, created)
+			log.info('Created new webhook', {
+				event: 'webhook.created',
+				channelId: channel.id,
+				webhookId: created.id,
+			})
+			return created
+		} catch (error) {
+			log.error('Error getting or creating webhook', {
+				event: 'webhook.error',
+				channelId: channel.id,
+				error,
+			})
+			throw error
+		}
+	}
+
+	/**
+	 * Evict a channel's cached webhook entry, e.g. after a webhook is deleted.
+	 */
+	invalidate(channelId: string): void {
+		this.cache.delete(channelId)
+	}
+
+	/**
+	 * Fetch all webhooks for `channel` owned by the bot, without touching the
+	 * cache.
+	 */
+	async listOwned(channel: TextChannel): Promise<Webhook[]> {
+		try {
+			const webhooks = await channel.fetchWebhooks()
+			const clientId = channel.client.user?.id
+			return clientId
+				? webhooks.filter((wh) => wh.owner?.id === clientId).toJSON()
+				: []
+		} catch (error) {
+			log.error('Error listing webhooks', {
+				event: 'webhook.list_error',
+				channelId: channel.id,
+				error,
+			})
+			return []
+		}
+	}
+}
+
+export const webhookManager = new WebhookManager()

--- a/src/utils/logger/discord-logger.ts
+++ b/src/utils/logger/discord-logger.ts
@@ -1,0 +1,98 @@
+import { container } from '@sapphire/framework'
+import {
+	type ColorResolvable,
+	EmbedBuilder,
+	type TextChannel,
+} from 'discord.js'
+import GuildWrapper from '../api/Khronos/guild/guild-wrapper.js'
+
+interface EmbedLogOptions {
+	guildId: string
+	description: string
+	title?: string
+	footer?: string
+}
+
+/**
+ * DexterLogger — sends structured embeds to a guild's configured log channel.
+ *
+ * All severity methods (error, warn, info, success) delegate to the single
+ * `log()` entry point. On failure `container.logger.error` is the canonical
+ * sink; no parallel `console.error` calls are present alongside it.
+ */
+export class DexterLogger {
+	// -------------------------------------------------------------------------
+	// Core send method
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Send an embed to the guild's configured log channel.
+	 *
+	 * @param options - Embed content and target guild.
+	 * @param color   - Embed colour. Defaults to Discord blurple `#7289DA` — a
+	 *   neutral tone for generic log messages. Severity helpers (error, warn,
+	 *   info, success) pass an appropriate colour automatically; callers using
+	 *   `.log()` directly rarely need to override this.
+	 */
+	async log(
+		options: EmbedLogOptions,
+		color: ColorResolvable = '#7289DA',
+	): Promise<void> {
+		const { guildId, description, title, footer } = options
+
+		let logChannel: TextChannel | null = null
+		try {
+			logChannel = await new GuildWrapper().getLogChannel(guildId)
+		} catch {
+			logChannel = null
+		}
+
+		if (!logChannel) {
+			// Single canonical sink — no console.error alongside container.logger.
+			container.logger.error('DexterLogger: log channel unavailable', {
+				guildId,
+			})
+			return
+		}
+
+		const embed = new EmbedBuilder()
+			.setDescription(description)
+			.setColor(color)
+			.setTimestamp()
+
+		if (title) embed.setTitle(title)
+		if (footer) embed.setFooter({ text: footer })
+
+		try {
+			await logChannel.send({ embeds: [embed] })
+		} catch (error) {
+			// Single canonical sink — no console.error alongside container.logger.
+			container.logger.error('DexterLogger: failed to send embed', {
+				guildId,
+				error,
+			})
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Severity helpers — call log() with a preset colour
+	// -------------------------------------------------------------------------
+
+	async error(options: EmbedLogOptions): Promise<void> {
+		return this.log(options, '#FF0000')
+	}
+
+	async warn(options: EmbedLogOptions): Promise<void> {
+		return this.log(options, '#f29831')
+	}
+
+	async info(options: EmbedLogOptions): Promise<void> {
+		return this.log(options, '#3498db')
+	}
+
+	async success(options: EmbedLogOptions): Promise<void> {
+		return this.log(options, '#57f287')
+	}
+}
+
+export const dexterLogger = new DexterLogger()


### PR DESCRIPTION
## Summary

Fixes four logging issues identified in PR #559 code review across four new files introduced by the logging consolidation.

- **Issue 1 — array logger args** (`webhook-manager.ts`, `handle-gm.ts`): All `logger.error`/`logger.info` calls that passed an array as the first argument (e.g. `logger.error(['msg:', err])`) are replaced with the correct two-argument Winston form `logger.error('msg', { error })`. The array form coerces the error object to `[object Error]`, discarding the full error payload from structured output.
- **Issue 2 — info→debug for per-stat logs** (`game/player/compare.ts`): The per-stat-pair loop log is demoted from `logger.info` to `logger.debug`. Each `/compare` invocation drives through every stat descriptor; logging at `info` generates significant noise in production transports. `debug` keeps these visible in dev/test while suppressing them in production.
- **Issue 3 — redundant `console.error`** (`discord-logger.ts`): Both fallback paths (no channel configured, send failure) previously called `container.logger.error(…)` followed immediately by `console.error(…)`. The `console.error` calls are removed — Winston (via `container.logger`) is the single canonical sink.
- **Issue 4 — red default color** (`discord-logger.ts`): `DexterLogger.log()` defaulted to `'#FF0000'` (error red). Changed to `'#7289DA'` (Discord blurple) — a neutral tone that doesn't imply severity on generic log messages. Severity helpers (`error`, `warn`, `info`, `success`) continue to supply their own explicit colours.

## Test plan

- [ ] Run the bot locally and invoke `/compare` — confirm per-stat logs do **not** appear at `info` level in the console, but do appear when `LOG_LEVEL=debug`
- [ ] Trigger a webhook creation in a test channel — confirm `logger.error` output in Winston transports contains a structured `error` field, not a stringified array
- [ ] Simulate a missing log channel — confirm only one `container.logger.error` line appears with no accompanying `console.error`
- [ ] Call `dexterLogger.log(…)` without a colour — confirm the embed renders in blurple, not red

https://claude.ai/code/session_01LGsmPmydPmjfANJxpsWV1g

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGsmPmydPmjfANJxpsWV1g)_