### PR TITLE
fix(ci): add dry-run Docker deploy path

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -126,9 +126,11 @@ jobs:
 
           # 3. Fallback (should never happen)
           VERSION="${VERSION:-0.0.0}"
+          ENABLE_LATEST="${{ github.ref == 'refs/heads/main' }}"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "enable_latest=$ENABLE_LATEST" >> $GITHUB_OUTPUT
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo "📦 Version:   $VERSION"
           echo "🔖 Short SHA: $SHORT_SHA"
@@ -190,7 +192,7 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}-${{ steps.version.outputs.short_sha }}
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=${{ steps.version.outputs.short_sha }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ steps.version.outputs.enable_latest }}
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_TITLE }}
             org.opencontainers.image.description=${{ env.IMAGE_DESCRIPTION }}
@@ -247,7 +249,9 @@ jobs:
             echo
             echo "### $TAGS_HEADING"
             echo '```'
-            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest"
+            if [[ "${{ steps.version.outputs.enable_latest }}" == "true" ]]; then
+              echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest"
+            fi
             echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
             echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.short_sha }}"
             echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ steps.version.outputs.short_sha }}"

--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -201,6 +201,7 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
       - name: Build Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -222,13 +223,21 @@ jobs:
 
       - name: Create deployment summary
         run: |
+          IMMUTABLE_IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ steps.version.outputs.short_sha }}"
+          IMAGE_DIGEST="${{ steps.build.outputs.digest }}"
+          DIGEST_IMAGE=""
+
+          if [[ -n "$IMAGE_DIGEST" ]]; then
+            DIGEST_IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@$IMAGE_DIGEST"
+          fi
+
           if [[ "${{ steps.deploy_mode.outputs.dry_run }}" == "true" ]]; then
             PUBLISH_NOTE="Dry run: image was built and loaded on the runner, but no GHCR push was performed."
             QUICK_PULL="Not available from this dry-run build."
             TAGS_HEADING="Built Tags"
           else
             PUBLISH_NOTE="Image was pushed to GHCR."
-            QUICK_PULL="docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
+            QUICK_PULL="docker pull $IMMUTABLE_IMAGE"
             TAGS_HEADING="Published Tags"
           fi
 
@@ -244,8 +253,13 @@ jobs:
             echo "| **Commit** | \`${{ steps.version.outputs.short_sha }}\` |"
             echo "| **Mode** | \`${{ steps.deploy_mode.outputs.mode }}\` |"
             echo "| **Pushed** | \`${{ steps.deploy_mode.outputs.push }}\` |"
+            echo "| **Deploy / Rollback Tag** | \`$IMMUTABLE_IMAGE\` |"
+            if [[ -n "$DIGEST_IMAGE" ]]; then
+              echo "| **Image Digest** | \`$DIGEST_IMAGE\` |"
+            fi
             echo
             echo "$PUBLISH_NOTE"
+            echo "Use the deploy / rollback tag, or the digest when available, for production rollbacks. Treat latest as a convenience pointer only."
             echo
             echo "### $TAGS_HEADING"
             echo '```'

--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -10,9 +10,13 @@ on:
   workflow_dispatch:
     inputs:
       force_build:
-        description: "Force Docker build and push"
+        description: "Run the Docker deploy job manually"
         type: boolean
         default: false
+      dry_run:
+        description: "Build and load the Docker image without pushing it"
+        type: boolean
+        default: true
       version_override:
         description: "Override version (e.g., 1.0.0-rc.1)"
         type: string
@@ -159,6 +163,24 @@ jobs:
         run: |
           echo "IMAGE_NAME=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
+      - name: Resolve deploy mode
+        id: deploy_mode
+        run: |
+          set -euo pipefail
+          DRY_RUN="${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}"
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            echo "push=false" >> "$GITHUB_OUTPUT"
+            echo "load=true" >> "$GITHUB_OUTPUT"
+            echo "mode=Dry run (build only)" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "push=true" >> "$GITHUB_OUTPUT"
+            echo "load=false" >> "$GITHUB_OUTPUT"
+            echo "mode=Publish" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -176,41 +198,63 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ steps.deploy_mode.outputs.push }}
+          load: ${{ steps.deploy_mode.outputs.load }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: true
-          sbom: true
+          provenance: ${{ steps.deploy_mode.outputs.push }}
+          sbom: ${{ steps.deploy_mode.outputs.push }}
+
+      - name: Inspect dry-run image
+        if: steps.deploy_mode.outputs.dry_run == 'true'
+        run: |
+          docker image inspect \
+            "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ steps.version.outputs.short_sha }}" \
+            --format='Loaded image {{ .Id }} with {{ len .RootFS.Layers }} layers'
 
       - name: Create deployment summary
         run: |
-          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
-          ## 🚀 Deployment Summary
+          if [[ "${{ steps.deploy_mode.outputs.dry_run }}" == "true" ]]; then
+            PUBLISH_NOTE="Dry run: image was built and loaded on the runner, but no GHCR push was performed."
+            QUICK_PULL="Not available from this dry-run build."
+            TAGS_HEADING="Built Tags"
+          else
+            PUBLISH_NOTE="Image was pushed to GHCR."
+            QUICK_PULL="docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
+            TAGS_HEADING="Published Tags"
+          fi
 
-          ### Image Details
-          | Property | Value |
-          |----------|-------|
-          | **Registry** | `${{ env.REGISTRY }}` |
-          | **Image** | `${{ github.repository_owner }}/${{ env.IMAGE_NAME }}` |
-          | **Version** | `${{ steps.version.outputs.version }}` |
-          | **Commit** | `${{ steps.version.outputs.short_sha }}` |
-
-          ### Published Tags
-          ```
-          ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
-          ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-          ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.short_sha }}
-          ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ steps.version.outputs.short_sha }}
-          ```
-
-          ### Quick Pull
-          ```bash
-          docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-          ```
-          EOF
+          {
+            echo "## 🚀 Deployment Summary"
+            echo
+            echo "### Image Details"
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| **Registry** | \`${{ env.REGISTRY }}\` |"
+            echo "| **Image** | \`${{ github.repository_owner }}/${{ env.IMAGE_NAME }}\` |"
+            echo "| **Version** | \`${{ steps.version.outputs.version }}\` |"
+            echo "| **Commit** | \`${{ steps.version.outputs.short_sha }}\` |"
+            echo "| **Mode** | \`${{ steps.deploy_mode.outputs.mode }}\` |"
+            echo "| **Pushed** | \`${{ steps.deploy_mode.outputs.push }}\` |"
+            echo
+            echo "$PUBLISH_NOTE"
+            echo
+            echo "### $TAGS_HEADING"
+            echo '```'
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest"
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.short_sha }}"
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ steps.version.outputs.short_sha }}"
+            echo '```'
+            echo
+            echo "### Quick Pull"
+            echo '```bash'
+            echo "$QUICK_PULL"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Build stage
 FROM node:26-slim AS base
+ARG PNPM_VERSION=10.27.0
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install -g pnpm
+RUN npm install -g pnpm@${PNPM_VERSION}
 
 # Install Doppler
 RUN apt-get update && apt-get install -y apt-transport-https ca-certificates curl gnupg && \
@@ -17,7 +18,7 @@ RUN apt-get update && apt-get install -y apt-transport-https ca-certificates cur
 FROM base AS builder
 WORKDIR /app
 
-# Copy package.json and pnpm-lock.yaml
+# Copy package metadata and pnpm build-script approvals
 COPY package.json pnpm-lock.yaml ./
 
 # Install dependencies

--- a/package.json
+++ b/package.json
@@ -39,6 +39,17 @@
 			"biome check --write --no-errors-on-unmatched"
 		]
 	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@swc/core",
+			"core-js",
+			"esbuild",
+			"msgpackr-extract",
+			"protobufjs",
+			"puppeteer",
+			"unrs-resolver"
+		]
+	},
 	"imports": {
 		"@pluto-config": "./dist/lib/PlutoConfig.js",
 		"#lib/*": "./dist/lib/*"


### PR DESCRIPTION
## Summary
- add a manual `dry_run` input for the CI/CD deploy workflow, defaulting to `true`
- route manual dry runs through Buildx with `push=false` and `load=true`
- keep release events and manual `dry_run=false` deploys on the publishing path
- pin Docker builds to pnpm `10.27.0` and add explicit pnpm build-script approvals in `package.json`
- inspect the loaded dry-run image and make deployment summaries state whether GHCR was pushed

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-cd-deployment.yml'); puts 'yaml ok'"`
- `git diff --check`
- `docker build -t pluto-betting-bot:dry-run-local .`
- `docker image inspect pluto-betting-bot:dry-run-local --format='Loaded image {{ .Id }} with {{ len .RootFS.Layers }} layers; size={{ .Size }} bytes'`

## Notes
- No Docker image was pushed while validating this branch.
- No release-please PR was merged.
- The post-merge proof should be a manual `CI/CD Pipeline` dispatch from `main` with `force_build=true` and `dry_run=true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dry-run toggle to build and inspect images locally without publishing.
  * Inspect step for dry-run images and mode-aware deployment summaries that reflect dry-run vs publish, including adjusted quick-pull messaging.
  * Conditional application of the "latest" tag only for main-branch builds.

* **Chores**
  * Made image build/publish behavior configurable so pushing, loading, and SBOM/provenance occur only when publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->