### PR TITLE
fix(ci): unblock dependabot auto-merge and validate bumps

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Enable auto-merge for Dependabot PRs
         if: contains(github.event.pull_request.labels.*.name, 'dependencies')
         run: |
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -50,7 +50,6 @@ jobs:
   verify:
     name: Verify
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Switch `gh pr merge` from `--merge` to `--squash` in [auto-merge-dependabot.yml](.github/workflows/auto-merge-dependabot.yml) — every Dependabot PR's auto-merge job was failing with `GraphQL: Merge commits are not allowed on this repository`, because the repo has `allow_merge_commit: false` and only `squash` is enabled.
- Drop `if: github.actor != 'dependabot[bot]'` from the `Verify` job in [ci-cd-deployment.yml](.github/workflows/ci-cd-deployment.yml). `Verify` is a required check, and skipping it for Dependabot meant bumps were auto-merging with zero build validation — a broken bump would only surface after landing on `main`.

## Why

The bot's PRs have been stuck for ~10 consecutive runs (#544–#553). The auto-merge step was failing at the API level, so nothing in the auto-merge pipeline was ever triggered. With `--squash` it matches the repo's only allowed merge method, and with `Verify` enabled for Dependabot the `--auto` gate now only fires once `pnpm install --frozen-lockfile && pnpm build` actually succeed against the new version.

## End-to-end flow after this PR

1. Dependabot opens a PR with the `dependencies` label.
2. `Verify` runs against the bumped package and must pass.
3. `Validate PR title` passes (Dependabot's `chore(deps): …` prefix matches the semantic-pr config).
4. `dependabot-auto-merge` calls `gh pr merge --auto --squash`, which queues the PR and merges it the moment required checks turn green.

## Test plan

- [ ] CI passes on this PR (`Verify` should now run for non-Dependabot too — unchanged behavior there)
- [ ] After merge, manually re-run the failed `dependabot-auto-merge` job on one open Dependabot PR (e.g. #553) and confirm it succeeds + the PR gets queued for auto-merge
- [ ] Confirm the rest of the open Dependabot PRs (#544–#552) self-resolve via Dependabot's auto-rebase or a one-shot bulk rerun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management automation to use squash merge strategy
  * Ensured code verification runs consistently across all workflow triggers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->