### PR TITLE
fix(ci): deploy on every release-please release (PAT token)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Release Please
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Must be a PAT, not GITHUB_TOKEN. GitHub does not trigger new
+          # workflow runs from events created with the default GITHUB_TOKEN,
+          # so a release published with it would never fire the
+          # `release: published` trigger in ci-cd-deployment.yml and Deploy
+          # would never run. PLUTO_BOT_PAT lets the release event cascade.
+          token: ${{ secrets.PLUTO_BOT_PAT }}
           release-type: node
           config-file: .github/release-please-config.json


### PR DESCRIPTION
## Root cause: regression introduced by #531

`ci-cd-deployment.yml` deploy worked fine through **v4.5.0** (2026-05-07). It broke for **v4.6.0** (2026-05-17) — the first release after **#531** (`14d7ad7`, "chore: release-only deploys", merged 2026-05-14, mirroring khronos#581).

**Before #531:** deploy triggered on `push: branches: [main]` with a `startsWith(..., 'chore(main): release' / fix/patch/hotfix)` condition. Merging a release-please PR pushed a squash commit to `main` **authored by the human merging** → that `push` event fired → deploy ran. No PAT needed, because the trigger was the human push, not the bot's release event.

**After #531:** the `push: main` trigger and that deploy condition were removed; deploy now only runs on `release: published` / `workflow_dispatch`. But release-please publishes the GitHub Release using the default `GITHUB_TOKEN`, and **GitHub does not start new workflow runs from `GITHUB_TOKEN`-created events** (recursion guard). So under the new release-only model the `release: published` trigger never fires → Deploy never runs. v4.6.0 was simply the first release to hit this.

Run [25994460903](https://github.com/fearandesire/Pluto-Betting-Bot/actions/runs/25994460903) (skipped Deploy) is unrelated noise — that's the `pull_request` run on release-please PR #529, where Deploy correctly skips by design.

## Fix (canonical release-please CD pattern)

Keep #531's release-only model and run release-please under `secrets.PLUTO_BOT_PAT` instead of `GITHUB_TOKEN`. This is the documented release-please pattern for triggering downstream workflows: a release created under a PAT (or GitHub App token) **does** fire `release: published`, so `release: published` → `verify` → `deploy` runs on every release-please release.

## PAT verification (empirical)

`PLUTO_BOT_PAT` confirmed valid and sufficiently scoped: PR #536 (`chore(deps): bump @pluto-khronos/* to 3.3.0`) was created **2026-05-17 14:39 UTC** by the `khronos-client-update` workflow, which authenticates only with `PLUTO_BOT_PAT`. That run pushed the `chore/khronos-update` branch (proves `contents:write`) and opened PR #536 (proves `pull-requests:write`) — exactly the scopes release-please needs (tags + releases are under the same `contents` write permission). PR #536's author is the `fearandesire` user account, so the token is a real user PAT (not `GITHUB_TOKEN`), which is precisely why releases it creates will fire `release: published`.

Only the token owner can confirm in GitHub settings: (a) the PAT's expiry, and (b) if it's fine-grained, that `Contents: Read and write` is granted (already implied by the branch push above).

## Scope / notes

- **Khronos is out of scope** — its Khronos → Pluto path works as the owner expects; no change there.
- Reverting to the pre-#531 push-to-main model was considered and rejected: it undoes #531's intended commit-hygiene simplification and is the older, hackier style. PAT + release-only is the idiomatic setup.
- Minor: `ci-cd-deployment.yml` header still says `Deploy triggers: ... | fix/patch/hotfix commits | ...` — stale since #531 removed that path. Left for a separate one-line edit to avoid a full-file rewrite via API.

## Test plan

- [x] Confirm `PLUTO_BOT_PAT` is valid and authorized for branch/PR/release writes — verified empirically via PR #536 (2026-05-17).
- [ ] Owner to confirm PAT expiry (and `Contents: write` if fine-grained) in GitHub settings.
- [ ] Merge the next release-please PR and confirm `release: published` triggers CI/CD Pipeline and Deploy runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release contains no user-visible changes. Internal infrastructure updates were made to the CI/CD workflow configuration to improve the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->