### PR TITLE
fix(ci): use PLUTO_BOT_PAT for GHCR login

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -158,8 +158,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PLUTO_BOT_PAT }}
 
       - name: Set lowercase image name
         run: |

--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -92,7 +92,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: write
       attestations: write
       id-token: write
 

--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -42,7 +42,6 @@ env:
 permissions:
   contents: read
   pull-requests: read
-  packages: write
 
 jobs:
   # ===========================================================================


### PR DESCRIPTION
## What broke

Run [25995037876](https://github.com/fearandesire/Pluto-Betting-Bot/actions/runs/25995037876) failed with:
```
403 Forbidden on HEAD request to https://ghcr.io/v2/fearandesire/pluto-betting-bot/blobs/sha256:...
```

The deploy job was using `GITHUB_TOKEN` for the GHCR login. `GITHUB_TOKEN` is a **repo-scoped** token; GHCR authorises writes based on package-to-repository linking. The `release: published` trigger is now fired by `PLUTO_BOT_PAT` (fearandesire) after #537 — this appears to produce a `GITHUB_TOKEN` context where GHCR's package write authorisation fails (403, not 401 — auth passes, but the package write is rejected).

## Fix

Switch the registry login to `PLUTO_BOT_PAT` with `github.repository_owner` as the username. Since the PAT belongs to `fearandesire` who owns the `ghcr.io/fearandesire/pluto-betting-bot` package namespace, writes are always authorised — no package-linking dependency.

```diff
- username: ${{ github.actor }}
- password: ${{ secrets.GITHUB_TOKEN }}
+ username: ${{ github.repository_owner }}
+ password: ${{ secrets.PLUTO_BOT_PAT }}
```

## ⚠️ Pre-merge check — verify `PLUTO_BOT_PAT` has `write:packages`

I cannot read the PAT's scopes from here. Before merging, confirm `PLUTO_BOT_PAT` has the required scope:

**Classic PAT:** GitHub → Settings → Developer settings → Personal access tokens → find the token → check `write:packages` is ticked. If it only has `repo`, GHCR writes will still fail — add `write:packages`.

**Fine-grained PAT:** GitHub → Settings → Developer settings → Fine-grained tokens → find the token → confirm "Packages: Read and write" is granted for this repo.

Once this PR is merged, trigger a fresh deploy via **Actions → CI/CD Pipeline → Run workflow → `force_build: true`, `dry_run: false`** to validate the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_016qDDmvn2ifunf5HLa33jQp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI/CD job permissions and updated registry authentication to use a dedicated registry account (instead of the runtime actor). Deployment and image publishing behavior remain unchanged, improving security and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->