### PR TITLE
fix(ci): authenticate GHCR push with owner PAT

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -185,8 +185,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Set lowercase image name
         run: |


### PR DESCRIPTION
## Problem

Docker deploy fails with `403 Forbidden` pushing to `ghcr.io/fearandesire/pluto-betting-bot` ([failing run](https://github.com/fearandesire/Pluto-Betting-Bot/actions/runs/25995776075/job/76409959839)).

## Root cause

Not a workflow regression — `git log -p` shows the login/permissions block unchanged. The ephemeral `GITHUB_TOKEN` lost **write** access to the user-owned `pluto-betting-bot` container package. The package is still linked to this repo and `private`, but for **user-scoped** GHCR packages the repo→package Actions-access (Write role) is a UI-only setting with no stable REST API, so it can silently break on a visibility/access change with zero code changes.

## Fix

Log in to GHCR as the **package owner** (`github.repository_owner`) using a new `GHCR_PAT` secret (classic PAT, `write:packages`, owned by `fearandesire`) instead of the ephemeral `GITHUB_TOKEN`. Authenticating as the owner removes the dependency on the fragile repo→package link, so a future visibility toggle can't break deploys again. Using `github.repository_owner` (not `github.actor`) keeps it correct for release/bot-triggered runs.

- Secret `GHCR_PAT` added to repo secrets.
- Workflow `docker/login-action` switched to `username: ${{ github.repository_owner }}` / `password: ${{ secrets.GHCR_PAT }}`.

## Test plan

- [ ] Merge, then trigger CI/CD (release or `workflow_dispatch` with `force_build=true`) and confirm the Docker image pushes to GHCR without 403.
- [ ] Rotate the PAT after verification (it was shared in plaintext during setup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD deployment authentication to use improved credential management for container registry deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->