### PR TITLE
feat(predictions): consolidate prediction command group

### DIFF
--- a/src/commands/predictions/__tests__/predictions.test.ts
+++ b/src/commands/predictions/__tests__/predictions.test.ts
@@ -127,8 +127,8 @@ describe('/predictions', () => {
 			total_users: 1,
 		})
 		mockGetActivePredictionsForUser.mockResolvedValue([
-			{ id: 'pending-1' },
-			{ id: 'pending-2' },
+			{ id: 'pending-1', guild_id: 'guild-1' },
+			{ id: 'pending-2', guild_id: 'guild-1' },
 		])
 
 		const interaction = makeInteraction()
@@ -163,6 +163,20 @@ describe('/predictions', () => {
 	it('returns friendly empty copy when server stats and pending data are empty', async () => {
 		mockGetLeaderboard.mockResolvedValue({ entries: [], total_users: 0 })
 		mockGetActivePredictionsForUser.mockResolvedValue([])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			content: "You haven't made any predictions yet.",
+		})
+	})
+
+	it('does not count pending predictions from another guild', async () => {
+		mockGetLeaderboard.mockResolvedValue({ entries: [], total_users: 0 })
+		mockGetActivePredictionsForUser.mockResolvedValue([
+			{ id: 'pending-other-guild', guild_id: 'guild-2' },
+		])
 
 		const interaction = makeInteraction()
 		await command.handleStats(interaction as never)

--- a/src/commands/predictions/__tests__/predictions.test.ts
+++ b/src/commands/predictions/__tests__/predictions.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetLeaderboard = vi.fn()
+const mockGetActivePredictionsForUser = vi.fn()
+
+vi.mock(
+	'../../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js',
+	() => ({
+		default: vi.fn().mockImplementation(function () {
+			return { getLeaderboard: mockGetLeaderboard }
+		}),
+	}),
+)
+
+vi.mock(
+	'../../../utils/api/Khronos/prediction/predictionApiWrapper.js',
+	() => ({
+		default: vi.fn().mockImplementation(function () {
+			return {
+				getActivePredictionsForUser: mockGetActivePredictionsForUser,
+			}
+		}),
+	}),
+)
+
+vi.mock('../../../utils/api/Khronos/props/props-api-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getPropByUuid: vi.fn() }
+	}),
+}))
+
+vi.mock('../../../utils/common/TeamInfo.js', () => ({
+	default: {
+		resolveTeamIdentifier: vi.fn().mockResolvedValue({
+			away_team: 'AWY',
+			home_team: 'HME',
+		}),
+	},
+}))
+
+vi.mock('../../../utils/bot_res/ClientTools.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { resolveMember: vi.fn() }
+	}),
+}))
+
+vi.mock('@sapphire/discord.js-utilities', () => ({
+	PaginatedMessageEmbedFields: vi.fn().mockImplementation(function () {
+		return {
+			setItems: vi.fn().mockReturnThis(),
+			setItemsPerPage: vi.fn().mockReturnThis(),
+			make: vi.fn().mockReturnValue({ run: vi.fn() }),
+		}
+	}),
+}))
+
+const { SlashCommandBuilder } = await import('discord.js')
+const { UserCommand } = await import('../predictions.js')
+
+function makeInteraction() {
+	return {
+		guildId: 'guild-1',
+		user: { id: 'user-1', username: 'Fenix' },
+		deferReply: vi.fn().mockResolvedValue(undefined),
+		editReply: vi.fn().mockResolvedValue(undefined),
+		options: {
+			getUser: vi.fn().mockReturnValue(null),
+			getString: vi.fn().mockReturnValue(null),
+		},
+	}
+}
+
+describe('/predictions', () => {
+	let command: InstanceType<typeof UserCommand>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		command = Object.create(UserCommand.prototype) as InstanceType<
+			typeof UserCommand
+		>
+		Object.defineProperty(command, 'container', {
+			configurable: true,
+			value: { logger: { error: vi.fn(), warn: vi.fn() } },
+		})
+	})
+
+	it('registers guild-only history, stats, and leaderboard subcommands', () => {
+		const registry = {
+			registerChatInputCommand: vi.fn(),
+		}
+		Object.defineProperties(command, {
+			name: { configurable: true, value: 'predictions' },
+			description: {
+				configurable: true,
+				value: 'View prediction history, stats, and leaderboard',
+			},
+		})
+
+		command.registerApplicationCommands(registry as never)
+
+		expect(registry.registerChatInputCommand).toHaveBeenCalledTimes(1)
+		const [builder, options] =
+			registry.registerChatInputCommand.mock.calls[0]
+		const json = builder(new SlashCommandBuilder()).toJSON()
+
+		expect(json.name).toBe('predictions')
+		expect(json.contexts).toEqual([0])
+		expect(json.options?.map((option) => option.name)).toEqual([
+			'history',
+			'stats',
+			'leaderboard',
+		])
+		expect(options.idHints).toEqual(['1298280482123026537'])
+	})
+
+	it('renders server-calculated stats and pending count', async () => {
+		mockGetLeaderboard.mockResolvedValue({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+				},
+			],
+			total_users: 1,
+		})
+		mockGetActivePredictionsForUser.mockResolvedValue([
+			{ id: 'pending-1' },
+			{ id: 'pending-2' },
+		])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(mockGetLeaderboard).toHaveBeenCalledWith({ guildId: 'guild-1' })
+		expect(mockGetActivePredictionsForUser).toHaveBeenCalledWith({
+			userId: 'user-1',
+		})
+		const [{ embeds }] = interaction.editReply.mock.calls.find(
+			([payload]) => payload.embeds,
+		) as [{ embeds: Array<{ toJSON: () => unknown }> }]
+		const embed = embeds[0].toJSON() as {
+			title?: string
+			description?: string
+			fields?: unknown[]
+		}
+		expect(embed.title).toBe('📊 Prediction Statistics')
+		expect(embed.description).toContain('Server stats')
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'Total Predictions',
+					value: '`12`',
+				}),
+				expect.objectContaining({ name: 'Win Rate', value: '`75.0%`' }),
+				expect.objectContaining({ name: '⏳ Pending', value: '`2`' }),
+			]),
+		)
+	})
+
+	it('returns friendly empty copy when server stats and pending data are empty', async () => {
+		mockGetLeaderboard.mockResolvedValue({ entries: [], total_users: 0 })
+		mockGetActivePredictionsForUser.mockResolvedValue([])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			content: "You haven't made any predictions yet.",
+		})
+	})
+})

--- a/src/commands/predictions/history.ts
+++ b/src/commands/predictions/history.ts
@@ -1,66 +1,22 @@
-import {
-	type AllUserPredictionsDto,
-	GetAllPredictionsFilteredStatusEnum,
-} from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
-import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
 import { Command } from '@sapphire/framework'
-import type { User } from 'discord.js'
-import { EmbedBuilder, InteractionContextType } from 'discord.js'
-import _ from 'lodash'
-import embedColors from '../../lib/colorsConfig.js'
-import { MarketKeyAbbreviations } from '../../utils/api/common/interfaces/market-abbreviations.js'
-import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
-import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
-import { DateManager } from '../../utils/common/DateManager.js'
-import TeamInfo from '../../utils/common/TeamInfo.js'
+import { InteractionContextType } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
+/**
+ * @deprecated Use /predictions history. Kept for one release as a pointer.
+ */
 @ApplyOptions<Command.Options>({
-	description: 'View your prediction history',
+	description: 'View your prediction history (legacy alias)',
 })
 export class UserCommand extends Command {
-	private readonly dateManager = new DateManager()
-
-	public constructor(context: Command.Context, options: Command.Options) {
-		super(context, {
-			...options,
-			description: 'View your prediction history.',
-		})
-	}
-
 	public override registerApplicationCommands(registry: Command.Registry) {
 		registry.registerChatInputCommand(
 			(builder) =>
-				builder //
+				builder
 					.setName(this.name)
 					.setDescription(this.description)
-					.setContexts(InteractionContextType.Guild)
-					.addUserOption((option) =>
-						option
-							.setName('user')
-							.setDescription(
-								'[Optional] The user to view history for (default: yourself)',
-							)
-							.setRequired(false),
-					)
-					.addStringOption((option) =>
-						option
-							.setName('status')
-							.setDescription(
-								'[Optional] Filter predictions by status',
-							)
-							.setRequired(false)
-							.addChoices(
-								{
-									name: 'Pending',
-									value: GetAllPredictionsFilteredStatusEnum.Pending,
-								},
-								{
-									name: 'Completed',
-									value: GetAllPredictionsFilteredStatusEnum.Completed,
-								},
-							),
-					),
+					.setContexts(InteractionContextType.Guild),
 			{ idHints: ['1298280482123026536'] },
 		)
 	}
@@ -68,166 +24,9 @@ export class UserCommand extends Command {
 	public override async chatInputRun(
 		interaction: Command.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const user = interaction.options.getUser('user') || interaction.user
-		const status = interaction.options.getString(
-			'status',
-		) as GetAllPredictionsFilteredStatusEnum | null
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions = await (status
-				? predictionApiWrapper.getPredictionsFiltered({
-						userId: user.id,
-						status,
-					})
-				: predictionApiWrapper.getPredictionsForUser({
-						userId: user.id,
-					}))
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: 'No predictions found for the specified criteria.',
-				})
-			}
-			const descStr = status ? `Filtered by: \`${status}\`` : null
-			const templateEmbed = new EmbedBuilder()
-				.setTitle(`Prediction History | ${user.username}`)
-				.setDescription(descStr)
-				.setColor(embedColors.PlutoBlue)
-
-			const propsApiWrapper = new PropsApiWrapper()
-			let hadFormattingFailures = false
-			const formattedPredictions = (
-				await Promise.allSettled(
-					usersPredictions.map((prediction) =>
-						this.createPredictionField(prediction, propsApiWrapper),
-					),
-				)
-			).flatMap((result, index) => {
-				if (result.status === 'fulfilled') {
-					return result.value ? [result.value] : []
-				}
-				hadFormattingFailures = true
-				const prediction = usersPredictions[index]
-				this.container.logger.error(
-					`Failed to create prediction field for prediction ${prediction?.id || 'unknown'} (user: ${user.id})`,
-					result.reason,
-				)
-				return []
-			})
-
-			if (formattedPredictions.length === 0) {
-				const baseDescription = descStr ? `${descStr}\n\n` : ''
-				const message = hadFormattingFailures
-					? 'We were unable to load details for your predictions. Please try again later.'
-					: 'No prediction history found. Your predictions will appear here once you make them.'
-
-				templateEmbed.setDescription(baseDescription + message)
-				return interaction.editReply({ embeds: [templateEmbed] })
-			}
-
-			const paginatedMsg = new PaginatedMessageEmbedFields({
-				template: { embeds: [templateEmbed] },
-			})
-				.setItems(formattedPredictions)
-				.setItemsPerPage(10)
-				.make()
-
-			await paginatedMsg.run(interaction)
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content:
-					'An error occurred while fetching the prediction history.',
-			})
-		}
-	}
-
-	private async createPredictionField(
-		prediction: AllUserPredictionsDto,
-		propsApiWrapper: PropsApiWrapper,
-	): Promise<{ name: string; value: string; inline: boolean } | null> {
-		const outcomeEmoji = this.getOutcomeEmoji(prediction)
-		const parsedMatchString = await this.parseMatchString(
-			prediction.match_string,
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions history',
 		)
-		const parsedChoice = this.parseChoice(prediction.choice)
-		const prop = await propsApiWrapper.getPropByUuid(
-			prediction.outcome_uuid,
-		)
-		const outcome = prop.outcomes.find(
-			(o) => o.outcome_uuid === prediction.outcome_uuid,
-		)
-		if (!outcome) {
-			this.container.logger.warn(
-				`Missing outcome for prediction ${prediction.id} (market_key: ${prop.market_key}, outcome_uuid: ${prediction.outcome_uuid})`,
-			)
-			return null
-		}
-		const { market_key } = prop
-		const point = outcome.point ?? null
-		let parsedMarketKey = MarketKeyAbbreviations[market_key] || market_key
-		parsedMarketKey = _.startCase(parsedMarketKey)
-		const outcomeStr = (emoji: string) => {
-			if (emoji === '⏳') {
-				return 'Pending ⏳'
-			}
-			if (emoji === '✅') {
-				return 'Correct ✅'
-			}
-			if (emoji === '❌') {
-				return 'Incorrect ❌'
-			}
-			return emoji
-		}
-		const date = this.dateManager.toMMDDYYYY(
-			prop.event_context.commence_time,
-		)
-		const pointText = point ?? ''
-		const formattedChoice =
-			pointText === ''
-				? `\`${parsedChoice}\``
-				: `\`${parsedChoice} ${pointText}\``
-		let value = `**Date**: ${date}\n**Status**: ${outcomeStr(outcomeEmoji)}\n**Choice**: ${formattedChoice}\n**Market**: ${parsedMarketKey} `
-
-		if (prediction.description && prediction.description.trim() !== '') {
-			value += `\n**Player:** ${prediction.description}`
-		}
-
-		return {
-			name: `${parsedMatchString}`,
-			value: value,
-			inline: false,
-		}
-	}
-
-	private getOutcomeEmoji(prediction: AllUserPredictionsDto): string {
-		if (
-			prediction.status !== GetAllPredictionsFilteredStatusEnum.Completed
-		) {
-			return '⏳'
-		}
-		if (prediction.is_correct === null) {
-			return '⏳'
-		}
-		return prediction?.is_correct ? '✅' : '❌'
-	}
-
-	private async parseMatchString(matchString: string) {
-		const [awayTeam, homeTeam] = matchString.split(' vs. ')
-		if (!awayTeam || !homeTeam) {
-			return matchString
-		}
-		const result = await TeamInfo.resolveTeamIdentifier({
-			away_team: awayTeam,
-			home_team: homeTeam,
-		})
-
-		return `${result.away_team} vs. ${result.home_team}`
-	}
-	private parseChoice(choice: string) {
-		return choice.charAt(0).toUpperCase() + choice.slice(1).toLowerCase()
 	}
 }

--- a/src/commands/predictions/history.ts
+++ b/src/commands/predictions/history.ts
@@ -11,13 +11,12 @@ import { sendPredictionCommandDeprecation } from '../../utils/commands/predictio
 })
 export class UserCommand extends Command {
 	public override registerApplicationCommands(registry: Command.Registry) {
-		registry.registerChatInputCommand(
-			(builder) =>
-				builder
-					.setName(this.name)
-					.setDescription(this.description)
-					.setContexts(InteractionContextType.Guild),
-			{ idHints: ['1298280482123026536'] },
+		// No id hint: the former history hint was shared with /prediction.
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName(this.name)
+				.setDescription(this.description)
+				.setContexts(InteractionContextType.Guild),
 		)
 	}
 

--- a/src/commands/predictions/prediction-leaderboard.ts
+++ b/src/commands/predictions/prediction-leaderboard.ts
@@ -1,16 +1,13 @@
-import type { SimpleLeaderboardResponseDto } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
 import { Command } from '@sapphire/framework'
-import { EmbedBuilder, InteractionContextType, type Message } from 'discord.js'
-import _ from 'lodash'
-import embedColors from '../../lib/colorsConfig.js'
-import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
-import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
-import ClientTools from '../../utils/bot_res/ClientTools.js'
-import Pagination from '../../utils/embeds/pagination.js'
+import { InteractionContextType } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
+/**
+ * @deprecated Use /predictions leaderboard. Kept for one release as a pointer.
+ */
 @ApplyOptions<Command.Options>({
-	description: 'View the leaderboard for accuracy challenge',
+	description: 'View the prediction leaderboard (legacy alias)',
 })
 export class UserCommand extends Command {
 	public override registerApplicationCommands(registry: Command.Registry) {
@@ -20,255 +17,16 @@ export class UserCommand extends Command {
 					.setName('accuracy_leaderboard')
 					.setDescription(this.description)
 					.setContexts([InteractionContextType.Guild]),
-			{
-				idHints: ['1297933995123933225'],
-			},
+			{ idHints: ['1297933995123933225'] },
 		)
 	}
 
 	public override async chatInputRun(
 		interaction: Command.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply()
-
-		try {
-			const guildId = interaction.guildId
-
-			await interaction.editReply({
-				content: 'Fetching leaderboard data...',
-			})
-
-			const leaderboardWrapper = new LeaderboardWrapper()
-			const leaderboard = await leaderboardWrapper.getLeaderboard({
-				guildId,
-			})
-
-			if (!leaderboard || _.isEmpty(leaderboard.entries)) {
-				return interaction.editReply({
-					content: 'No leaderboard data found.',
-				})
-			}
-
-			await this.container.logger.info({
-				leaderboardEntries: leaderboard.entries.length,
-			})
-
-			await interaction.editReply({
-				content: 'Processing leaderboard data...',
-			})
-
-			const thumbnail = interaction.guild?.iconURL({ extension: 'png' })
-			const parsedLeaderboard = this.parseLeaderboardData(leaderboard)
-
-			const embed = await this.createLeaderboardEmbed({
-				leaderboardData: parsedLeaderboard,
-				currentPage: 1,
-				metadata: { thumbnail },
-			})
-
-			const pagination = new Pagination()
-			const components = pagination.createPaginationButtons(
-				1,
-				Math.ceil(parsedLeaderboard.length / 20),
-			)
-
-			const reply = await interaction.editReply({
-				content: null,
-				embeds: [embed],
-				components,
-			})
-
-			await this.handlePagination(interaction, reply, parsedLeaderboard)
-		} catch (error) {
-			if (error instanceof EmptyDataException) {
-				return interaction.editReply({
-					content: error.message,
-				})
-			}
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching the leaderboard.',
-			})
-		}
-	}
-
-	private parseLeaderboardData(
-		leaderboardData: SimpleLeaderboardResponseDto,
-	): ParsedLeaderboardEntry[] {
-		if (!leaderboardData.entries || leaderboardData.entries.length === 0) {
-			return []
-		}
-
-		// Entries are already aggregated and sorted by the backend
-		// Calculate score using the formula: (correct * 10) + (incorrect * -2)
-		// Default values from ScoringService as per predictions/prediction-system.md
-		return leaderboardData.entries.map((entry, index) => {
-			const score =
-				entry.correct_predictions * LEADERBOARD_SCORING.CORRECT_POINTS +
-				entry.incorrect_predictions *
-					LEADERBOARD_SCORING.INCORRECT_PENALTY
-
-			return {
-				userId: entry.user_id,
-				score,
-				correctPredictions: entry.correct_predictions,
-				incorrectPredictions: entry.incorrect_predictions,
-				position: index + 1,
-			}
-		})
-	}
-
-	async createLeaderboardEmbed(
-		params: CreateLeaderboardEmbedParams,
-	): Promise<EmbedBuilder> {
-		if (
-			!params.leaderboardData ||
-			params.leaderboardData.length === 0 ||
-			_.isEmpty(params.leaderboardData)
-		) {
-			throw new EmptyDataException('the leaderboard')
-		}
-
-		const currentPage = params.currentPage || 1
-		const startIndex = (currentPage - 1) * 20
-		const endIndex = startIndex + 20
-		const pageEntries = params.leaderboardData.slice(startIndex, endIndex)
-		const totalPages = Math.ceil(params.leaderboardData.length / 20)
-
-		// Process user data in parallel with proper error handling
-		const descriptionLines = await Promise.all(
-			pageEntries.map(async (entry) => {
-				try {
-					const member = await this.getMember(entry.userId)
-					const username = member ? member.username : entry.userId
-					const total =
-						entry.correctPredictions + entry.incorrectPredictions
-					return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
-				} catch (error) {
-					this.container.logger.error(
-						`Error processing user ${entry.userId}:`,
-						error,
-					)
-					return `${entry.position}. Unknown User - **\`${entry.score}\`** *(${entry.correctPredictions}/${entry.correctPredictions + entry.incorrectPredictions})*`
-				}
-			}),
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions leaderboard',
 		)
-
-		const embed = new EmbedBuilder()
-			.setTitle(
-				`Accuracy Leaderboard${params.title ? ` | ${params.title}` : ''}`,
-			)
-			.setColor(embedColors.PlutoBlue)
-			.setDescription(descriptionLines.join('\n'))
-			.setFooter({
-				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${params.leaderboardData.length}`,
-			})
-
-		if (params.metadata?.thumbnail) {
-			embed.setThumbnail(params.metadata.thumbnail)
-		}
-
-		return embed
-	}
-
-	private async getMember(userId: string) {
-		try {
-			return await new ClientTools(this.container).resolveMember(userId)
-		} catch (error) {
-			this.container.logger.error(
-				`Failed to resolve member ${userId}:`,
-				error,
-			)
-			return null
-		}
-	}
-
-	private async handlePagination(
-		interaction: Command.ChatInputCommandInteraction,
-		reply: Message,
-		leaderboard: ParsedLeaderboardEntry[],
-	) {
-		const totalPages = Math.ceil(leaderboard.length / 20)
-		let currentPage = 1
-
-		const collector = reply.createMessageComponentCollector({ time: 60000 })
-
-		collector.on('collect', async (i) => {
-			if (i.user.id !== interaction.user.id) {
-				await i.followUp({
-					content:
-						'Only the original user can interact with these buttons.',
-					ephemeral: true,
-				})
-				return
-			}
-
-			switch (i.customId) {
-				case 'first':
-					currentPage = 1
-					break
-				case 'previous':
-					currentPage = Math.max(1, currentPage - 1)
-					break
-				case 'next':
-					currentPage = Math.min(totalPages, currentPage + 1)
-					break
-				case 'last':
-					currentPage = totalPages
-					break
-			}
-
-			const newEmbed = await this.createLeaderboardEmbed({
-				leaderboardData: leaderboard,
-				currentPage,
-			})
-			const pagination = new Pagination()
-			const newComponents = pagination.createPaginationButtons(
-				currentPage,
-				totalPages,
-			)
-
-			await i.update({ embeds: [newEmbed], components: newComponents })
-		})
-
-		collector.on('end', async () => {
-			const pagination = new Pagination()
-			const disabledComponents = pagination
-				.createPaginationButtons(currentPage, totalPages)
-				.map((row) => {
-					for (const button of row.components) {
-						button.setDisabled(true)
-					}
-					return row
-				})
-
-			await reply.edit({ components: disabledComponents })
-		})
-	}
-	private validateOptions(interaction: Command.ChatInputCommandInteraction) {}
-}
-
-interface ParsedLeaderboardEntry {
-	position: number
-	userId: string
-	score: number
-	correctPredictions: number
-	incorrectPredictions: number
-}
-
-class CreateLeaderboardEmbedParams {
-	leaderboardData: ParsedLeaderboardEntry[]
-	currentPage?: number = 1
-	title?: string
-	metadata?: {
-		thumbnail?: string
-	}
-}
-
-class EmptyDataException extends Error {
-	constructor(message: string) {
-		super(message)
-		this.name = 'EmptyDataException'
-		this.message = `No data found for ${message}.`
 	}
 }

--- a/src/commands/predictions/prediction.ts
+++ b/src/commands/predictions/prediction.ts
@@ -1,26 +1,15 @@
-import type { AllUserPredictionsDto } from '@pluto-khronos/api-client'
-import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
-import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities'
 import { Subcommand } from '@sapphire/plugin-subcommands'
-import {
-	EmbedBuilder,
-	InteractionContextType,
-	PermissionFlagsBits,
-} from 'discord.js'
-import _ from 'lodash'
-import { teamResolver } from 'resolve-team'
-import embedColors from '../../lib/colorsConfig.js'
-import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
-import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
-import TeamInfo from '../../utils/common/TeamInfo.js'
+import { InteractionContextType, PermissionFlagsBits } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
 /**
- * User-facing prediction command for viewing personal prediction history and stats
+ * @deprecated Use /predictions history or /predictions stats. Kept for one
+ * release so existing command registrations have a clear migration path.
  */
 @ApplyOptions<Subcommand.Options>({
 	name: 'prediction',
-	description: 'View your predictions',
+	description: 'View your predictions (legacy alias)',
 	requiredClientPermissions: [
 		PermissionFlagsBits.SendMessages,
 		PermissionFlagsBits.EmbedLinks,
@@ -41,452 +30,36 @@ export class UserCommand extends Subcommand {
 					.addSubcommand((subcommand) =>
 						subcommand
 							.setName('history')
-							.setDescription('View your prediction history')
-							.addStringOption((option) =>
-								option
-									.setName('view')
-									.setDescription('Which predictions to view')
-									.setRequired(true)
-									.addChoices(
-										{
-											name: '⏳ Pending',
-											value: 'pending',
-										},
-										{
-											name: '✅ Completed',
-											value: 'completed',
-										},
-									),
+							.setDescription(
+								'Legacy alias for /predictions history',
 							),
 					)
 					.addSubcommand((subcommand) =>
 						subcommand
 							.setName('stats')
-							.setDescription('View your prediction statistics'),
+							.setDescription(
+								'Legacy alias for /predictions stats',
+							),
 					),
 			{ idHints: ['1298280482123026536'] },
 		)
 	}
 
-	/**
-	 * Handle /predictions history subcommand
-	 */
 	public async handleHistory(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const view = interaction.options.getString('view', true) as
-			| 'pending'
-			| 'completed'
-		const user = interaction.user
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions =
-				await predictionApiWrapper.getPredictionsForUser({
-					userId: user.id,
-				})
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: "You haven't made any predictions yet.",
-				})
-			}
-
-			switch (view) {
-				case 'pending':
-					return this.showPendingView(interaction, usersPredictions)
-				case 'completed':
-					return this.showCompletedView(interaction, usersPredictions)
-			}
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching your predictions.',
-			})
-		}
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions history',
+		)
 	}
 
-	/**
-	 * Handle /predictions stats subcommand
-	 */
 	public async handleStats(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const user = interaction.user
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions =
-				await predictionApiWrapper.getPredictionsForUser({
-					userId: user.id,
-				})
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: "You haven't made any predictions yet.",
-				})
-			}
-
-			// Calculate statistics
-			const totalPredictions = usersPredictions.length
-			const completedPredictions = usersPredictions.filter(
-				(p) =>
-					p.status === GetAllPredictionsFilteredStatusEnum.Completed,
-			)
-			const pendingPredictions = usersPredictions.filter(
-				(p) => p.status === GetAllPredictionsFilteredStatusEnum.Pending,
-			)
-
-			const correctPredictions = completedPredictions.filter(
-				(p) => p.is_correct === true,
-			)
-			const incorrectPredictions = completedPredictions.filter(
-				(p) => p.is_correct === false,
-			)
-
-			const winRate =
-				completedPredictions.length > 0
-					? (
-							(correctPredictions.length /
-								completedPredictions.length) *
-							100
-						).toFixed(1)
-					: '0.0'
-
-			const embed = new EmbedBuilder()
-				.setTitle('📊 Prediction Statistics')
-				.setColor(embedColors.PlutoBlue)
-				.setDescription(`Stats for ${user.username}`)
-				.addFields(
-					{
-						name: 'Total Predictions',
-						value: `\`${totalPredictions}\``,
-						inline: true,
-					},
-					{
-						name: 'Win Rate',
-						value: `\`${winRate}%\``,
-						inline: true,
-					},
-					{ name: '\u200B', value: '\u200B', inline: true },
-					{
-						name: '✅ Correct',
-						value: `\`${correctPredictions.length}\``,
-						inline: true,
-					},
-					{
-						name: '❌ Incorrect',
-						value: `\`${incorrectPredictions.length}\``,
-						inline: true,
-					},
-					{
-						name: '⏳ Pending',
-						value: `\`${pendingPredictions.length}\``,
-						inline: true,
-					},
-				)
-				.setTimestamp()
-
-			return interaction.editReply({ embeds: [embed] })
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching your statistics.',
-			})
-		}
-	}
-
-	/**
-	 * Show pending predictions view with detailed format
-	 */
-	private async showPendingView(
-		interaction: Subcommand.ChatInputCommandInteraction,
-		predictions: AllUserPredictionsDto[],
-	) {
-		const pending = predictions.filter(
-			(p) => p.status === GetAllPredictionsFilteredStatusEnum.Pending,
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions stats',
 		)
-
-		if (pending.length === 0) {
-			return interaction.editReply({
-				content: 'You have no pending predictions.',
-			})
-		}
-
-		type FormattedPrediction = {
-			formattedText: string
-		}
-
-		const formattedPredictions = await Promise.all(
-			pending.map(async (p): Promise<FormattedPrediction> => {
-				const outcome = await this.getOutcomeDetails(p.outcome_uuid)
-				const formattedText = await this.formatPredictionCompact(
-					p,
-					outcome,
-					null,
-				)
-
-				return {
-					formattedText,
-				}
-			}),
-		)
-
-		const templateEmbed = new EmbedBuilder()
-			.setTitle('⏳ Your Pending Predictions')
-			.setDescription(
-				`You have ${pending.length} active prediction${
-					pending.length !== 1 ? 's' : ''
-				}`,
-			)
-			.setColor(embedColors.PlutoYellow)
-
-		const paginatedMsg =
-			new PaginatedFieldMessageEmbed<FormattedPrediction>()
-				.setTitleField('\u200B')
-				.setTemplate(templateEmbed)
-				.setItems(formattedPredictions)
-				.setItemsPerPage(5)
-				.formatItems((item) => item.formattedText)
-				.make()
-
-		return paginatedMsg.run(interaction)
-	}
-
-	/**
-	 * Show completed predictions view with compact format
-	 */
-	private async showCompletedView(
-		interaction: Subcommand.ChatInputCommandInteraction,
-		predictions: AllUserPredictionsDto[],
-	) {
-		const completed = predictions.filter(
-			(p) => p.status !== GetAllPredictionsFilteredStatusEnum.Pending,
-		)
-
-		if (completed.length === 0) {
-			return interaction.editReply({
-				content: 'You have no completed predictions yet.',
-			})
-		}
-
-		const correct = completed.filter(
-			(p) =>
-				p.status === GetAllPredictionsFilteredStatusEnum.Completed &&
-				p.is_correct === true,
-		).length
-		const incorrect = completed.length - correct
-
-		type FormattedCompletedPrediction = {
-			formattedText: string
-		}
-
-		const formattedPredictions = await Promise.all(
-			completed.map(async (p): Promise<FormattedCompletedPrediction> => {
-				// Determine if prediction is correct (only for Completed status)
-				let isCorrect: boolean | null = null
-				if (
-					p.status === GetAllPredictionsFilteredStatusEnum.Completed
-				) {
-					isCorrect = p.is_correct === true
-				}
-				const outcome = await this.getOutcomeDetails(p.outcome_uuid)
-				const formattedText = await this.formatPredictionCompact(
-					p,
-					outcome,
-					isCorrect,
-				)
-
-				return {
-					formattedText,
-				}
-			}),
-		)
-
-		const templateEmbed = new EmbedBuilder()
-			.setTitle('📊 Your Completed Predictions')
-			.setDescription(`${correct} correct • ${incorrect} incorrect`)
-			.setColor(embedColors.PlutoBlue)
-
-		const paginatedMsg =
-			new PaginatedFieldMessageEmbed<FormattedCompletedPrediction>()
-				.setTitleField('\u200B')
-				.setTemplate(templateEmbed)
-				.setItems(formattedPredictions)
-				.setItemsPerPage(8)
-				.formatItems((item) => item.formattedText)
-				.make()
-
-		return paginatedMsg.run(interaction)
-	}
-
-	/**
-	 * Get outcome details from prop API
-	 */
-	private async getOutcomeDetails(outcomeUuid: string): Promise<{
-		name: string
-		description?: string
-		point: number
-		market_key: string
-		event_context: {
-			home_team: string
-			away_team: string
-		}
-	} | null> {
-		try {
-			const propApiWrapper = new PropsApiWrapper()
-			const prop = await propApiWrapper.getPropByUuid(outcomeUuid)
-
-			const outcome = prop.outcomes.find(
-				(o) => o.outcome_uuid === outcomeUuid,
-			)
-
-			if (!outcome) return null
-
-			return {
-				name: outcome.name,
-				description: outcome.description,
-				point: outcome.point,
-				market_key: prop.market_key,
-				event_context: prop.event_context,
-			}
-		} catch (error) {
-			this.container.logger.error(
-				'Failed to fetch outcome details:',
-				error,
-			)
-			return null
-		}
-	}
-
-	/**
-	 * Formats a prediction choice with point and market information
-	 */
-	private formatPredictionChoice(
-		choice: string,
-		point: number | undefined,
-		marketKey: string,
-	): string {
-		const upperChoice = choice.toUpperCase()
-		const marketName = _.startCase(marketKey.replace('player_', ''))
-
-		if (point !== null && point !== undefined) {
-			return `${upperChoice} ${point} ${marketName}`
-		}
-
-		return `${upperChoice} ${marketName}`
-	}
-
-	/**
-	 * Format prediction in compact view format
-	 * Player format: **✅ Player Name** (ABBREV vs. ABBREV)\nProp Type • **PICK Line**\n*<t:TIMESTAMP:d>*
-	 * Team format: **✅ Team Name**\nProp Type • **PICK Line**\n*<t:TIMESTAMP:d>*
-	 */
-	private async formatPredictionCompact(
-		prediction: AllUserPredictionsDto,
-		outcome: {
-			name: string
-			description?: string
-			point: number
-			market_key: string
-			event_context: {
-				home_team: string
-				away_team: string
-			}
-		} | null,
-		isCorrect: boolean | null,
-	): Promise<string> {
-		if (!outcome) {
-			return 'Unknown prediction'
-		}
-
-		const result =
-			isCorrect === true ? '✅' : isCorrect === false ? '❌' : '⏳'
-		const isPlayerPrediction =
-			outcome.description && outcome.description.trim() !== ''
-
-		let entityLine: string
-		if (isPlayerPrediction) {
-			const playerName = outcome.description!
-			let matchupString: string
-			if (prediction.match_string) {
-				const [awayTeam, homeTeam] =
-					prediction.match_string.split(' vs. ')
-				const awayTeamData = await teamResolver.resolve(
-					awayTeam || outcome.event_context.away_team,
-					{ full: true },
-				)
-				const homeTeamData = await teamResolver.resolve(
-					homeTeam || outcome.event_context.home_team,
-					{ full: true },
-				)
-				const awayAbbrev =
-					awayTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(
-						awayTeam || outcome.event_context.away_team,
-					)
-				const homeAbbrev =
-					homeTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(
-						homeTeam || outcome.event_context.home_team,
-					)
-				matchupString = `${awayAbbrev} vs. ${homeAbbrev}`
-			} else {
-				const awayTeamData = await teamResolver.resolve(
-					outcome.event_context.away_team,
-					{ full: true },
-				)
-				const homeTeamData = await teamResolver.resolve(
-					outcome.event_context.home_team,
-					{ full: true },
-				)
-				const awayAbbrev =
-					awayTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(outcome.event_context.away_team)
-				const homeAbbrev =
-					homeTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(outcome.event_context.home_team)
-				matchupString = `${awayAbbrev} vs. ${homeAbbrev}`
-			}
-			entityLine = `**${result} ${playerName}** (${matchupString})`
-		} else {
-			const teamName = TeamInfo.getTeamShortName(outcome.name)
-			entityLine = `**${result} ${teamName}**`
-		}
-
-		const propType = _.startCase(
-			outcome.market_key.replace('player_', '').replace('_', ' '),
-		)
-
-		const pick = prediction.choice.toUpperCase()
-		const line =
-			outcome.point !== null && outcome.point !== undefined
-				? outcome.point.toString()
-				: ''
-
-		const timestamp = Math.floor(
-			new Date(prediction.created_at).getTime() / 1000,
-		)
-		const formattedDate = `<t:${timestamp}:d>`
-
-		const propLine = line
-			? `${propType} • **${pick} ${line}**`
-			: `${propType} • **${pick}**`
-
-		return `${entityLine}\n${propLine}\n*${formattedDate}*`
-	}
-
-	private async parseMatchString(matchString: string) {
-		const [awayTeam, homeTeam] = matchString.split(' vs. ')
-		const result = await TeamInfo.resolveTeamIdentifier({
-			away_team: awayTeam,
-			home_team: homeTeam,
-		})
-
-		return `${result.away_team} vs. ${result.home_team}`
 	}
 }

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -198,12 +198,15 @@ export class UserCommand extends Subcommand {
 		}
 
 		try {
-			const [leaderboard, pending] = await Promise.all([
+			const [leaderboard, allPending] = await Promise.all([
 				new LeaderboardWrapper().getLeaderboard({ guildId }),
 				new PredictionApiWrapper().getActivePredictionsForUser({
 					userId: interaction.user.id,
 				}),
 			])
+			const pending = allPending.filter(
+				(prediction) => prediction.guild_id === guildId,
+			)
 
 			const entry = leaderboard.entries.find(
 				(candidate) => candidate.user_id === interaction.user.id,

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -1,0 +1,478 @@
+import type {
+	AllUserPredictionsDto,
+	SimpleLeaderboardResponseDto,
+} from '@pluto-khronos/api-client'
+import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
+import { ApplyOptions } from '@sapphire/decorators'
+import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
+import { Subcommand } from '@sapphire/plugin-subcommands'
+import {
+	EmbedBuilder,
+	InteractionContextType,
+	type Message,
+	PermissionFlagsBits,
+} from 'discord.js'
+import _ from 'lodash'
+import { teamResolver } from 'resolve-team'
+import embedColors from '../../lib/colorsConfig.js'
+import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
+import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
+import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
+import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
+import ClientTools from '../../utils/bot_res/ClientTools.js'
+import { DateManager } from '../../utils/common/DateManager.js'
+import TeamInfo from '../../utils/common/TeamInfo.js'
+import Pagination from '../../utils/embeds/pagination.js'
+
+/**
+ * Reserved command id for the consolidated group. Legacy aliases retain their
+ * existing hints for one release and are removed with the alias pieces after
+ * the migration window.
+ */
+const PREDICTIONS_COMMAND_ID_HINTS = ['1298280482123026537']
+
+@ApplyOptions<Subcommand.Options>({
+	name: 'predictions',
+	description: 'View prediction history, stats, and leaderboard',
+	requiredClientPermissions: [
+		PermissionFlagsBits.SendMessages,
+		PermissionFlagsBits.EmbedLinks,
+	],
+	subcommands: [
+		{ name: 'history', chatInputRun: 'handleHistory' },
+		{ name: 'stats', chatInputRun: 'handleStats' },
+		{ name: 'leaderboard', chatInputRun: 'handleLeaderboard' },
+	],
+})
+export class UserCommand extends Subcommand {
+	private readonly dateManager = new DateManager()
+
+	public override registerApplicationCommands(registry: Subcommand.Registry) {
+		registry.registerChatInputCommand(
+			(builder) =>
+				builder
+					.setName(this.name)
+					.setDescription(this.description)
+					.setContexts(InteractionContextType.Guild)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('history')
+							.setDescription('View prediction history')
+							.addUserOption((option) =>
+								option
+									.setName('user')
+									.setDescription(
+										'[Optional] The user to view history for (default: yourself)',
+									)
+									.setRequired(false),
+							)
+							.addStringOption((option) =>
+								option
+									.setName('status')
+									.setDescription(
+										'Filter predictions by status',
+									)
+									.setRequired(false)
+									.addChoices(
+										{
+											name: 'Pending',
+											value: GetAllPredictionsFilteredStatusEnum.Pending,
+										},
+										{
+											name: 'Completed',
+											value: GetAllPredictionsFilteredStatusEnum.Completed,
+										},
+									),
+							),
+					)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('stats')
+							.setDescription(
+								'View server-calculated prediction statistics',
+							),
+					)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('leaderboard')
+							.setDescription(
+								'View the prediction accuracy leaderboard',
+							),
+					),
+			{ idHints: PREDICTIONS_COMMAND_ID_HINTS },
+		)
+	}
+
+	public async handleHistory(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ ephemeral: true })
+
+		const user = interaction.options.getUser('user') || interaction.user
+		const status = interaction.options.getString(
+			'status',
+		) as GetAllPredictionsFilteredStatusEnum | null
+
+		try {
+			const predictionApiWrapper = new PredictionApiWrapper()
+			const predictions = await (status
+				? predictionApiWrapper.getPredictionsFiltered({
+						userId: user.id,
+						status,
+					})
+				: predictionApiWrapper.getPredictionsForUser({
+						userId: user.id,
+					}))
+
+			if (!predictions || predictions.length === 0) {
+				return interaction.editReply({
+					content: 'No predictions found for the specified criteria.',
+				})
+			}
+
+			const description = status
+				? `Filtered by: \`${status}\``
+				: undefined
+			const templateEmbed = new EmbedBuilder()
+				.setTitle(`Prediction History | ${user.username}`)
+				.setColor(embedColors.PlutoBlue)
+			if (description) templateEmbed.setDescription(description)
+
+			const propsApiWrapper = new PropsApiWrapper()
+			let hadFormattingFailures = false
+			const formattedPredictions = (
+				await Promise.allSettled(
+					predictions.map((prediction) =>
+						this.createPredictionField(prediction, propsApiWrapper),
+					),
+				)
+			).flatMap((result, index) => {
+				if (result.status === 'fulfilled') {
+					return result.value ? [result.value] : []
+				}
+				hadFormattingFailures = true
+				this.container.logger.error(
+					`Failed to create prediction field for prediction ${predictions[index]?.id || 'unknown'} (user: ${user.id})`,
+					result.reason,
+				)
+				return []
+			})
+
+			if (formattedPredictions.length === 0) {
+				const message = hadFormattingFailures
+					? 'We were unable to load details for your predictions. Please try again later.'
+					: 'No prediction history found. Your predictions will appear here once you make them.'
+				templateEmbed.setDescription(
+					description ? `${description}\n\n${message}` : message,
+				)
+				return interaction.editReply({ embeds: [templateEmbed] })
+			}
+
+			const paginatedMessage = new PaginatedMessageEmbedFields({
+				template: { embeds: [templateEmbed] },
+			})
+				.setItems(formattedPredictions)
+				.setItemsPerPage(10)
+				.make()
+
+			return paginatedMessage.run(interaction)
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content:
+					'An error occurred while fetching the prediction history.',
+			})
+		}
+	}
+
+	public async handleStats(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ ephemeral: true })
+
+		const guildId = interaction.guildId
+		if (!guildId) {
+			return interaction.editReply({
+				content: 'This command can only be used in a guild.',
+			})
+		}
+
+		try {
+			const [leaderboard, pending] = await Promise.all([
+				new LeaderboardWrapper().getLeaderboard({ guildId }),
+				new PredictionApiWrapper().getActivePredictionsForUser({
+					userId: interaction.user.id,
+				}),
+			])
+
+			const entry = leaderboard.entries.find(
+				(candidate) => candidate.user_id === interaction.user.id,
+			)
+			if (!entry && pending.length === 0) {
+				return interaction.editReply({
+					content: "You haven't made any predictions yet.",
+				})
+			}
+
+			const totalPredictions = entry?.total_predictions ?? 0
+			const correctPredictions = entry?.correct_predictions ?? 0
+			const incorrectPredictions = entry?.incorrect_predictions ?? 0
+			const winRate = entry?.success_rate ?? 0
+			const embed = new EmbedBuilder()
+				.setTitle('📊 Prediction Statistics')
+				.setColor(embedColors.PlutoBlue)
+				.setDescription(`Server stats for ${interaction.user.username}`)
+				.addFields(
+					{
+						name: 'Total Predictions',
+						value: `\`${totalPredictions}\``,
+						inline: true,
+					},
+					{
+						name: 'Win Rate',
+						value: `\`${winRate.toFixed(1)}%\``,
+						inline: true,
+					},
+					{ name: '\u200B', value: '\u200B', inline: true },
+					{
+						name: '✅ Correct',
+						value: `\`${correctPredictions}\``,
+						inline: true,
+					},
+					{
+						name: '❌ Incorrect',
+						value: `\`${incorrectPredictions}\``,
+						inline: true,
+					},
+					{
+						name: '⏳ Pending',
+						value: `\`${pending.length}\``,
+						inline: true,
+					},
+				)
+				.setFooter({
+					text: 'Streaks will appear here after the engagement rollout.',
+				})
+				.setTimestamp()
+
+			return interaction.editReply({ embeds: [embed] })
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content: 'An error occurred while fetching your statistics.',
+			})
+		}
+	}
+
+	public async handleLeaderboard(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply()
+		const guildId = interaction.guildId
+		if (!guildId) {
+			return interaction.editReply({
+				content: 'This command can only be used in a guild.',
+			})
+		}
+
+		try {
+			const leaderboard = await new LeaderboardWrapper().getLeaderboard({
+				guildId,
+			})
+			if (!leaderboard.entries.length) {
+				return interaction.editReply({
+					content: 'No leaderboard data found.',
+				})
+			}
+
+			const parsed = this.parseLeaderboardData(leaderboard)
+			const totalPages = Math.ceil(parsed.length / 20)
+			const embed = await this.createLeaderboardEmbed(parsed, 1)
+			const pagination = new Pagination()
+			const reply = await interaction.editReply({
+				content: null,
+				embeds: [embed],
+				components: pagination.createPaginationButtons(1, totalPages),
+			})
+
+			await this.handlePagination(interaction, reply, parsed)
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content: 'An error occurred while fetching the leaderboard.',
+			})
+		}
+	}
+
+	private async createPredictionField(
+		prediction: AllUserPredictionsDto,
+		propsApiWrapper: PropsApiWrapper,
+	): Promise<{ name: string; value: string; inline: boolean } | null> {
+		const prop = await propsApiWrapper.getPropByUuid(
+			prediction.outcome_uuid,
+		)
+		const outcome = prop.outcomes.find(
+			(candidate) => candidate.outcome_uuid === prediction.outcome_uuid,
+		)
+		if (!outcome) return null
+
+		const parsedMatch = await this.parseMatchString(prediction.match_string)
+		const point = outcome.point ?? null
+		const choice =
+			prediction.choice.charAt(0).toUpperCase() +
+			prediction.choice.slice(1).toLowerCase()
+		const status =
+			prediction.status !== GetAllPredictionsFilteredStatusEnum.Completed
+				? 'Pending ⏳'
+				: prediction.is_correct === true
+					? 'Correct ✅'
+					: prediction.is_correct === false
+						? 'Incorrect ❌'
+						: 'Pending ⏳'
+		const market = _.startCase(prop.market_key.replace('player_', ''))
+		const date = this.dateManager.toMMDDYYYY(
+			prop.event_context.commence_time,
+		)
+		const value = [
+			`**Date**: ${date}`,
+			`**Status**: ${status}`,
+			`**Choice**: \`${choice}${point === null ? '' : ` ${point}`}\``,
+			`**Market**: ${market}`,
+			prediction.description?.trim()
+				? `**Player:** ${prediction.description}`
+				: null,
+		]
+			.filter((line): line is string => Boolean(line))
+			.join('\n')
+
+		return { name: parsedMatch, value, inline: false }
+	}
+
+	private async parseMatchString(matchString: string) {
+		const [awayTeam, homeTeam] = matchString.split(' vs. ')
+		if (!awayTeam || !homeTeam) return matchString
+		const result = await TeamInfo.resolveTeamIdentifier({
+			away_team: awayTeam,
+			home_team: homeTeam,
+		})
+		return `${result.away_team} vs. ${result.home_team}`
+	}
+
+	private parseLeaderboardData(
+		leaderboard: SimpleLeaderboardResponseDto,
+	): ParsedLeaderboardEntry[] {
+		return leaderboard.entries.map((entry, index) => ({
+			userId: entry.user_id,
+			position: index + 1,
+			score:
+				entry.correct_predictions * LEADERBOARD_SCORING.CORRECT_POINTS +
+				entry.incorrect_predictions *
+					LEADERBOARD_SCORING.INCORRECT_PENALTY,
+			correctPredictions: entry.correct_predictions,
+			incorrectPredictions: entry.incorrect_predictions,
+		}))
+	}
+
+	private async createLeaderboardEmbed(
+		leaderboard: ParsedLeaderboardEntry[],
+		currentPage: number,
+	): Promise<EmbedBuilder> {
+		const startIndex = (currentPage - 1) * 20
+		const pageEntries = leaderboard.slice(startIndex, startIndex + 20)
+		const totalPages = Math.ceil(leaderboard.length / 20)
+		const description = await Promise.all(
+			pageEntries.map(async (entry) => {
+				const member = await this.getMember(entry.userId)
+				const username = member?.username ?? entry.userId
+				const total =
+					entry.correctPredictions + entry.incorrectPredictions
+				return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
+			}),
+		)
+
+		return new EmbedBuilder()
+			.setTitle('Prediction Accuracy Leaderboard')
+			.setColor(embedColors.PlutoBlue)
+			.setDescription(description.join('\n'))
+			.setFooter({
+				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length}`,
+			})
+	}
+
+	private async getMember(userId: string) {
+		try {
+			return await new ClientTools(this.container).resolveMember(userId)
+		} catch (error) {
+			this.container.logger.error(
+				`Failed to resolve member ${userId}:`,
+				error,
+			)
+			return null
+		}
+	}
+
+	private async handlePagination(
+		interaction: Subcommand.ChatInputCommandInteraction,
+		reply: Message,
+		leaderboard: ParsedLeaderboardEntry[],
+	) {
+		const totalPages = Math.ceil(leaderboard.length / 20)
+		let currentPage = 1
+		const collector = reply.createMessageComponentCollector({ time: 60000 })
+
+		collector.on('collect', async (buttonInteraction) => {
+			if (buttonInteraction.user.id !== interaction.user.id) {
+				await buttonInteraction.followUp({
+					content:
+						'Only the original user can interact with these buttons.',
+					ephemeral: true,
+				})
+				return
+			}
+			switch (buttonInteraction.customId) {
+				case 'first':
+					currentPage = 1
+					break
+				case 'previous':
+					currentPage = Math.max(1, currentPage - 1)
+					break
+				case 'next':
+					currentPage = Math.min(totalPages, currentPage + 1)
+					break
+				case 'last':
+					currentPage = totalPages
+					break
+			}
+			const embed = await this.createLeaderboardEmbed(
+				leaderboard,
+				currentPage,
+			)
+			await buttonInteraction.update({
+				embeds: [embed],
+				components: new Pagination().createPaginationButtons(
+					currentPage,
+					totalPages,
+				),
+			})
+		})
+
+		collector.on('end', async () => {
+			const disabled = new Pagination()
+				.createPaginationButtons(currentPage, totalPages)
+				.map((row) => {
+					for (const button of row.components)
+						button.setDisabled(true)
+					return row
+				})
+			await reply.edit({ components: disabled })
+		})
+	}
+}
+
+interface ParsedLeaderboardEntry {
+	position: number
+	userId: string
+	score: number
+	correctPredictions: number
+	incorrectPredictions: number
+}

--- a/src/utils/commands/prediction-deprecation.ts
+++ b/src/utils/commands/prediction-deprecation.ts
@@ -1,0 +1,25 @@
+import { type ChatInputCommandInteraction, EmbedBuilder } from 'discord.js'
+import embedColors from '../../lib/colorsConfig.js'
+
+/**
+ * Keep legacy prediction commands discoverable while the consolidated command
+ * rolls out. The aliases can be removed after one release cycle.
+ */
+export async function sendPredictionCommandDeprecation(
+	interaction: ChatInputCommandInteraction,
+	replacement: string,
+) {
+	await interaction.deferReply({ ephemeral: true })
+
+	const embed = new EmbedBuilder()
+		.setColor(embedColors.info)
+		.setTitle('Prediction command moved')
+		.setDescription(
+			`This command is kept for one release as an alias. Use **${replacement}** instead.`,
+		)
+		.setFooter({
+			text: 'Legacy aliases will be removed after the migration window.',
+		})
+
+	return interaction.editReply({ embeds: [embed] })
+}


### PR DESCRIPTION
## Summary

Implements Linear TF-972 on the Pluto integration branch.

- Adds guild-only `/predictions` with `history`, `stats`, and `leaderboard` subcommands.
- Ports the richer history user/status filters and paginated embed output.
- Uses Khronos server leaderboard aggregates plus the pending-predictions endpoint for stats; leaves a streak placeholder for TF-975.
- Keeps `/prediction`, `/history`, and `/accuracy_leaderboard` as one-release ephemeral pointer aliases.
- Fixes user-facing command guidance to point at the canonical `/predictions` group.
- Adds a reserved id hint for the new group and documents the retirement window in source comments.
- Adds Vitest coverage for registration and server-backed stats behavior.

## Verification

- `pnpm test:run`: 9 files, 62 tests passed
- `pnpm typecheck`: passed
- `pnpm build`: passed (199 files compiled)
- Biome check on changed files: passed

Targets `dev/parlays-props`; no main/production changes.