### PR TITLE
feat(ci): hydrate matchup image assets from Cloudflare R2

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -134,6 +134,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
       id-token: write
 
     outputs:
@@ -218,6 +219,7 @@ jobs:
             org.opencontainers.image.description=${{ env.IMAGE_DESCRIPTION }}
             org.opencontainers.image.vendor=${{ env.IMAGE_VENDOR }}
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -174,6 +174,21 @@ jobs:
           echo "🔖 Short SHA: $SHORT_SHA"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+      - name: Hydrate assets from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        run: |
+          set -euo pipefail
+          aws s3 cp s3://pluto-assets/matchupimages.tar.gz /tmp/matchupimages.tar.gz \
+            --endpoint-url="$R2_ENDPOINT"
+          mkdir -p assets
+          tar -xzf /tmp/matchupimages.tar.gz -C assets/
+          rm /tmp/matchupimages.tar.gz
+          echo "Hydrated $(find assets/matchupimages -type f | wc -l) asset files"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@
    7. [Getting Started](#getting-started)
       1. [Prerequisites](#prerequisites)
       2. [Installation](#installation)
-   8. [Documentation](#documentation)
-   9. [Contributing](#contributing)
-      1. [Contributors](#contributors)
-   10. [License](#license)
-   11. [Support](#support)
+    8. [Assets](#assets)
+   9. [Documentation](#documentation)
+   10. [Contributing](#contributing)
+       1. [Contributors](#contributors)
+   11. [License](#license)
+   12. [Support](#support)
 
 ---
 
@@ -205,6 +206,29 @@ pnpm ci-gen-api
 pnpm release
 ```
 </details>
+
+## Assets
+
+Matchup images under `assets/matchupimages/` are proprietary and **not committed to git** (`assets/` is gitignored). The source of truth is a private Cloudflare R2 bucket: `pluto-assets`, key `matchupimages.tar.gz`.
+
+**CI behavior:** The `deploy` job in [`.github/workflows/ci-cd-deployment.yml`](.github/workflows/ci-cd-deployment.yml) hydrates the tarball from R2 (S3-compatible API) into the build context before the Docker build, so the existing `COPY` chain works unchanged. Required GitHub Actions secrets: `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ACCOUNT_ID`.
+
+**Refreshing assets (local → R2):**
+
+1. Configure an AWS CLI profile pinned to R2 (one-time):
+   ```bash
+   aws configure --profile pluto-r2
+   # Access Key ID:     <R2 token key>
+   # Secret Access Key: <R2 token secret>
+   # Default region:    auto
+   ```
+2. Run from repo root with your account ID exported:
+   ```bash
+   export R2_ACCOUNT_ID=<your-cloudflare-account-id>
+   pnpm assets:upload
+   ```
+
+The script tars `assets/matchupimages/`, uploads to `s3://pluto-assets/matchupimages.tar.gz`, and cleans up. See [`scripts/upload-assets.sh`](scripts/upload-assets.sh).
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"dvault-prod": "npx dotenv-vault@latest push production",
 		"release": "release-it",
 		"docker:ci": "docker-compose build && docker-compose push",
+		"assets:upload": "bash scripts/upload-assets.sh",
 		"prepare": "husky",
 		"test": "vitest",
 		"test:run": "vitest run",

--- a/scripts/upload-assets.sh
+++ b/scripts/upload-assets.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Upload assets/matchupimages/ to Cloudflare R2 as a single tarball.
+# See README "Assets" section for setup. Run from repo root: `pnpm assets:upload`.
+set -euo pipefail
+
+BUCKET="pluto-assets"
+KEY="matchupimages.tar.gz"
+PROFILE="${R2_AWS_PROFILE:-pluto-r2}"
+ACCOUNT_ID="${R2_ACCOUNT_ID:?Set R2_ACCOUNT_ID env var}"
+ENDPOINT="https://${ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+if [[ ! -d assets/matchupimages ]]; then
+  echo "ERROR: assets/matchupimages not found. Run from repo root." >&2
+  exit 1
+fi
+
+TMP=$(mktemp -t matchupimages.XXXXXX.tar.gz)
+trap 'rm -f "$TMP"' EXIT
+
+echo "Packing assets/matchupimages → $TMP"
+tar -czf "$TMP" -C assets matchupimages
+
+SIZE=$(du -h "$TMP" | cut -f1)
+COUNT=$(find assets/matchupimages -type f | wc -l | tr -d ' ')
+echo "Uploading $COUNT files ($SIZE) to s3://$BUCKET/$KEY"
+
+aws s3 cp "$TMP" "s3://$BUCKET/$KEY" \
+  --endpoint-url="$ENDPOINT" \
+  --profile "$PROFILE"
+
+echo "Done."


### PR DESCRIPTION
## Summary
- CI deploy job now pulls `matchupimages.tar.gz` from private R2 bucket `pluto-assets` before the Docker build, fixing the broken `COPY /app/assets ./assets` chain that was failing because `assets/` is gitignored
- Local helper `pnpm assets:upload` packs and uploads the directory via the S3-compatible R2 endpoint
- Zero runtime/app code changes — `fetchVsImg` keeps reading from `./assets/matchupimages/<sport>/<file>`

## Required secrets (set by Codex prior to merge)
- `R2_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY`
- `R2_ACCOUNT_ID`

## Verification
- [ ] R2 bucket `pluto-assets` created + API token scoped to Object Read & Write
- [ ] GitHub Actions secrets set (3 above)
- [ ] Initial tarball uploaded via `pnpm assets:upload`
- [ ] `workflow_dispatch` with `force_build: true` succeeds end-to-end on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD deployment pipeline to ensure match-up assets are prepared and available prior to build and publish, resulting in more reliable and consistent deployments.
  * Expanded workflow permissions to support the enhanced deployment steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->