### PR TITLE
feat(pluto): deliver parlay result notifications (TF-967)

### DIFF
--- a/src/utils/api/common/endpoints.ts
+++ b/src/utils/api/common/endpoints.ts
@@ -3,6 +3,7 @@ export class Endpoints {
 		bets: {},
 		notifiy: {
 			betResults: '/notifications/bets/results',
+			parlayResults: '/notifications/parlays/results',
 		},
 		channels: {
 			incoming: '/channels/incoming',

--- a/src/utils/api/routes/notifications/__tests__/notifications.controller.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.controller.parlay.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const processParlayResult = vi.fn()
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../notifications.service.js', () => ({
+	default: class MockNotificationService {
+		processParlayResult = processParlayResult
+	},
+}))
+
+import NotificationRouter from '../notifications.controller.js'
+
+const validPayload = {
+	kind: 'won',
+	parlay_id: '11111111-1111-4111-8111-111111111110',
+	user_id: 'user-1',
+	stake: 10,
+	combined_odds_american: 377,
+	payout: 47.7,
+	actual_payout: 47.7,
+	legs: [
+		{
+			id: 'leg-1',
+			event_id: 'event-1',
+			outcome_uuid: 'outcome-1',
+			market_key: 'h2h',
+			selection_display: 'Lakers',
+			odds_american: -110,
+			point: null,
+			commence_time: '2026-07-11T20:00:00.000Z',
+			result: 'won',
+		},
+		{
+			id: 'leg-2',
+			event_id: 'event-2',
+			outcome_uuid: 'outcome-2',
+			market_key: 'totals',
+			selection_display: 'Over 220.5',
+			odds_american: 105,
+			point: 220.5,
+			commence_time: '2026-07-11T20:00:00.000Z',
+			result: 'won',
+		},
+	],
+}
+
+function getParlayRoute() {
+	const route = NotificationRouter.stack.find(
+		(layer) => layer.path === '/notifications/parlays/results',
+	)
+	if (!route) throw new Error('Parlay notification route not registered')
+	return route.stack[0]
+}
+
+describe('POST /notifications/parlays/results', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns 200 after processing a valid payload', async () => {
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+		}
+
+		await getParlayRoute()(ctx as never, async () => undefined)
+
+		expect(processParlayResult).toHaveBeenCalledOnce()
+		expect(ctx.status).toBe(200)
+		expect(ctx.body).toEqual({ success: true })
+	})
+
+	it('returns 422 and skips delivery for malformed payloads', async () => {
+		const ctx = {
+			request: { body: { ...validPayload, parlay_id: 'not-a-uuid' } },
+			body: undefined as unknown,
+			status: 200,
+		}
+
+		await getParlayRoute()(ctx as never, async () => undefined)
+
+		expect(processParlayResult).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(422)
+		expect(ctx.body).toEqual({
+			success: false,
+			error: 'Invalid parlay notification data. Failed Zod validation.',
+		})
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
@@ -123,4 +123,45 @@ describe('NotificationService.processParlayResult', () => {
 			}),
 		)
 	})
+
+	it('falls back to payout and stake when nullable amounts are absent', async () => {
+		const payload = {
+			...makePayload('won'),
+			actual_payout: null,
+			payout: 47.7,
+		}
+		await new NotificationService().processParlayResult(payload)
+		const embed = (
+			mocks.send.mock.calls[0][0].embeds[0] as {
+				toJSON: () => { fields: Array<{ name: string; value: string }> }
+			}
+		).toJSON()
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: '🏆 Payout', value: '$47.70' }),
+			]),
+		)
+	})
+
+	it('keeps every leg field within Discord limits', async () => {
+		const payload = {
+			...makePayload('won'),
+			legs: Array.from({ length: 30 }, (_, index) => ({
+				...baseLeg,
+				id: `leg-${index}`,
+				selection_display: 'A'.repeat(1200),
+			})),
+		}
+		await new NotificationService().processParlayResult(payload)
+		const embed = (
+			mocks.send.mock.calls[0][0].embeds[0] as {
+				toJSON: () => { fields: Array<{ name: string; value: string }> }
+			}
+		).toJSON()
+		for (const field of embed.fields.filter((field) =>
+			field.name.startsWith('🧾 Legs'),
+		)) {
+			expect(field.value.length).toBeLessThanOrEqual(1024)
+		}
+	})
 })

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	send: vi.fn(),
+	fetch: vi.fn(),
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	container: {
+		client: {
+			users: {
+				fetch: mocks.fetch,
+			},
+		},
+	},
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: mocks.logger,
+}))
+
+import NotificationService from '../notifications.service.js'
+
+const baseLeg = {
+	id: '00000000-0000-0000-0000-000000000001',
+	event_id: 'event-1',
+	outcome_uuid: 'outcome-1',
+	market_key: 'h2h' as const,
+	selection_display: 'Lakers',
+	odds_american: 125,
+	point: null,
+	commence_time: new Date('2026-07-11T20:00:00.000Z'),
+	result: 'won' as const,
+}
+
+function makePayload(kind: 'won' | 'busted' | 'push_refunded') {
+	return {
+		kind,
+		parlay_id: '11111111-1111-4111-8111-111111111110',
+		user_id: 'user-1',
+		stake: 10,
+		combined_odds_american: 377,
+		payout: kind === 'won' ? 47.7 : 0,
+		actual_payout:
+			kind === 'won' ? 47.7 : kind === 'push_refunded' ? 10 : 0,
+		refund_amount: kind === 'push_refunded' ? 10 : undefined,
+		old_balance: kind === 'won' ? 100 : undefined,
+		new_balance: kind === 'won' ? 137.7 : undefined,
+		legs: [
+			baseLeg,
+			{
+				...baseLeg,
+				id: '00000000-0000-0000-0000-000000000002',
+				event_id: 'event-2',
+				selection_display: 'Celtics',
+				odds_american: -110,
+				result:
+					kind === 'busted'
+						? ('lost' as const)
+						: kind === 'push_refunded'
+							? ('push' as const)
+							: ('won' as const),
+			},
+		],
+	}
+}
+
+describe('NotificationService.processParlayResult', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.fetch.mockResolvedValue({ send: mocks.send })
+	})
+
+	it.each([
+		['won', '🎉 Parlay Won! 🎉', 0x57f287],
+		['busted', '❌ Parlay Busted', 0xff6961],
+		['push_refunded', '🔄 Parlay Refunded', 0xffa500],
+	] as const)('sends a distinct %s multi-leg embed', async (kind, title, color) => {
+		await new NotificationService().processParlayResult(makePayload(kind))
+
+		expect(mocks.fetch).toHaveBeenCalledWith('user-1')
+		expect(mocks.send).toHaveBeenCalledOnce()
+		const [message] = mocks.send.mock.calls[0] as [
+			{ embeds: Array<{ toJSON: () => Record<string, unknown> }> },
+		]
+		const embed = message.embeds[0].toJSON()
+		expect(embed.title).toBe(title)
+		expect(embed.color).toBe(color)
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: '🧾 Legs' }),
+				expect.objectContaining({
+					name: '📈 Combined Odds',
+					value: '+377',
+				}),
+			]),
+		)
+		const legsField = (
+			embed.fields as Array<{ name: string; value: string }>
+		).find((field) => field.name === '🧾 Legs')
+		expect(legsField?.value).toContain('+125')
+		expect(legsField?.value).toContain('-110')
+	})
+
+	it('logs Discord delivery errors as critical and does not throw', async () => {
+		mocks.fetch.mockRejectedValue(new Error('DMs closed'))
+
+		await expect(
+			new NotificationService().processParlayResult(makePayload('won')),
+		).resolves.toBeUndefined()
+
+		expect(mocks.logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'parlay.notification.delivery_failed',
+				critical: true,
+				parlay_id: '11111111-1111-4111-8111-111111111110',
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+import { validateParlayResultNotification } from '../parlay-notification-utils.js'
+
+const validLeg = {
+	id: '00000000-0000-0000-0000-000000000001',
+	event_id: 'event-1',
+	outcome_uuid: 'outcome-1',
+	market_key: 'h2h' as const,
+	selection_display: 'Lakers',
+	odds_american: -110,
+	point: null,
+	commence_time: '2026-07-11T20:00:00.000Z',
+	result: 'won' as const,
+}
+
+const validPayload = {
+	kind: 'won' as const,
+	parlay_id: '11111111-1111-4111-8111-111111111110',
+	user_id: 'user-1',
+	stake: 10,
+	combined_odds_american: 377,
+	payout: 47.7,
+	actual_payout: 47.7,
+	old_balance: 100,
+	new_balance: 137.7,
+	legs: [validLeg, { ...validLeg, id: 'leg-2', event_id: 'event-2' }],
+}
+
+describe('validateParlayResultNotification', () => {
+	it('accepts a strict won payload', () => {
+		const result = validateParlayResultNotification(validPayload)
+		expect(result).not.toBeNull()
+		expect(result).toMatchObject({
+			parlay_id: validPayload.parlay_id,
+			kind: 'won',
+		})
+		expect(result?.legs[0].commence_time).toEqual(
+			new Date(validLeg.commence_time),
+		)
+	})
+
+	it('rejects malformed payloads', () => {
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				parlay_id: 'not-a-uuid',
+			}),
+		).toBeNull()
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				legs: [
+					{
+						...validLeg,
+						commence_time: 'not-a-date',
+					},
+				],
+			}),
+		).toBeNull()
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts
@@ -62,5 +62,12 @@ describe('validateParlayResultNotification', () => {
 				],
 			}),
 		).toBeNull()
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				payout: undefined,
+				actual_payout: null,
+			}),
+		).toBeNull()
 	})
 })

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -2,6 +2,7 @@ import Router from '@koa/router'
 import { logger } from '../../../logging/WinstonLogger.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
+import { validateParlayResultNotification } from './parlay-notification-utils.js'
 
 const NotificationRouter = new Router()
 
@@ -44,6 +45,43 @@ NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 		ctx.body = {
 			success: false,
 			error: 'Failed to process notifications',
+		}
+		ctx.status = 500
+	}
+})
+
+NotificationRouter.post('/notifications/parlays/results', async (ctx) => {
+	const rawPayload = ctx.request.body || {}
+	const validatedData = validateParlayResultNotification(rawPayload)
+
+	if (!validatedData) {
+		ctx.body = {
+			success: false,
+			error: 'Invalid parlay notification data. Failed Zod validation.',
+		}
+		ctx.status = 422
+		return
+	}
+
+	try {
+		await new NotificationService().processParlayResult(validatedData)
+		ctx.body = {
+			success: true,
+		}
+	} catch (error) {
+		logger.error({
+			method: 'NotificationRouter',
+			event: 'parlay.notification.processing_failed',
+			message: 'CRITICAL: Failed to process parlay result notification',
+			error: error instanceof Error ? error.message : error,
+			critical: true,
+			parlay_id: validatedData.parlay_id,
+			user_id: validatedData.user_id,
+			kind: validatedData.kind,
+		})
+		ctx.body = {
+			success: false,
+			error: 'Failed to process parlay notifications',
 		}
 		ctx.status = 500
 	}

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -117,16 +117,16 @@ export default class NotificationService {
 	 * is unavailable.
 	 */
 	async processParlayResult(data: ParlayResultNotification): Promise<void> {
-		const embed = this.buildParlayEmbed(data)
-		await this.sendParlayEmbed(data.user_id, data, embed)
+		const embeds = this.buildParlayEmbeds(data)
+		await this.sendParlayEmbeds(data.user_id, data, embeds)
 	}
 
-	private buildParlayEmbed(data: ParlayResultNotification): EmbedBuilder {
+	private buildParlayEmbeds(data: ParlayResultNotification): EmbedBuilder[] {
 		const combinedOdds = this.formatAmericanOdds(
 			data.combined_odds_american,
 		)
 
-		const embed = new EmbedBuilder()
+		const baseEmbed = new EmbedBuilder()
 			.setTimestamp()
 			.setFooter({ text: `Pluto | Parlay ID: ${data.parlay_id}` })
 			.addFields({
@@ -137,7 +137,7 @@ export default class NotificationService {
 
 		switch (data.kind) {
 			case 'won': {
-				embed
+				baseEmbed
 					.setTitle('🎉 Parlay Won! 🎉')
 					.setColor('#57f287')
 					.addFields(
@@ -158,7 +158,7 @@ export default class NotificationService {
 					data.old_balance !== undefined &&
 					data.new_balance !== undefined
 				) {
-					embed.addFields({
+					baseEmbed.addFields({
 						name: '📊 Balance Update',
 						value: `${MoneyFormatter.toUSD(data.old_balance)} → ${MoneyFormatter.toUSD(data.new_balance)}`,
 						inline: false,
@@ -168,7 +168,7 @@ export default class NotificationService {
 			}
 			case 'busted':
 			case 'lost':
-				embed
+				baseEmbed
 					.setTitle('❌ Parlay Busted')
 					.setColor('#ff6961')
 					.addFields({
@@ -178,7 +178,7 @@ export default class NotificationService {
 					})
 				break
 			case 'push_refunded':
-				embed
+				baseEmbed
 					.setTitle('🔄 Parlay Refunded')
 					.setColor('#ffa500')
 					.addFields({
@@ -198,55 +198,90 @@ export default class NotificationService {
 				break
 		}
 
-		for (const field of this.buildParlayLegFields(data)) {
-			embed.addFields(field)
-		}
-
-		return embed
+		const groups = this.buildParlayLegFieldGroups(data)
+		if (groups.length === 0) return [baseEmbed]
+		return groups.map((fields, index) => {
+			const embed =
+				index === 0
+					? baseEmbed
+					: new EmbedBuilder()
+							.setTitle('🧾 Parlay Legs (continued)')
+							.setTimestamp()
+							.setFooter({
+								text: `Pluto | Parlay ID: ${data.parlay_id}`,
+							})
+			embed.addFields(...fields)
+			return embed
+		})
 	}
 
-	private buildParlayLegFields(
+	private buildParlayLegFieldGroups(
 		data: ParlayResultNotification,
-	): Array<{ name: string; value: string; inline: false }> {
-		const maxFieldLength = 900
-		const maxSelectionLength = 400
-		const fields: Array<{ name: string; value: string; inline: false }> = []
+	): Array<Array<{ name: string; value: string; inline: false }>> {
+		const maxFieldLength = 800
+		const maxFieldsPerEmbed = 20
+		const maxLegCharactersPerEmbed = 4500
+		const groups: Array<
+			Array<{ name: string; value: string; inline: false }>
+		> = []
+		let currentGroup: Array<{
+			name: string
+			value: string
+			inline: false
+		}> = []
 		let currentLines: string[] = []
-		let currentLength = 0
+		let currentFieldLength = 0
+		let currentGroupLength = 0
 
-		const flush = () => {
+		const flushField = () => {
 			if (currentLines.length === 0) return
-			fields.push({
+			currentGroup.push({
 				name:
-					fields.length === 0
+					currentGroup.length === 0
 						? '🧾 Legs'
-						: `🧾 Legs (${fields.length + 1})`,
+						: `🧾 Legs (${currentGroup.length + 1})`,
 				value: currentLines.join('\n'),
 				inline: false,
 			})
 			currentLines = []
-			currentLength = 0
+			currentFieldLength = 0
+		}
+		const flushGroup = () => {
+			flushField()
+			if (currentGroup.length === 0) return
+			groups.push(currentGroup)
+			currentGroup = []
+			currentGroupLength = 0
 		}
 
 		for (const leg of data.legs) {
 			const selection = leg.selection_display
 			const shortenedSelection =
-				selection.length > maxSelectionLength
-					? `${selection.slice(0, maxSelectionLength - 1)}…`
+				selection.length > 350
+					? `${selection.slice(0, 349)}…`
 					: selection
 			const line = `${this.parlayLegGlyph(leg.result)} ${shortenedSelection} (${this.formatAmericanOdds(leg.odds_american)})`
 			if (
 				currentLines.length > 0 &&
-				currentLength + line.length + 1 > maxFieldLength
+				currentFieldLength + line.length + 1 > maxFieldLength
 			) {
-				flush()
+				flushField()
+			}
+			if (
+				currentGroup.length >= maxFieldsPerEmbed ||
+				(currentGroupLength > 0 &&
+					currentGroupLength + line.length + 1 >
+						maxLegCharactersPerEmbed)
+			) {
+				flushGroup()
 			}
 			currentLines.push(line)
-			currentLength += line.length + 1
+			currentFieldLength += line.length + 1
+			currentGroupLength += line.length + 1
 		}
-		flush()
+		flushGroup()
 
-		return fields.slice(0, 25)
+		return groups
 	}
 
 	private parlayLegGlyph(
@@ -269,16 +304,16 @@ export default class NotificationService {
 		return odds > 0 ? `+${odds}` : `${odds}`
 	}
 
-	private async sendParlayEmbed(
+	private async sendParlayEmbeds(
 		userId: string,
 		data: ParlayResultNotification,
-		embed: EmbedBuilder,
+		embeds: EmbedBuilder[],
 	): Promise<void> {
 		const client = container.client
 
 		if (!client) {
 			logger.error({
-				method: this.sendParlayEmbed.name,
+				method: this.sendParlayEmbeds.name,
 				event: 'parlay.notification.delivery_failed',
 				message: 'Discord client not available for parlay notification',
 				critical: true,
@@ -291,10 +326,12 @@ export default class NotificationService {
 
 		try {
 			const user = await client.users.fetch(userId)
-			await user.send({ embeds: [embed] })
+			for (const embed of embeds) {
+				await user.send({ embeds: [embed] })
+			}
 		} catch (error) {
 			logger.error({
-				method: this.sendParlayEmbed.name,
+				method: this.sendParlayEmbeds.name,
 				event: 'parlay.notification.delivery_failed',
 				message: 'Unable to send parlay result Discord DM',
 				critical: true,

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -13,6 +13,7 @@ import type {
 	DisplayResultWon,
 	NotifyBetUsers,
 } from './notifications.interface.js'
+import type { ParlayResultNotification } from './parlay-notification-contract.js'
 
 export default class NotificationService {
 	async processBetResults(data: NotifyBetUsers): Promise<void> {
@@ -104,6 +105,166 @@ export default class NotificationService {
 
 				await this.notifyUser(displayPush)
 			}
+		}
+	}
+
+	/**
+	 * Deliver one multi-leg parlay resolution to its owner.
+	 *
+	 * Discord delivery failures are intentionally swallowed after structured
+	 * logging, matching the singles notification route's no-retry-storm
+	 * behavior. Khronos still receives a successful HTTP response when Discord
+	 * is unavailable.
+	 */
+	async processParlayResult(data: ParlayResultNotification): Promise<void> {
+		const embed = this.buildParlayEmbed(data)
+		await this.sendParlayEmbed(data.user_id, data, embed)
+	}
+
+	private buildParlayEmbed(data: ParlayResultNotification): EmbedBuilder {
+		const legs = data.legs
+			.map((leg) => {
+				const glyph = this.parlayLegGlyph(leg.result)
+				return `${glyph} ${leg.selection_display} (${this.formatAmericanOdds(leg.odds_american)})`
+			})
+			.join('\n')
+		const combinedOdds = this.formatAmericanOdds(
+			data.combined_odds_american,
+		)
+
+		const embed = new EmbedBuilder()
+			.setTimestamp()
+			.setFooter({ text: `Pluto | Parlay ID: ${data.parlay_id}` })
+			.addFields({
+				name: '🧾 Legs',
+				value: legs,
+				inline: false,
+			})
+			.addFields({
+				name: '📈 Combined Odds',
+				value: combinedOdds,
+				inline: true,
+			})
+
+		switch (data.kind) {
+			case 'won': {
+				embed
+					.setTitle('🎉 Parlay Won! 🎉')
+					.setColor('#57f287')
+					.addFields(
+						{
+							name: '💰 Stake',
+							value: MoneyFormatter.toUSD(data.stake),
+							inline: true,
+						},
+						{
+							name: '🏆 Payout',
+							value: MoneyFormatter.toUSD(
+								data.actual_payout ?? 0,
+							),
+							inline: true,
+						},
+					)
+				if (
+					data.old_balance !== undefined &&
+					data.new_balance !== undefined
+				) {
+					embed.addFields({
+						name: '📊 Balance Update',
+						value: `${MoneyFormatter.toUSD(data.old_balance)} → ${MoneyFormatter.toUSD(data.new_balance)}`,
+						inline: false,
+					})
+				}
+				break
+			}
+			case 'busted':
+			case 'lost':
+				embed
+					.setTitle('❌ Parlay Busted')
+					.setColor('#ff6961')
+					.addFields({
+						name: '💸 Lost',
+						value: MoneyFormatter.toUSD(data.stake),
+						inline: true,
+					})
+				break
+			case 'push_refunded':
+				embed
+					.setTitle('🔄 Parlay Refunded')
+					.setColor('#ffa500')
+					.addFields({
+						name: '💵 Refunded Amount',
+						value: MoneyFormatter.toUSD(
+							data.refund_amount ?? data.actual_payout,
+						),
+						inline: true,
+					})
+					.addFields({
+						name: 'ℹ️ Reason',
+						value: 'All eligible legs pushed or were voided. Your stake has been refunded.',
+						inline: false,
+					})
+				break
+		}
+
+		return embed
+	}
+
+	private parlayLegGlyph(
+		result: ParlayResultNotification['legs'][number]['result'],
+	): string {
+		switch (result) {
+			case 'won':
+				return '✅'
+			case 'lost':
+				return '❌'
+			case 'pending':
+				return '⏳'
+			case 'push':
+			case 'void':
+				return '➖'
+		}
+	}
+
+	private formatAmericanOdds(odds: number): string {
+		return odds > 0 ? `+${odds}` : `${odds}`
+	}
+
+	private async sendParlayEmbed(
+		userId: string,
+		data: ParlayResultNotification,
+		embed: EmbedBuilder,
+	): Promise<void> {
+		const client = container.client
+
+		if (!client) {
+			logger.error({
+				method: this.sendParlayEmbed.name,
+				event: 'parlay.notification.delivery_failed',
+				message: 'Discord client not available for parlay notification',
+				critical: true,
+				kind: data.kind,
+				parlay_id: data.parlay_id,
+				user_id: userId,
+			})
+			return
+		}
+
+		try {
+			const user = await client.users.fetch(userId)
+			await user.send({ embeds: [embed] })
+		} catch (error) {
+			logger.error({
+				method: this.sendParlayEmbed.name,
+				event: 'parlay.notification.delivery_failed',
+				message: 'Unable to send parlay result Discord DM',
+				critical: true,
+				kind: data.kind,
+				parlay_id: data.parlay_id,
+				user_id: userId,
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			})
 		}
 	}
 

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -122,12 +122,6 @@ export default class NotificationService {
 	}
 
 	private buildParlayEmbed(data: ParlayResultNotification): EmbedBuilder {
-		const legs = data.legs
-			.map((leg) => {
-				const glyph = this.parlayLegGlyph(leg.result)
-				return `${glyph} ${leg.selection_display} (${this.formatAmericanOdds(leg.odds_american)})`
-			})
-			.join('\n')
 		const combinedOdds = this.formatAmericanOdds(
 			data.combined_odds_american,
 		)
@@ -135,11 +129,6 @@ export default class NotificationService {
 		const embed = new EmbedBuilder()
 			.setTimestamp()
 			.setFooter({ text: `Pluto | Parlay ID: ${data.parlay_id}` })
-			.addFields({
-				name: '🧾 Legs',
-				value: legs,
-				inline: false,
-			})
 			.addFields({
 				name: '📈 Combined Odds',
 				value: combinedOdds,
@@ -160,7 +149,7 @@ export default class NotificationService {
 						{
 							name: '🏆 Payout',
 							value: MoneyFormatter.toUSD(
-								data.actual_payout ?? 0,
+								data.actual_payout ?? data.payout ?? 0,
 							),
 							inline: true,
 						},
@@ -195,7 +184,9 @@ export default class NotificationService {
 					.addFields({
 						name: '💵 Refunded Amount',
 						value: MoneyFormatter.toUSD(
-							data.refund_amount ?? data.actual_payout,
+							data.refund_amount ??
+								data.actual_payout ??
+								data.stake,
 						),
 						inline: true,
 					})
@@ -207,7 +198,55 @@ export default class NotificationService {
 				break
 		}
 
+		for (const field of this.buildParlayLegFields(data)) {
+			embed.addFields(field)
+		}
+
 		return embed
+	}
+
+	private buildParlayLegFields(
+		data: ParlayResultNotification,
+	): Array<{ name: string; value: string; inline: false }> {
+		const maxFieldLength = 900
+		const maxSelectionLength = 400
+		const fields: Array<{ name: string; value: string; inline: false }> = []
+		let currentLines: string[] = []
+		let currentLength = 0
+
+		const flush = () => {
+			if (currentLines.length === 0) return
+			fields.push({
+				name:
+					fields.length === 0
+						? '🧾 Legs'
+						: `🧾 Legs (${fields.length + 1})`,
+				value: currentLines.join('\n'),
+				inline: false,
+			})
+			currentLines = []
+			currentLength = 0
+		}
+
+		for (const leg of data.legs) {
+			const selection = leg.selection_display
+			const shortenedSelection =
+				selection.length > maxSelectionLength
+					? `${selection.slice(0, maxSelectionLength - 1)}…`
+					: selection
+			const line = `${this.parlayLegGlyph(leg.result)} ${shortenedSelection} (${this.formatAmericanOdds(leg.odds_american)})`
+			if (
+				currentLines.length > 0 &&
+				currentLength + line.length + 1 > maxFieldLength
+			) {
+				flush()
+			}
+			currentLines.push(line)
+			currentLength += line.length + 1
+		}
+		flush()
+
+		return fields.slice(0, 25)
 	}
 
 	private parlayLegGlyph(

--- a/src/utils/api/routes/notifications/parlay-notification-contract.ts
+++ b/src/utils/api/routes/notifications/parlay-notification-contract.ts
@@ -8,36 +8,50 @@ import { z } from 'zod'
  * `parlayResultNotificationSchema`; replace this module import with the
  * published package export when the paired Khronos release lands.
  */
-export const parlayResultNotificationSchema = z.object({
-	kind: z.enum(['won', 'lost', 'push_refunded', 'busted']),
-	parlay_id: z.string().uuid(),
-	user_id: z.string().min(1),
-	guild_id: z.string().min(1).optional(),
-	stake: z.number().finite().nonnegative(),
-	combined_odds_american: z.number().int(),
-	payout: z.number().finite().nonnegative().optional(),
-	actual_payout: z.number().finite().nonnegative().nullable(),
-	refund_amount: z.number().finite().nonnegative().optional(),
-	old_balance: z.number().finite().optional(),
-	new_balance: z.number().finite().optional(),
-	legs: z
-		.array(
-			z.object({
-				id: z.string().min(1),
-				event_id: z.string().min(1),
-				outcome_uuid: z.string().min(1),
-				selection_display: z.string().min(1),
-				market_key: z.string().min(1),
-				odds_american: z.number().int(),
-				point: z.number().finite().nullable(),
-				commence_time: z.coerce.date(),
-				result: z.enum(['pending', 'won', 'lost', 'push', 'void']),
-				home_team: z.string().min(1).optional(),
-				away_team: z.string().min(1).optional(),
-			}),
-		)
-		.min(1),
-})
+export const parlayResultNotificationSchema = z
+	.object({
+		kind: z.enum(['won', 'lost', 'push_refunded', 'busted']),
+		parlay_id: z.string().uuid(),
+		user_id: z.string().min(1),
+		guild_id: z.string().min(1).optional(),
+		stake: z.number().finite().nonnegative(),
+		combined_odds_american: z.number().int(),
+		payout: z.number().finite().nonnegative().optional(),
+		actual_payout: z.number().finite().nonnegative().nullable(),
+		refund_amount: z.number().finite().nonnegative().optional(),
+		old_balance: z.number().finite().optional(),
+		new_balance: z.number().finite().optional(),
+		legs: z
+			.array(
+				z.object({
+					id: z.string().min(1),
+					event_id: z.string().min(1),
+					outcome_uuid: z.string().min(1),
+					selection_display: z.string().min(1),
+					market_key: z.string().min(1),
+					odds_american: z.number().int(),
+					point: z.number().finite().nullable(),
+					commence_time: z.coerce.date(),
+					result: z.enum(['pending', 'won', 'lost', 'push', 'void']),
+					home_team: z.string().min(1).optional(),
+					away_team: z.string().min(1).optional(),
+				}),
+			)
+			.min(1),
+	})
+	.superRefine((payload, context) => {
+		if (
+			payload.kind === 'won' &&
+			payload.actual_payout === null &&
+			payload.payout === undefined
+		) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['payout'],
+				message: 'won notifications require payout or actual_payout',
+			})
+		}
+	})
 
 export type ParlayResultNotification = z.infer<
 	typeof parlayResultNotificationSchema

--- a/src/utils/api/routes/notifications/parlay-notification-contract.ts
+++ b/src/utils/api/routes/notifications/parlay-notification-contract.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+/**
+ * Temporary compatibility contract for TF-967.
+ *
+ * @pluto-khronos/types@3.4.3 does not export the C5 parlay notification
+ * schema yet. Keep this shape aligned with TF-949's
+ * `parlayResultNotificationSchema`; replace this module import with the
+ * published package export when the paired Khronos release lands.
+ */
+export const parlayResultNotificationSchema = z.object({
+	kind: z.enum(['won', 'lost', 'push_refunded', 'busted']),
+	parlay_id: z.string().uuid(),
+	user_id: z.string().min(1),
+	guild_id: z.string().min(1).optional(),
+	stake: z.number().finite().nonnegative(),
+	combined_odds_american: z.number().int(),
+	payout: z.number().finite().nonnegative().optional(),
+	actual_payout: z.number().finite().nonnegative().nullable(),
+	refund_amount: z.number().finite().nonnegative().optional(),
+	old_balance: z.number().finite().optional(),
+	new_balance: z.number().finite().optional(),
+	legs: z
+		.array(
+			z.object({
+				id: z.string().min(1),
+				event_id: z.string().min(1),
+				outcome_uuid: z.string().min(1),
+				selection_display: z.string().min(1),
+				market_key: z.string().min(1),
+				odds_american: z.number().int(),
+				point: z.number().finite().nullable(),
+				commence_time: z.coerce.date(),
+				result: z.enum(['pending', 'won', 'lost', 'push', 'void']),
+				home_team: z.string().min(1).optional(),
+				away_team: z.string().min(1).optional(),
+			}),
+		)
+		.min(1),
+})
+
+export type ParlayResultNotification = z.infer<
+	typeof parlayResultNotificationSchema
+>

--- a/src/utils/api/routes/notifications/parlay-notification-utils.ts
+++ b/src/utils/api/routes/notifications/parlay-notification-utils.ts
@@ -1,0 +1,24 @@
+import { logger } from '../../../logging/WinstonLogger.js'
+import {
+	type ParlayResultNotification,
+	parlayResultNotificationSchema,
+} from './parlay-notification-contract.js'
+
+/** Parse and strictly validate the Khronos parlay result notification. */
+export function validateParlayResultNotification(
+	payload: unknown,
+): ParlayResultNotification | null {
+	const result = parlayResultNotificationSchema.safeParse(payload)
+
+	if (!result.success) {
+		logger.warn({
+			method: 'validateParlayResultNotification',
+			event: 'parlay.notification.validation_failed',
+			message: 'Invalid parlay result notification payload',
+			errors: result.error.issues,
+		})
+		return null
+	}
+
+	return result.data
+}


### PR DESCRIPTION
## Summary
- add `POST /notifications/parlays/results` and `Endpoints.paths.notifiy.parlayResults`
- validate C5 parlay result payloads with a temporary Zod compatibility contract aligned to TF-949 until `@pluto-khronos/types` publishes the schema
- deliver won, busted/lost, and push-refunded multi-leg DMs with result glyphs, American odds, and `MoneyFormatter` amounts
- log Discord delivery failures with `critical: true`

## Tests
- `pnpm exec vitest run src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts src/utils/api/routes/notifications/__tests__/notifications.controller.parlay.test.ts`
- `pnpm test:run`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec biome check --write .`

## Linear
- TF-967
- Paired Khronos contract: TF-949

Targets `dev/parlays-props`; no `main` changes.