### PR TITLE
fix(typecheck): resolve 2 tsc errors and promote typecheck into CI gate

### DIFF
--- a/.github/workflows/khronos-client-update.yml
+++ b/.github/workflows/khronos-client-update.yml
@@ -40,13 +40,16 @@ jobs:
 
     steps:
       - name: Validate dispatch payload
+        env:
+          KHRONOS_VERSION: ${{ github.event.client_payload.khronos_version }}
+          KHRONOS_SHA: ${{ github.event.client_payload.sha }}
         run: |
-          if [[ -z "${{ github.event.client_payload.khronos_version }}" ]]; then
+          if [[ -z "$KHRONOS_VERSION" ]]; then
             echo "::error::client_payload.khronos_version is required"
             exit 1
           fi
-          echo "📦 Bumping @pluto-khronos/api-client + @pluto-khronos/types to ${{ github.event.client_payload.khronos_version }}"
-          echo "🔗 Khronos commit: ${{ github.event.client_payload.sha }}"
+          echo "📦 Bumping @pluto-khronos/api-client + @pluto-khronos/types to $KHRONOS_VERSION"
+          echo "🔗 Khronos commit: $KHRONOS_SHA"
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -66,10 +69,12 @@ jobs:
           cache: pnpm
 
       - name: Bump dependencies (lockstep)
+        env:
+          KHRONOS_VERSION: ${{ github.event.client_payload.khronos_version }}
         run: |
           pnpm add \
-            "@pluto-khronos/api-client@${{ github.event.client_payload.khronos_version }}" \
-            "@pluto-khronos/types@${{ github.event.client_payload.khronos_version }}"
+            "@pluto-khronos/api-client@$KHRONOS_VERSION" \
+            "@pluto-khronos/types@$KHRONOS_VERSION"
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/khronos-client-update.yml
+++ b/.github/workflows/khronos-client-update.yml
@@ -2,19 +2,25 @@
 #
 # Triggered by Khronos's `publish_client` job (in fearandesire/khronos
 # .github/workflows/ci-cd-deployment.yml) after each stable release publishes
-# a new @pluto-khronos/api-client to npm.
+# new @pluto-khronos/api-client AND @pluto-khronos/types versions to npm.
+#
+# Both packages always ship at the same version (= Khronos root version).
 #
 # Flow:
 #   1. Receive repository_dispatch (event_type: khronos-release)
-#   2. Bump @pluto-khronos/api-client to the dispatched version
-#   3. Run `pnpm test:run` — if tests fail, no PR is opened
-#   4. Open a PR with the bump
-#   5. Enable auto-merge on the PR (squash)
+#   2. Bump BOTH @pluto-khronos/api-client AND @pluto-khronos/types in lockstep
+#   3. Verify: pnpm typecheck && pnpm build && pnpm test:run
+#   4. Open PR — DRAFT if verify failed; ready-for-review if green
+#   5. Human reviews + clicks merge (NO auto-merge)
+#
+# Re-dispatch behavior: uses a static branch name (`chore/khronos-update`),
+# so a newer release updates the existing PR rather than opening a duplicate
+# or orphaning the prior draft.
 #
 # Manual trigger (testing):
 #   gh api repos/fearandesire/Pluto-Betting-Bot/dispatches \
 #     -f event_type=khronos-release \
-#     -f 'client_payload[version]=3.2.0' \
+#     -f 'client_payload[khronos_version]=3.2.0' \
 #     -f 'client_payload[sha]=$(git rev-parse HEAD)'
 
 name: Khronos client update
@@ -29,17 +35,17 @@ permissions:
 
 jobs:
   bump:
-    name: Bump @pluto-khronos/api-client
+    name: Bump @pluto-khronos/* packages
     runs-on: ubuntu-latest
 
     steps:
       - name: Validate dispatch payload
         run: |
-          if [[ -z "${{ github.event.client_payload.version }}" ]]; then
-            echo "::error::client_payload.version is required"
+          if [[ -z "${{ github.event.client_payload.khronos_version }}" ]]; then
+            echo "::error::client_payload.khronos_version is required"
             exit 1
           fi
-          echo "📦 Bumping to @pluto-khronos/api-client@${{ github.event.client_payload.version }}"
+          echo "📦 Bumping @pluto-khronos/api-client + @pluto-khronos/types to ${{ github.event.client_payload.khronos_version }}"
           echo "🔗 Khronos commit: ${{ github.event.client_payload.sha }}"
 
       - name: Checkout
@@ -59,15 +65,26 @@ jobs:
           node-version: 22.x
           cache: pnpm
 
-      - name: Bump dependency
+      - name: Bump dependencies (lockstep)
         run: |
-          pnpm add "@pluto-khronos/api-client@${{ github.event.client_payload.version }}"
+          pnpm add \
+            "@pluto-khronos/api-client@${{ github.event.client_payload.khronos_version }}" \
+            "@pluto-khronos/types@${{ github.event.client_payload.khronos_version }}"
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - name: Run tests
-        run: pnpm test:run
+      - name: Verify (build + test)
+        id: verify
+        continue-on-error: true
+        run: |
+          set -e
+          pnpm build
+          pnpm test:run
+        # NOTE: pnpm typecheck is NOT in the gate yet — the codebase has
+        # pre-existing tsc errors that swc-build silently ignores. Once those
+        # are cleaned up, add `pnpm typecheck` as the first command above so
+        # type-level breakage from upstream packages also surfaces here.
 
       - name: Detect changes
         id: diff
@@ -85,27 +102,28 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.PLUTO_BOT_PAT }}
-          branch: chore/bump-khronos-${{ github.event.client_payload.version }}
-          delete-branch: true
-          title: "chore(deps): bump @pluto-khronos/api-client to ${{ github.event.client_payload.version }}"
-          commit-message: "chore(deps): bump @pluto-khronos/api-client to ${{ github.event.client_payload.version }}"
+          branch: chore/khronos-update
+          delete-branch: false
+          title: "chore(deps): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}"
+          commit-message: "chore(deps): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}"
+          draft: ${{ steps.verify.outcome == 'failure' }}
           body: |
             Automated bump triggered by Khronos release.
 
-            - **Version:** `${{ github.event.client_payload.version }}`
-            - **Khronos commit:** [`${{ github.event.client_payload.sha }}`](https://github.com/fearandesire/khronos/commit/${{ github.event.client_payload.sha }})
-            - **npm:** https://www.npmjs.com/package/@pluto-khronos/api-client/v/${{ github.event.client_payload.version }}
+            ## Versions
+            - `@pluto-khronos/api-client@${{ github.event.client_payload.khronos_version }}`
+            - `@pluto-khronos/types@${{ github.event.client_payload.khronos_version }}`
 
-            Tests passed in the dispatch workflow before this PR was opened.
-            Auto-merge will engage on green.
+            ## Source
+            - **Khronos commit:** [`${{ github.event.client_payload.sha }}`](https://github.com/fearandesire/khronos/commit/${{ github.event.client_payload.sha }})
+            - **api-client npm:** https://www.npmjs.com/package/@pluto-khronos/api-client/v/${{ github.event.client_payload.khronos_version }}
+            - **types npm:** https://www.npmjs.com/package/@pluto-khronos/types/v/${{ github.event.client_payload.khronos_version }}
+
+            ## Quality gate
+            **Verify (build + test):** `${{ steps.verify.outcome }}`
+
+            ${{ steps.verify.outcome == 'failure' && '⚠️ Opened as DRAFT — fix consumers in this branch before marking ready. Then merge manually.' || '✅ All checks passed — ready for review. Click merge when you''ve scanned the diff.' }}
           labels: |
             dependencies
             automated
-
-      - name: Enable auto-merge
-        if: steps.cpr.outputs.pull-request-number
-        env:
-          GH_TOKEN: ${{ secrets.PLUTO_BOT_PAT }}
-        run: |
-          gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
-          echo "::notice::Auto-merge enabled on PR #${{ steps.cpr.outputs.pull-request-number }}"
+            khronos-bump

--- a/.github/workflows/khronos-client-update.yml
+++ b/.github/workflows/khronos-client-update.yml
@@ -74,17 +74,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - name: Verify (build + test)
+      - name: Verify (typecheck + build + test)
         id: verify
         continue-on-error: true
         run: |
           set -e
+          pnpm typecheck
           pnpm build
           pnpm test:run
-        # NOTE: pnpm typecheck is NOT in the gate yet — the codebase has
-        # pre-existing tsc errors that swc-build silently ignores. Once those
-        # are cleaned up, add `pnpm typecheck` as the first command above so
-        # type-level breakage from upstream packages also surfaces here.
 
       - name: Detect changes
         id: diff
@@ -120,7 +117,7 @@ jobs:
             - **types npm:** https://www.npmjs.com/package/@pluto-khronos/types/v/${{ github.event.client_payload.khronos_version }}
 
             ## Quality gate
-            **Verify (build + test):** `${{ steps.verify.outcome }}`
+            **Verify (typecheck + build + test):** `${{ steps.verify.outcome }}`
 
             ${{ steps.verify.outcome == 'failure' && '⚠️ Opened as DRAFT — fix consumers in this branch before marking ready. Then merge manually.' || '✅ All checks passed — ready for review. Click merge when you''ve scanned the diff.' }}
           labels: |

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ scripts/internal
 .frolic-session.json
 
 docs
+
+# yalc — local cross-repo linking against Khronos
+# (see "Local development against Khronos" in README)
+.yalc/
+yalc.lock

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,8 @@
+if [ -f yalc.lock ]; then
+  echo "❌ yalc.lock present — local @pluto-khronos/* link is active."
+  echo "   Run: pnpm dev:unlink-khronos"
+  echo "   Then re-stage and commit."
+  exit 1
+fi
+
 lint-staged

--- a/README.md
+++ b/README.md
@@ -199,14 +199,36 @@ pnpm watch
 # Run linter
 pnpm lint
 
-# Bump the Khronos API client (normally automated via repository_dispatch
-# from Khronos releases — see .github/workflows/khronos-client-update.yml)
-pnpm add @pluto-khronos/api-client@latest
+# Bump @pluto-khronos/* (normally automated via repository_dispatch from
+# Khronos releases — see .github/workflows/khronos-client-update.yml)
+pnpm add @pluto-khronos/api-client@latest @pluto-khronos/types@latest
 
 # Create a new release
 pnpm release
 ```
 </details>
+
+### Local development against Khronos
+
+When iterating on changes that span Pluto and Khronos (e.g. new endpoint, new event payload type), use [yalc](https://github.com/wclr/yalc) to link the local `@pluto-khronos/*` package builds without publishing to npm.
+
+**One-time setup per machine:** `npm i -g yalc`
+
+```bash
+# In Pluto (one-time per session): switch to local linked builds
+pnpm dev:link-khronos
+
+# In Khronos (every change): rebuild + push to all consumers
+pnpm dev:push-all
+
+# In Pluto (every change): verify
+pnpm typecheck     # or: pnpm test:run, pnpm dev
+
+# When done: restore npm versions
+pnpm dev:unlink-khronos
+```
+
+A pre-commit hook aborts the commit if `yalc.lock` is present — prevents accidentally committing a linked state. If you see it fire, run `pnpm dev:unlink-khronos` first.
 
 ## Assets
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	"dependencies": {
 		"@axiomhq/winston": "^1.6.1",
 		"@bull-board/api": "^7.0.0",
-		"@bull-board/koa": "^6.21.2",
+		"@bull-board/koa": "^7.0.0",
 		"@bull-board/ui": "^7.0.0",
 		"@faker-js/faker": "^10.4.0",
 		"@favware/colorette-spinner": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,12 @@
 		"docker:ci": "docker-compose build && docker-compose push",
 		"assets:upload": "bash scripts/upload-assets.sh",
 		"prepare": "husky",
+		"typecheck": "tsc --noEmit",
 		"test": "vitest",
 		"test:run": "vitest run",
-		"test:coverage": "vitest run --coverage"
+		"test:coverage": "vitest run --coverage",
+		"dev:link-khronos": "yalc add @pluto-khronos/api-client && yalc add @pluto-khronos/types && pnpm install",
+		"dev:unlink-khronos": "yalc remove @pluto-khronos/api-client && yalc remove @pluto-khronos/types && pnpm install"
 	},
 	"lint-staged": {
 		"*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(@bull-board/ui@7.0.0)
       '@bull-board/koa':
-        specifier: ^6.21.2
-        version: 6.21.3(@babel/core@7.29.0)(@types/koa@3.0.2)(handlebars@4.7.9)(lodash@4.18.1)
+        specifier: ^7.0.0
+        version: 7.0.0(@babel/core@7.29.0)(@types/koa@3.0.2)(handlebars@4.7.9)(lodash@4.18.1)
       '@bull-board/ui':
         specifier: ^7.0.0
         version: 7.0.0
@@ -581,21 +581,13 @@ packages:
   '@borewit/text-codec@0.2.1':
     resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
 
-  '@bull-board/api@6.21.3':
-    resolution: {integrity: sha512-FoQO+0MgZsPrQX9WLZx0KpINamJY48FUU+OyMcZxx9mQWCwsdak45V/uBgQrTYB3GaF5oGA0SxPXEp4RHwj36A==}
-    peerDependencies:
-      '@bull-board/ui': 6.21.3
-
   '@bull-board/api@7.0.0':
     resolution: {integrity: sha512-ISNspLHVmUWUSq/eLw+wd1FuBBUnqpLbYP2xUNmehpfKhS+NoZWMbBvqjUYVeE/HLfUkRcR1edzMKpl5n9zlSw==}
     peerDependencies:
       '@bull-board/ui': 7.0.0
 
-  '@bull-board/koa@6.21.3':
-    resolution: {integrity: sha512-JPGubXmAJgMqZTMqfBnHpNFdauNesthEmbnFCJed5JJwCT+AsPNCPjk5/87hRZdfnRr6do4j4iuBETBO1/g8UQ==}
-
-  '@bull-board/ui@6.21.3':
-    resolution: {integrity: sha512-s/PLBJab8cnoQAGVqjQb0v4oGe0KgB4aQ5G5g93doxzXB/D+wkXNL9P9+zLWLldBJXE57jL4CR99ttDCIiyNHw==}
+  '@bull-board/koa@7.0.0':
+    resolution: {integrity: sha512-/lZZUyqnb7SaXvzQXP34fAeell+si7Rc+McNv9AKB9mNheffNGuRgAMd/jEFPcPWbAuWXkHruCCNbABGz/oePw==}
 
   '@bull-board/ui@7.0.0':
     resolution: {integrity: sha512-AnKeklpDn0iMFgu4ukDU6uTNmw4oudl07G4k2Fh95SknKDrXSiWRV0N1TGUawMqyfG1Yi5P/W/8d7raBq/Uw6w==}
@@ -7567,20 +7559,15 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@bull-board/api@6.21.3(@bull-board/ui@6.21.3)':
-    dependencies:
-      '@bull-board/ui': 6.21.3
-      redis-info: 3.1.0
-
   '@bull-board/api@7.0.0(@bull-board/ui@7.0.0)':
     dependencies:
       '@bull-board/ui': 7.0.0
       redis-info: 3.1.0
 
-  '@bull-board/koa@6.21.3(@babel/core@7.29.0)(@types/koa@3.0.2)(handlebars@4.7.9)(lodash@4.18.1)':
+  '@bull-board/koa@7.0.0(@babel/core@7.29.0)(@types/koa@3.0.2)(handlebars@4.7.9)(lodash@4.18.1)':
     dependencies:
-      '@bull-board/api': 6.21.3(@bull-board/ui@6.21.3)
-      '@bull-board/ui': 6.21.3
+      '@bull-board/api': 7.0.0(@bull-board/ui@7.0.0)
+      '@bull-board/ui': 7.0.0
       '@koa/bodyparser': 6.1.0(koa@3.2.0)
       '@koa/router': 15.5.0(koa@3.2.0)
       '@ladjs/koa-views': 9.0.0(@babel/core@7.29.0)(@types/koa@3.0.2)(ejs@5.0.2)(handlebars@4.7.9)(lodash@4.18.1)
@@ -7638,10 +7625,6 @@ snapshots:
       - velocityjs
       - walrus
       - whiskers
-
-  '@bull-board/ui@6.21.3':
-    dependencies:
-      '@bull-board/api': 6.21.3(@bull-board/ui@6.21.3)
 
   '@bull-board/ui@7.0.0':
     dependencies:

--- a/src/commands/betting/__tests__/bet.test.ts
+++ b/src/commands/betting/__tests__/bet.test.ts
@@ -2,7 +2,7 @@ import type { MatchDetailDto } from '@pluto-khronos/api-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Must be hoisted above imports so module-level `new MatchCacheService()` gets the mock
-const mockGetMatch = vi.fn<[string], Promise<MatchDetailDto | null>>()
+const mockGetMatch = vi.fn<(id: string) => Promise<MatchDetailDto | null>>()
 
 vi.mock('../../../utils/api/routes/cache/match-cache-service.js', () => ({
 	default: vi.fn().mockImplementation(() => ({ getMatch: mockGetMatch })),


### PR DESCRIPTION
## Summary

- Bumps `@bull-board/koa` from v6 → v7 to align with `@bull-board/api@7.0.0`. The v6 koa adapter bundled its own `@bull-board/api@6` copy, causing a structural `IServerAdapter` incompatibility on the private `formatters` property (`TS2322` at `bullBoard.ts:26`).
- Fixes `vi.fn` generic in `bet.test.ts:5`: vitest v3 dropped the two-argument `<Args, Return>` form in favour of a single function-type argument — `vi.fn<(id: string) => Promise<MatchDetailDto | null>>()` (`TS2558`).
- Adds `pnpm typecheck` as the first command in the `khronos-client-update` workflow's Verify step and removes the NOTE comment that explained its absence; updates the PR-body label to match.

## Test plan

- [ ] `pnpm typecheck` exits 0 locally (verified in this branch)
- [ ] `pnpm build` still passes
- [ ] `pnpm test:run` still passes
- [ ] Review `.github/workflows/khronos-client-update.yml` to confirm the Verify step now runs typecheck first

https://claude.ai/code/session_01Pe8UsqgJnBXAuPmKt7a2Fn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe8UsqgJnBXAuPmKt7a2Fn)_