### PR TITLE
chore(ci): hide chore from changelog + retype khronos bumps

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -11,7 +11,7 @@
       "changelog-path": "CHANGELOG.md",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "fix", "section": "Fixes & Updates" },
         { "type": "hotfix", "section": "Hotfixes" },
         { "type": "patch", "section": "Patches" },
         { "type": "perf", "section": "Performance" },
@@ -20,7 +20,7 @@
         { "type": "deps", "section": "Dependencies" },
         { "type": "docs", "section": "Documentation", "hidden": true },
         { "type": "style", "section": "Styles", "hidden": true },
-        { "type": "chore", "section": "Miscellaneous" },
+        { "type": "chore", "section": "Miscellaneous", "hidden": true },
         { "type": "test", "section": "Tests", "hidden": true },
         { "type": "build", "section": "Build System", "hidden": true },
         { "type": "ci", "section": "CI", "hidden": true }

--- a/.github/workflows/khronos-client-update.yml
+++ b/.github/workflows/khronos-client-update.yml
@@ -13,9 +13,13 @@
 #   4. Open PR — DRAFT if verify failed; ready-for-review if green
 #   5. Human reviews + clicks merge (NO auto-merge)
 #
-# Re-dispatch behavior: uses a static branch name (`chore/khronos-update`),
+# Re-dispatch behavior: uses a static branch name (`deps/khronos-update`),
 # so a newer release updates the existing PR rather than opening a duplicate
 # or orphaning the prior draft.
+#
+# BEGIN_COMMIT_OVERRIDE in the PR body tells release-please to treat the
+# merged squash commit as fix(khronos) instead of deps(khronos), triggering
+# a patch version bump and changelog entry under "Fixes & Updates".
 #
 # Manual trigger (testing):
 #   gh api repos/fearandesire/Pluto-Betting-Bot/dispatches \
@@ -104,10 +108,10 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.PLUTO_BOT_PAT }}
-          branch: chore/khronos-update
+          branch: deps/khronos-update
           delete-branch: false
-          title: "chore(deps): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}"
-          commit-message: "chore(deps): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}"
+          title: "deps(khronos): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}"
+          commit-message: "deps(khronos): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}"
           draft: ${{ steps.verify.outcome == 'failure' }}
           body: |
             Automated bump triggered by Khronos release.
@@ -125,6 +129,10 @@ jobs:
             **Verify (typecheck + build + test):** `${{ steps.verify.outcome }}`
 
             ${{ steps.verify.outcome == 'failure' && '⚠️ Opened as DRAFT — fix consumers in this branch before marking ready. Then merge manually.' || '✅ All checks passed — ready for review. Click merge when you''ve scanned the diff.' }}
+
+            BEGIN_COMMIT_OVERRIDE
+            fix(khronos): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}
+            END_COMMIT_OVERRIDE
           labels: |
             dependencies
             automated


### PR DESCRIPTION
## What & why

Two coupled changes to clean up release-please changelog output.

### 1. Hide `chore` from changelog (`release-please-config.json`)
`chore` commits are housekeeping — they don't belong in release notes. Added `"hidden": true`. Also renamed the `fix` section from `"Bug Fixes"` → `"Fixes & Updates"` to accurately cover both bug fixes and integration updates.

### 2. Retype khronos bumps (`khronos-client-update.yml`)
Previously used `chore(deps):` — hidden, no version bump. Now:

| | Before | After |
|---|---|---|
| Branch | `chore/khronos-update` | `deps/khronos-update` |
| PR title / commit | `chore(deps): bump @pluto-khronos/*...` | `deps(khronos): bump @pluto-khronos/*...` |
| release-please sees | `chore` → hidden, no bump | `fix(khronos)` via `BEGIN_COMMIT_OVERRIDE` → patch bump + changelog |

**How `BEGIN_COMMIT_OVERRIDE` works:** When release-please processes the push to main after the khronos PR is squash-merged, it finds the override block in the PR body and uses `fix(khronos): bump @pluto-khronos/* to X.X.X` as the conventional commit instead of the actual squash commit title (`deps(khronos):`). This triggers a patch version bump (e.g. `4.6.0 → 4.6.1`) and surfaces the update in the changelog under "Fixes & Updates" — while keeping the PR title/branch semantically accurate.

**Resulting changelog entry:**
```markdown
### Fixes & Updates
* **khronos:** bump @pluto-khronos/* to 3.4.0 (#543) (abc1234)
```

## Test plan
- [ ] Merge this PR.
- [ ] Dispatch a test khronos event: `gh api repos/fearandesire/Pluto-Betting-Bot/dispatches -f event_type=khronos-release -f 'client_payload[khronos_version]=X.X.X' -f 'client_payload[sha]=HEAD'`
- [ ] Confirm opened PR: branch `deps/khronos-update`, title `deps(khronos):`, body contains the `BEGIN_COMMIT_OVERRIDE` block.
- [ ] Merge the khronos PR → confirm release-please opens a patch release PR and CHANGELOG.md shows `fix(khronos):` under "Fixes & Updates".

---
_Generated by [Claude Code](https://claude.ai/code/session_016qDDmvn2ifunf5HLa33jQp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update workflow to streamline PR management and ensure consistent release semantics for internal package updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->