### PR TITLE
fix(props): populate market_id in cron prop conversion (#491)

### DIFF
--- a/src/utils/cron/PropsCronService.ts
+++ b/src/utils/cron/PropsCronService.ts
@@ -2,7 +2,6 @@
 // Props Cron Service - Scheduled caching of props from Khronos
 // ============================================================================
 
-import type { PropDto } from '@pluto-khronos/api-client'
 import type PropsApiWrapper from '../api/Khronos/props/props-api-wrapper.js'
 import { logger } from '../logging/WinstonLogger.js'
 import type { ActivePropsService } from '../props/ActivePropsService.js'
@@ -10,6 +9,7 @@ import type {
 	CachedProp,
 	PropsCacheService,
 } from '../props/PropCacheService.js'
+import { convertFlatPropsToCachedProps } from '../props/prop-conversion.js'
 
 /**
  * Service for running scheduled prop caching jobs
@@ -106,7 +106,7 @@ export class PropsCronService {
 			})
 
 			// Convert flat PropDto array to CachedProp format
-			return this.convertFlatPropsToCachedProps(availableProps)
+			return convertFlatPropsToCachedProps(availableProps)
 		} catch (error) {
 			await logger.error({
 				message: `Failed to fetch props for ${sport}`,
@@ -120,49 +120,6 @@ export class PropsCronService {
 			// Return empty array instead of throwing to allow other sports to continue
 			return []
 		}
-	}
-
-	/**
-	 * Convert PropDto array (with outcomes) to CachedProp format
-	 * Filters to only include player props (excludes h2h, spreads, totals, etc.)
-	 * Flattens outcomes array into individual cached props
-	 */
-	private convertFlatPropsToCachedProps(props: PropDto[]): CachedProp[] {
-		const EXCLUDED_MARKETS = [
-			'h2h',
-			'spreads',
-			'totals',
-			'team_totals',
-			'player_anytime_td',
-		]
-		const cached: CachedProp[] = []
-
-		for (const prop of props) {
-			// Skip non-player props
-			if (EXCLUDED_MARKETS.includes(prop.market_key)) {
-				continue
-			}
-
-			// Skip if missing required fields
-			if (!prop.outcomes || !prop.event_context) {
-				continue
-			}
-
-			// Flatten each outcome into a separate cached prop
-			for (const outcome of prop.outcomes) {
-				cached.push({
-					outcome_uuid: outcome.outcome_uuid,
-					description: outcome.description || 'Unknown',
-					market_key: prop.market_key,
-					point: outcome.point || null,
-					home_team: prop.event_context.home_team,
-					away_team: prop.event_context.away_team,
-					commence_time: prop.event_context.commence_time,
-				})
-			}
-		}
-
-		return cached
 	}
 
 	/**

--- a/src/utils/props/prop-conversion.test.ts
+++ b/src/utils/props/prop-conversion.test.ts
@@ -60,6 +60,14 @@ describe('convertFlatPropsToCachedProps', () => {
 		expect(result.every((o) => o.market_id === null)).toBe(true)
 	})
 
+	it('preserves a point of 0 instead of coercing it to null', () => {
+		const prop = buildProp()
+		prop.outcomes[0].point = 0
+
+		const [outcome] = convertFlatPropsToCachedProps([prop])
+		expect(outcome.point).toBe(0)
+	})
+
 	it('keeps distinct market_ids so cron outcomes are groupable by prop', () => {
 		const result = convertFlatPropsToCachedProps([
 			buildProp({ market_id: 111 }),

--- a/src/utils/props/prop-conversion.test.ts
+++ b/src/utils/props/prop-conversion.test.ts
@@ -1,0 +1,112 @@
+import type { PropDto } from '@pluto-khronos/api-client'
+import { describe, expect, it } from 'vitest'
+import {
+	convertFlatPropsToCachedProps,
+	EXCLUDED_PROP_MARKETS,
+} from './prop-conversion.js'
+
+/**
+ * Builds a minimal valid PropDto for tests. `market_id` lives on the prop and
+ * is shared by all of its outcomes (e.g. the Over/Under pair).
+ */
+function buildProp(overrides: Partial<PropDto> = {}): PropDto {
+	return {
+		event_id: 'evt-1',
+		event_context: {
+			home_team: 'Lakers',
+			away_team: 'Warriors',
+			commence_time: '2999-01-27T20:00:00Z',
+			sport_title: 'NBA',
+		},
+		market_key: 'player_points',
+		bookmaker_key: 'draftkings',
+		market_id: 12345,
+		outcomes: [
+			{
+				outcome_uuid: 'uuid-over',
+				name: 'Over',
+				description: 'LeBron James',
+				price: 1.9,
+				point: 25.5,
+			},
+			{
+				outcome_uuid: 'uuid-under',
+				name: 'Under',
+				description: 'LeBron James',
+				price: 1.9,
+				point: 25.5,
+			},
+		],
+		...overrides,
+	}
+}
+
+describe('convertFlatPropsToCachedProps', () => {
+	it('populates market_id on every outcome from the source prop (#491)', () => {
+		const result = convertFlatPropsToCachedProps([buildProp()])
+
+		expect(result).toHaveLength(2)
+		expect(result.every((o) => o.market_id === 12345)).toBe(true)
+		// market_id must always be present (the bug omitted it entirely)
+		expect(result.every((o) => 'market_id' in o)).toBe(true)
+	})
+
+	it('sets market_id to null when the source prop has none (legacy data)', () => {
+		const result = convertFlatPropsToCachedProps([
+			buildProp({ market_id: undefined }),
+		])
+
+		expect(result).toHaveLength(2)
+		expect(result.every((o) => o.market_id === null)).toBe(true)
+	})
+
+	it('keeps distinct market_ids so cron outcomes are groupable by prop', () => {
+		const result = convertFlatPropsToCachedProps([
+			buildProp({ market_id: 111 }),
+			buildProp({ market_id: 222 }),
+		])
+
+		const uniqueMarketIds = new Set(result.map((o) => o.market_id))
+		expect(uniqueMarketIds).toEqual(new Set([111, 222]))
+	})
+
+	it('excludes non-player markets', () => {
+		const props: PropDto[] = EXCLUDED_PROP_MARKETS.map((market_key, i) =>
+			buildProp({ market_key, market_id: i }),
+		)
+		// ...plus one valid player prop that must survive the filter
+		props.push(buildProp({ market_key: 'player_assists', market_id: 999 }))
+
+		const result = convertFlatPropsToCachedProps(props)
+
+		expect(result).toHaveLength(2)
+		expect(result.every((o) => o.market_key === 'player_assists')).toBe(
+			true,
+		)
+		expect(result.every((o) => o.market_id === 999)).toBe(true)
+	})
+
+	it('skips props missing outcomes or event_context', () => {
+		const noOutcomes: PropDto = { ...buildProp(), outcomes: undefined }
+		const noContext: PropDto = { ...buildProp(), event_context: undefined }
+
+		expect(convertFlatPropsToCachedProps([noOutcomes, noContext])).toEqual(
+			[],
+		)
+	})
+
+	it('produces outcomes whose shape matches the CachedProp contract', () => {
+		const [outcome] = convertFlatPropsToCachedProps([buildProp()])
+
+		expect(outcome).toEqual({
+			outcome_uuid: 'uuid-over',
+			market_id: 12345,
+			description: 'LeBron James',
+			market_key: 'player_points',
+			point: 25.5,
+			home_team: 'Lakers',
+			away_team: 'Warriors',
+			commence_time: '2999-01-27T20:00:00Z',
+		})
+	})
+})

--- a/src/utils/props/prop-conversion.ts
+++ b/src/utils/props/prop-conversion.ts
@@ -59,7 +59,9 @@ export function convertFlatPropsToCachedProps(props: PropDto[]): CachedProp[] {
 				market_id: prop.market_id ?? null,
 				description: outcome.description || 'Unknown',
 				market_key: prop.market_key,
-				point: outcome.point || null,
+				// ?? (not ||) so a legitimate line of 0 is preserved, not
+				// coerced to null (CachedPropSchema distinguishes 0 from null).
+				point: outcome.point ?? null,
 				home_team: prop.event_context.home_team,
 				away_team: prop.event_context.away_team,
 				commence_time: prop.event_context.commence_time,

--- a/src/utils/props/prop-conversion.ts
+++ b/src/utils/props/prop-conversion.ts
@@ -1,0 +1,71 @@
+// ============================================================================
+// Prop Conversion - Pure transforms from Khronos PropDto to CachedProp
+// ============================================================================
+
+import type { PropDto } from '@pluto-khronos/api-client'
+import type { CachedProp } from './PropCacheService.js'
+
+/**
+ * Market keys that are NOT player props and are excluded from the prop cache.
+ *
+ * Exported so every layer (cron, filtering, presentation) shares one exclusion
+ * contract instead of redefining the list locally.
+ */
+export const EXCLUDED_PROP_MARKETS: readonly string[] = [
+	'h2h',
+	'spreads',
+	'totals',
+	'team_totals',
+	'player_anytime_td',
+]
+
+/**
+ * Flatten Khronos `PropDto[]` into individual `CachedProp` outcomes.
+ *
+ * Pure function — no Discord, cache, or logging dependencies — so it is unit
+ * testable in isolation.
+ *
+ * Behaviour:
+ * - Skips non-player markets (see {@link EXCLUDED_PROP_MARKETS}).
+ * - Skips props missing `outcomes` or `event_context`.
+ * - Populates `market_id` from the source prop. `market_id` groups the
+ *   Over/Under outcomes of a prop into a pair, which is what
+ *   `PropsCacheService.getActiveProps` deduplicates on; it is `null` only when
+ *   the source prop has no `market_id` (legacy data). Previously this field was
+ *   omitted here, so cron-sourced outcomes were written to the prop cache with
+ *   a shape that violates `CachedPropSchema` and cannot be deduplicated by
+ *   `market_id` (see GitHub #491).
+ */
+export function convertFlatPropsToCachedProps(props: PropDto[]): CachedProp[] {
+	const cached: CachedProp[] = []
+
+	for (const prop of props) {
+		// Skip non-player props
+		if (EXCLUDED_PROP_MARKETS.includes(prop.market_key)) {
+			continue
+		}
+
+		// Skip if missing required nested fields
+		if (!prop.outcomes || !prop.event_context) {
+			continue
+		}
+
+		// Flatten each outcome into a separate cached outcome
+		for (const outcome of prop.outcomes) {
+			cached.push({
+				outcome_uuid: outcome.outcome_uuid,
+				// Source market_id from the prop so Over/Under outcomes of the
+				// same prop share it and dedup-by-market_id works.
+				market_id: prop.market_id ?? null,
+				description: outcome.description || 'Unknown',
+				market_key: prop.market_key,
+				point: outcome.point || null,
+				home_team: prop.event_context.home_team,
+				away_team: prop.event_context.away_team,
+				commence_time: prop.event_context.commence_time,
+			})
+		}
+	}
+
+	return cached
+}


### PR DESCRIPTION
## What & why

Fixes a data-contract drift in the cron prop-caching path. `PropsCronService.convertFlatPropsToCachedProps()` built `CachedProp` objects **without `market_id`**, even though `market_id` is required by `CachedProp` / `CachedPropSchema` (`z.number().nullable()`). Cron-sourced outcomes were written to the `props:all` cache with a shape that violates the schema and can't be deduplicated by `market_id` (the field that groups an Over/Under pair).

## Changes

- **Extract** the conversion into a pure, dependency-free module `src/utils/props/prop-conversion.ts` (no Discord/cache/logging imports) so it's unit-testable in isolation and reusable. `PropsCronService` now delegates to it.
- **Populate `market_id`** from the source prop (`prop.market_id ?? null`), mirroring how `ActivePropsService` already does it for the `props:active` path.
- **Export `EXCLUDED_PROP_MARKETS`** so the market-exclusion contract is shared instead of redefined locally.
- **Tests** (`prop-conversion.test.ts`): market_id population, `null` fallback for legacy props, excluded-market filtering, missing-field guards, and full `CachedProp` shape.

## Accuracy / scope notes

The issue framed the impact as "breaks dedup in `getActiveProps()`". In the current code that's imprecise: `getActiveProps()` reads `props:active`, which `ActivePropsService` already populates with `market_id`. The cron path feeds `props:all` via `cacheAllProps()`, which (a) writes **without** Zod validation and (b) has **no caller** of `getAllProps()` in `src/` today — so the malformed shape did not throw at runtime. The fix still aligns cron output with the schema contract and makes cron-sourced data correctly groupable by `market_id`.

Left **out of scope** (flagged for a separate pass): `PropsCacheCronJob.refreshPropsCache()` has the same omission and additionally reads non-existent flat fields via `prop: any`; it has no callers (dead code).

## Verification

- `tsc --noEmit` — 0 errors (full project)
- `vitest run` — 8 files / 58 tests pass (6 new)
- `biome check` — clean

Closes #491

https://claude.ai/code/session_01GVHfTn8TYyiTycCsYaLRhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVHfTn8TYyiTycCsYaLRhX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated prop conversion logic into a shared utility module for better code reusability.

* **Tests**
  * Added comprehensive test suite for prop conversion functionality, including edge cases and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->