### PR TITLE
fix: populate cached prop market ids

### DIFF
--- a/src/utils/cron/PropsCronService.test.ts
+++ b/src/utils/cron/PropsCronService.test.ts
@@ -1,0 +1,74 @@
+import type { PropDto } from '@pluto-khronos/api-client'
+import { describe, expect, it } from 'vitest'
+import { convertFlatPropsToCachedProps } from './props-conversion.js'
+
+const eventContext = {
+	home_team: 'Los Angeles Lakers',
+	away_team: 'Boston Celtics',
+	commence_time: '2026-06-01T20:00:00.000Z',
+}
+
+describe('convertFlatPropsToCachedProps', () => {
+	it('copies market_id from the parent PropDto to each cached outcome', () => {
+		const props = [
+			{
+				market_id: 12345,
+				market_key: 'player_points',
+				event_context: eventContext,
+				outcomes: [
+					{
+						outcome_uuid: 'outcome-over',
+						description: 'Player over points',
+						point: 24.5,
+					},
+					{
+						outcome_uuid: 'outcome-under',
+						description: 'Player under points',
+						point: 24.5,
+					},
+				],
+			} as PropDto,
+		]
+
+		const cachedProps = convertFlatPropsToCachedProps(props)
+
+		expect(cachedProps).toHaveLength(2)
+		expect(cachedProps).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					outcome_uuid: 'outcome-over',
+					market_id: 12345,
+				}),
+				expect.objectContaining({
+					outcome_uuid: 'outcome-under',
+					market_id: 12345,
+				}),
+			]),
+		)
+	})
+
+	it.each([
+		'h2h',
+		'spreads',
+		'totals',
+		'team_totals',
+		'player_anytime_td',
+	])('excludes %s market props', (marketKey) => {
+		const props = [
+			{
+				market_id: 12345,
+				market_key: marketKey,
+				event_context: eventContext,
+				outcomes: [
+					{
+						outcome_uuid: `${marketKey}-outcome`,
+						description: 'Excluded outcome',
+						point: null,
+					},
+				],
+			} as PropDto,
+		]
+
+		expect(convertFlatPropsToCachedProps(props)).toEqual([])
+	})
+})

--- a/src/utils/cron/PropsCronService.ts
+++ b/src/utils/cron/PropsCronService.ts
@@ -10,6 +10,7 @@ import type {
 	CachedProp,
 	PropsCacheService,
 } from '../props/PropCacheService.js'
+import { convertFlatPropsToCachedProps } from './props-conversion.js'
 
 /**
  * Service for running scheduled prop caching jobs
@@ -128,41 +129,7 @@ export class PropsCronService {
 	 * Flattens outcomes array into individual cached props
 	 */
 	private convertFlatPropsToCachedProps(props: PropDto[]): CachedProp[] {
-		const EXCLUDED_MARKETS = [
-			'h2h',
-			'spreads',
-			'totals',
-			'team_totals',
-			'player_anytime_td',
-		]
-		const cached: CachedProp[] = []
-
-		for (const prop of props) {
-			// Skip non-player props
-			if (EXCLUDED_MARKETS.includes(prop.market_key)) {
-				continue
-			}
-
-			// Skip if missing required fields
-			if (!prop.outcomes || !prop.event_context) {
-				continue
-			}
-
-			// Flatten each outcome into a separate cached prop
-			for (const outcome of prop.outcomes) {
-				cached.push({
-					outcome_uuid: outcome.outcome_uuid,
-					description: outcome.description || 'Unknown',
-					market_key: prop.market_key,
-					point: outcome.point || null,
-					home_team: prop.event_context.home_team,
-					away_team: prop.event_context.away_team,
-					commence_time: prop.event_context.commence_time,
-				})
-			}
-		}
-
-		return cached
+		return convertFlatPropsToCachedProps(props)
 	}
 
 	/**

--- a/src/utils/cron/props-conversion.ts
+++ b/src/utils/cron/props-conversion.ts
@@ -30,7 +30,7 @@ export function convertFlatPropsToCachedProps(props: PropDto[]): CachedProp[] {
 				market_id: prop.market_id ?? null,
 				description: outcome.description || 'Unknown',
 				market_key: prop.market_key,
-				point: outcome.point || null,
+				point: outcome.point ?? null,
 				home_team: prop.event_context.home_team,
 				away_team: prop.event_context.away_team,
 				commence_time: prop.event_context.commence_time,

--- a/src/utils/cron/props-conversion.ts
+++ b/src/utils/cron/props-conversion.ts
@@ -1,0 +1,42 @@
+import type { PropDto } from '@pluto-khronos/api-client'
+import type { CachedProp } from '../props/PropCacheService.js'
+
+const EXCLUDED_MARKETS = [
+	'h2h',
+	'spreads',
+	'totals',
+	'team_totals',
+	'player_anytime_td',
+]
+
+/**
+ * Convert PropDto array (with outcomes) to CachedProp format.
+ */
+export function convertFlatPropsToCachedProps(props: PropDto[]): CachedProp[] {
+	const cached: CachedProp[] = []
+
+	for (const prop of props) {
+		if (EXCLUDED_MARKETS.includes(prop.market_key)) {
+			continue
+		}
+
+		if (!prop.outcomes || !prop.event_context) {
+			continue
+		}
+
+		for (const outcome of prop.outcomes) {
+			cached.push({
+				outcome_uuid: outcome.outcome_uuid,
+				market_id: prop.market_id ?? null,
+				description: outcome.description || 'Unknown',
+				market_key: prop.market_key,
+				point: outcome.point || null,
+				home_team: prop.event_context.home_team,
+				away_team: prop.event_context.away_team,
+				commence_time: prop.event_context.commence_time,
+			})
+		}
+	}
+
+	return cached
+}


### PR DESCRIPTION
## Summary
- Closes #491
- Extracts the cron prop conversion into a pure helper for focused coverage.
- Populates `CachedProp.market_id` from `PropDto.market_id ?? null`.
- Adds Vitest coverage for market ID propagation and excluded market filtering.

## Validation
- PASS: `pnpm install --frozen-lockfile`
- PASS: `pnpm vitest run src/utils/cron/PropsCronService.test.ts`
- PASS: `pnpm exec biome check src/utils/cron/PropsCronService.ts src/utils/cron/PropsCronService.test.ts src/utils/cron/props-conversion.ts`
- PASS: `pnpm typecheck`
- PASS: `pnpm build`
- FAIL: `pnpm test:run` is blocked by an existing unrelated mock constructor issue in `src/commands/betting/__tests__/bet.test.ts`.