### PR TITLE
ci: allow deps type in PR title validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -33,6 +33,7 @@ jobs:
             build
             ci
             chore
+            deps
             revert
             hotfix
             patch


### PR DESCRIPTION
## Summary
The `khronos-client-update` workflow opens its automated bump PRs with a `deps(khronos)` title by design (release-please still gets a patch bump via the `BEGIN_COMMIT_OVERRIDE` → `fix(khronos)` block in the PR body). However `deps` was missing from the allowed types in `pr-title.yml`, so the required **Validate PR title** check (`amannn/action-semantic-pull-request@v5`) rejected every Khronos bump PR — e.g. #556 (`deps(khronos): bump @pluto-khronos/* to 3.4.3`), which was otherwise fully green.

This aligns the lint vocabulary with the generator's deliberate type choice by adding `deps` to the allowed types.

## Change
- `.github/workflows/pr-title.yml`: add `deps` to the `types` list.

## Test plan
- [ ] This PR's own **Validate PR title** check passes (`ci:` is already allowed).
- [ ] After merge, re-trigger the title check on #556 and confirm it goes green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal pull request validation workflow to support additional commit types.

---

*Note: This is an internal process improvement with no end-user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->