### PR TITLE
chore(ci): default workflow_dispatch dry_run to false

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -1,7 +1,7 @@
 # CI/CD Pipeline - Pluto Betting Bot
 # Builds, verifies, and deploys Docker images to GHCR
 #
-# Deploy triggers: release event | fix/patch/hotfix commits | workflow_dispatch
+# Deploy triggers: release event | workflow_dispatch (force_build)
 # Skip CI: Use native [skip ci] in commit message
 
 name: CI/CD Pipeline
@@ -16,7 +16,7 @@ on:
       dry_run:
         description: "Build and load the Docker image without pushing it"
         type: boolean
-        default: true
+        default: false
       version_override:
         description: "Override version (e.g., 1.0.0-rc.1)"
         type: string


### PR DESCRIPTION
## What

Two-line change to `ci-cd-deployment.yml`:

1. `workflow_dispatch.inputs.dry_run.default`: `true` → `false`
2. Header comment line 4: drop the dead `fix/patch/hotfix commits` trigger note → `release event | workflow_dispatch (force_build)`

## Why

The Khronos-style "publish only on release, never on PRs/main" model is **already enforced structurally**:
- There is no `push:` trigger — direct pushes to `main` cannot deploy.
- The `deploy` job `if:` is `release || (workflow_dispatch && force_build)` — PRs run `verify` only and structurally cannot publish.

`dry_run` therefore only ever affected **manual** dispatches (`deploy_mode` gates it behind `github.event_name == 'workflow_dispatch'`). Releases compute `dry_run=false` regardless of the input default and always push. Defaulting the input to `false` removes redundant friction on manual `force_build` runs; `dry_run=true` remains available as an explicit opt-in for build-only testing.

No changes to `on:` triggers or the deploy `if:`.

## Test plan

- [ ] PR runs `Verify` only (confirms PRs still never deploy).
- [ ] Post-merge: `workflow_dispatch` with `force_build=true` and no `dry_run` → publishes (Mode `Publish`, Pushed `true`).
- [ ] `workflow_dispatch` with `force_build=true` + `dry_run=true` → build-only, no push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to streamline release triggers and modified the default behavior for manual deployment runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->