### PR TITLE
test: fix vitest 4 constructable mocks in bet.test.ts and document the gotcha

### DIFF
--- a/src/commands/betting/__tests__/bet.test.ts
+++ b/src/commands/betting/__tests__/bet.test.ts
@@ -5,14 +5,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mockGetMatch = vi.fn<(id: string) => Promise<MatchDetailDto | null>>()
 
 vi.mock('../../../utils/api/routes/cache/match-cache-service.js', () => ({
-	default: vi.fn().mockImplementation(() => ({ getMatch: mockGetMatch })),
+	default: vi.fn().mockImplementation(function () {
+		return { getMatch: mockGetMatch }
+	}),
 }))
 
 const mockInitialize = vi.fn().mockResolvedValue(undefined)
 vi.mock('../../../utils/api/Khronos/bets/BetslipsManager.js', () => ({
-	BetslipManager: vi.fn().mockImplementation(() => ({
-		initialize: mockInitialize,
-	})),
+	BetslipManager: vi.fn().mockImplementation(function () {
+		return { initialize: mockInitialize }
+	}),
 }))
 
 vi.mock('../../../utils/api/Khronos/bets/betslip-wrapper.js', () => ({


### PR DESCRIPTION
## Summary

`pnpm test:run` has been failing on `main` since the repo was upgraded to Vitest 4 (`^4.1.6`), independently of any `@pluto-khronos/*` version bump. The failure:

\`\`\`
FAIL src/commands/betting/__tests__/bet.test.ts
TypeError: () => ({ getMatch: mockGetMatch }) is not a constructor
  ❯ src/commands/betting/__tests__/bet.test.ts:52:25
\`\`\`

**Root cause:** Vitest 4 enforces that mock implementations for classes instantiated via `new` must be constructable. Arrow functions have no `[[Construct]]` slot, so `vi.fn().mockImplementation(() => ({...}))` throws when `bet.ts` calls `new MatchCacheService(new CacheManager())` at module-level import time (line 15) and `new BetslipManager(...)` at runtime (line 113).

This is **unrelated to the `@pluto-khronos/* 3.4.3` bump** — verified: identical failure reproduces on `main` with `3.3.0`.

## Changes

- **`bet.test.ts`**: converted two arrow mock implementations to regular `function` expressions. A constructable `function` returning an object yields that object when `new`'d — correct mock semantics preserved.
- **`CLAUDE.md`**: corrected stale Vitest version (`^3.2.4` → `^4.1.6` per `package.json`) and added a new Testing gotchas bullet documenting the Vitest 4 arrow/constructor rule so agents and developers don't reintroduce it.

## Test plan

- [ ] `pnpm test:run` — all suites pass, `bet.test.ts` no longer throws "is not a constructor"
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm build` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test mock structure for consistency.

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fearandesire/Pluto-Betting-Bot/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->