### PR TITLE
feat(parlays): add Components V2 parlay builder

### DIFF
--- a/src/commands/betting/parlay.ts
+++ b/src/commands/betting/parlay.ts
@@ -1,0 +1,52 @@
+import { ApplyOptions } from '@sapphire/decorators'
+import { Command } from '@sapphire/framework'
+import { InteractionContextType, MessageFlags } from 'discord.js'
+import { ParlayBuilderService } from '../../services/ParlayBuilderService.js'
+import { ErrorEmbeds } from '../../utils/common/errors/global.js'
+
+@ApplyOptions<Command.Options>({
+	description: '🎲 Build a multi-game parlay',
+})
+export class UserCommand extends Command {
+	private builderService?: ParlayBuilderService
+
+	private getService(): ParlayBuilderService {
+		return (this.builderService ??= new ParlayBuilderService())
+	}
+
+	public override registerApplicationCommands(registry: Command.Registry) {
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName(this.name)
+				.setDescription(this.description)
+				.setContexts(InteractionContextType.Guild),
+		)
+	}
+
+	public override async chatInputRun(
+		interaction: Command.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral })
+		try {
+			const service = this.getService()
+			const session = await service.start(interaction.user.id)
+			return interaction.editReply(service.render(session))
+		} catch (error) {
+			this.container.logger.error({
+				message: 'Failed to start parlay builder',
+				metadata: {
+					userId: interaction.user.id,
+					error:
+						error instanceof Error ? error.message : String(error),
+				},
+			})
+			return interaction.editReply({
+				embeds: [
+					await ErrorEmbeds.internalErr(
+						'Unable to start your parlay. Please try again.',
+					),
+				],
+			})
+		}
+	}
+}

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -1,0 +1,249 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import {
+	type ButtonInteraction,
+	LabelBuilder,
+	MessageFlags,
+	ModalBuilder,
+	StringSelectMenuBuilder,
+	TextInputBuilder,
+	TextInputStyle,
+} from 'discord.js'
+import {
+	getParlayErrorMessage,
+	logParlayBuilderError,
+	ParlayBuilderService,
+} from '../services/ParlayBuilderService.js'
+import { BetsCacheService } from '../utils/api/common/bets/BetsCacheService.js'
+import { BetslipManager } from '../utils/api/Khronos/bets/BetslipsManager.js'
+import BetslipWrapper from '../utils/api/Khronos/bets/betslip-wrapper.js'
+import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+
+const removeId = /^parlay_btn_remove_(\d+)$/
+
+export class ParlayButtonHandler extends InteractionHandler {
+	private readonly builderService = new ParlayBuilderService()
+	private readonly parlayApi = new ParlayApiWrapper()
+	private readonly matchCache = new MatchCacheService(new CacheManager())
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.Button,
+		})
+	}
+
+	public override async parse(interaction: ButtonInteraction) {
+		if (!interaction.customId.startsWith('parlay_btn_')) return this.none()
+		if (interaction.customId === 'parlay_btn_add') {
+			try {
+				await interaction.showModal(await this.buildAddLegModal())
+			} catch (error) {
+				logParlayBuilderError(error, {
+					action: 'open_add_leg_modal',
+					userId: interaction.user.id,
+				})
+				await interaction.reply({
+					content:
+						error instanceof Error
+							? error.message
+							: 'No upcoming games are available right now.',
+					ephemeral: true,
+				})
+			}
+			return this.none()
+		}
+		if (interaction.customId === 'parlay_btn_stake') {
+			await interaction.showModal(this.buildStakeModal())
+			return this.none()
+		}
+		const removeMatch = removeId.exec(interaction.customId)
+		if (removeMatch) {
+			await interaction.deferUpdate()
+			return this.some({
+				action: 'remove',
+				index: Number(removeMatch[1]),
+			})
+		}
+		if (interaction.customId === 'parlay_btn_cancel') {
+			await interaction.deferUpdate()
+			return this.some({ action: 'cancel' })
+		}
+		if (interaction.customId === 'parlay_btn_confirm') {
+			await interaction.deferUpdate()
+			return this.some({ action: 'confirm' })
+		}
+		return this.none()
+	}
+
+	public async run(
+		interaction: ButtonInteraction,
+		payload:
+			| { action: 'remove'; index: number }
+			| { action: 'cancel' }
+			| { action: 'confirm' },
+	) {
+		const userId = interaction.user.id
+		try {
+			if (payload.action === 'cancel') {
+				await this.builderService.clear(userId)
+				return interaction.editReply(
+					this.builderService.renderMessage(
+						'Parlay builder cancelled.',
+					),
+				)
+			}
+			if (payload.action === 'remove') {
+				const session = await this.builderService.removeLeg(
+					userId,
+					payload.index,
+				)
+				return interaction.editReply(
+					this.builderService.render(session),
+				)
+			}
+			const session = await this.builderService.get(userId)
+			if (!session)
+				throw new Error(
+					'Your parlay builder expired. Run `/parlay` to start again.',
+				)
+			this.builderService.validateForPlacement(session)
+			const initialized = await this.parlayApi.init({
+				legs: session.legs.map(({ event_id, outcome_uuid }) => ({
+					event_id,
+					outcome_uuid,
+				})),
+				stake: session.stake!,
+				guild_id: interaction.guildId!,
+				user_id: userId,
+			})
+			const placed = await this.parlayApi.place(initialized.init_token)
+			await new BetslipManager(
+				new BetslipWrapper(),
+				new BetsCacheService(new CacheManager()),
+			).announceParlayPlaced(interaction, {
+				parlayId: placed.id,
+				legCount: placed.leg_count,
+				stake: Number(placed.stake),
+				potentialPayout: Number(placed.potential_payout),
+			})
+			await this.builderService.clear(userId)
+			return interaction.editReply(
+				this.builderService.renderMessage(
+					`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
+					0x57f287,
+				),
+			)
+		} catch (error) {
+			logParlayBuilderError(error, { action: payload.action, userId })
+			const message = getParlayErrorMessage(error)
+			return interaction.editReply({
+				...this.builderService.renderMessage(message),
+				flags: MessageFlags.IsComponentsV2,
+			})
+		}
+	}
+
+	private async buildAddLegModal(): Promise<ModalBuilder> {
+		const matches = ((await this.matchCache.getMatches()) ?? [])
+			.filter((match) => match.id && match.home_team && match.away_team)
+			.filter(
+				(match) =>
+					!match.commence_time ||
+					new Date(match.commence_time).getTime() > Date.now(),
+			)
+			.slice(0, 25)
+		if (matches.length === 0)
+			throw new Error('No upcoming games are available right now.')
+		const gameSelect = new StringSelectMenuBuilder()
+			.setCustomId('parlay_game')
+			.setPlaceholder('Choose an upcoming game')
+			.setRequired(true)
+			.addOptions(
+				matches.map((match) => ({
+					label: `${match.away_team} @ ${match.home_team}`.slice(
+						0,
+						100,
+					),
+					value: match.id!,
+					description: match.commence_time
+						? new Date(match.commence_time).toLocaleString(
+								'en-US',
+								{
+									month: 'short',
+									day: 'numeric',
+									hour: 'numeric',
+									minute: '2-digit',
+								},
+							)
+						: 'Start time TBD',
+				})),
+			)
+		return new ModalBuilder()
+			.setCustomId('parlay_modal_add_leg')
+			.setTitle('Add a parlay leg')
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Game')
+					.setDescription('Choose an upcoming game')
+					.setStringSelectMenuComponent(gameSelect),
+			)
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Market')
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder()
+							.setCustomId('parlay_market')
+							.setPlaceholder('Choose market')
+							.addOptions(
+								{ label: 'Moneyline', value: 'h2h' },
+								{ label: 'Spread', value: 'spreads' },
+								{ label: 'Total', value: 'totals' },
+							)
+							.setRequired(true),
+					),
+			)
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Side')
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder()
+							.setCustomId('parlay_side')
+							.setPlaceholder('Choose side')
+							.addOptions(
+								{ label: 'Home team', value: 'home' },
+								{ label: 'Away team', value: 'away' },
+								{ label: 'Over', value: 'over' },
+								{ label: 'Under', value: 'under' },
+							)
+							.setRequired(true),
+					),
+			)
+	}
+
+	private buildStakeModal(): ModalBuilder {
+		return new ModalBuilder()
+			.setCustomId('parlay_modal_stake')
+			.setTitle('Set parlay stake')
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Stake (whole dollars)')
+					.setTextInputComponent(
+						new TextInputBuilder()
+							.setCustomId('parlay_stake')
+							.setStyle(TextInputStyle.Short)
+							.setPlaceholder('10')
+							.setRequired(true)
+							.setMinLength(1)
+							.setMaxLength(6),
+					),
+			)
+	}
+}

--- a/src/interaction-handlers/parlay-modal-handler.ts
+++ b/src/interaction-handlers/parlay-modal-handler.ts
@@ -1,0 +1,102 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import { type ModalSubmitInteraction } from 'discord.js'
+import {
+	getParlayErrorMessage,
+	logParlayBuilderError,
+	ParlayBuilderService,
+} from '../services/ParlayBuilderService.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+
+export class ParlayModalHandler extends InteractionHandler {
+	private readonly builderService = new ParlayBuilderService()
+	private readonly matchCache = new MatchCacheService(new CacheManager())
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.ModalSubmit,
+		})
+	}
+
+	public override parse(interaction: ModalSubmitInteraction) {
+		if (!interaction.customId.startsWith('parlay_modal_'))
+			return this.none()
+		const kind = interaction.customId.replace('parlay_modal_', '')
+		if (kind !== 'add_leg' && kind !== 'stake') return this.none()
+		return this.some({
+			kind,
+		})
+	}
+
+	public async run(
+		interaction: ModalSubmitInteraction,
+		payload: { kind: 'add_leg' | 'stake' },
+	) {
+		await interaction.deferReply({ ephemeral: true })
+		const userId = interaction.user.id
+		try {
+			if (payload.kind === 'stake') {
+				const rawStake = interaction.fields
+					.getTextInputValue('parlay_stake')
+					.trim()
+				if (!/^\d+$/.test(rawStake))
+					throw new Error('Stake must be a whole number. Try again.')
+				const session = await this.builderService.setStake(
+					userId,
+					Number(rawStake),
+				)
+				return interaction.editReply(
+					this.builderService.render(session),
+				)
+			}
+
+			const gameId =
+				interaction.fields.getStringSelectValues('parlay_game')[0]
+			const marketKey = interaction.fields.getStringSelectValues(
+				'parlay_market',
+			)[0] as 'h2h' | 'spreads' | 'totals'
+			const side = interaction.fields.getStringSelectValues(
+				'parlay_side',
+			)[0] as 'home' | 'away' | 'over' | 'under'
+			if (!gameId || !marketKey || !side)
+				throw new Error('Choose a game, market, and side.')
+			const match = await this.matchCache.getMatch(gameId)
+			if (!match) throw new Error('Choose a valid game from the list.')
+			if (marketKey === 'h2h' && (side === 'over' || side === 'under')) {
+				throw new Error(
+					'Over/Under is only valid for totals. Choose a team for moneyline.',
+				)
+			}
+			if (
+				(marketKey === 'spreads' || marketKey === 'h2h') &&
+				(side === 'over' || side === 'under')
+			) {
+				throw new Error('That side is not valid for this market.')
+			}
+			if (
+				marketKey === 'totals' &&
+				(side === 'home' || side === 'away')
+			) {
+				throw new Error('Totals require Over or Under.')
+			}
+			const session = await this.builderService.addLeg(userId, {
+				matchId: gameId,
+				marketKey,
+				side,
+			})
+			return interaction.editReply(this.builderService.render(session))
+		} catch (error) {
+			logParlayBuilderError(error, { userId, modal: payload.kind })
+			return interaction.editReply(
+				this.builderService.renderMessage(getParlayErrorMessage(error)),
+			)
+		}
+	}
+}

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -1,0 +1,367 @@
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ContainerBuilder,
+	type InteractionEditReplyOptions,
+	MessageFlags,
+	SectionBuilder,
+	SeparatorSpacingSize,
+} from 'discord.js'
+import ParlayApiWrapper, {
+	type EventOutcome,
+	type ParlayLegInput,
+	type ParlayMarketKey,
+} from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { combineAmericanOdds } from '../utils/betting/american-odds.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+import { logger } from '../utils/logging/WinstonLogger.js'
+
+export const PARLAY_BUILDER_TTL_SECONDS = 15 * 60
+export const PARLAY_BUILDER_MAX_LEGS = 6
+
+export interface ParlayBuilderLeg extends ParlayLegInput {
+	market_key: ParlayMarketKey
+	selection_display: string
+	odds_american: number
+	point: number | null
+	commence_time: string
+}
+
+export interface ParlayBuilderSession {
+	legs: ParlayBuilderLeg[]
+	stake: number | null
+}
+
+export type ParlaySide = 'home' | 'away' | 'over' | 'under'
+
+export interface AddParlayLegSelection {
+	matchId: string
+	marketKey: ParlayMarketKey
+	side: ParlaySide
+}
+
+export const parlayBuilderKey = (userId: string): string =>
+	`parlay-builder:${userId}`
+
+export class ParlayBuilderService {
+	constructor(
+		private readonly cache: CacheManager = new CacheManager(),
+		private readonly matchCache = new MatchCacheService(new CacheManager()),
+		private readonly parlayApi = new ParlayApiWrapper(),
+	) {}
+
+	async get(userId: string): Promise<ParlayBuilderSession | null> {
+		const value = await this.cache.get(parlayBuilderKey(userId))
+		if (!value || typeof value !== 'object') return null
+		const session = value as Partial<ParlayBuilderSession>
+		if (!Array.isArray(session.legs)) return null
+		return {
+			legs: session.legs as ParlayBuilderLeg[],
+			stake: typeof session.stake === 'number' ? session.stake : null,
+		}
+	}
+
+	async start(userId: string): Promise<ParlayBuilderSession> {
+		const session: ParlayBuilderSession = { legs: [], stake: null }
+		await this.save(userId, session)
+		return session
+	}
+
+	async save(userId: string, session: ParlayBuilderSession): Promise<void> {
+		await this.cache.set(
+			parlayBuilderKey(userId),
+			session,
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	}
+
+	async clear(userId: string): Promise<void> {
+		await this.cache.remove(parlayBuilderKey(userId))
+	}
+
+	async setStake(
+		userId: string,
+		stake: number,
+	): Promise<ParlayBuilderSession> {
+		if (!Number.isSafeInteger(stake) || stake <= 0) {
+			throw new Error('Stake must be a whole number greater than $0.')
+		}
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		const updated = { ...session, stake }
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async removeLeg(
+		userId: string,
+		index: number,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		if (index < 0 || index >= session.legs.length) {
+			throw new Error('That parlay leg is no longer available.')
+		}
+		const updated = {
+			...session,
+			legs: session.legs.filter((_, i) => i !== index),
+		}
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async addLeg(
+		userId: string,
+		selection: AddParlayLegSelection,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
+			throw new Error('A parlay can contain at most 6 legs.')
+		}
+		if (session.legs.some((leg) => leg.event_id === selection.matchId)) {
+			throw new Error('Each parlay leg must use a different game.')
+		}
+
+		const leg = await this.resolveLeg(selection)
+		const updated = { ...session, legs: [...session.legs, leg] }
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async resolveLeg(
+		selection: AddParlayLegSelection,
+	): Promise<ParlayBuilderLeg> {
+		const match = await this.matchCache.getMatch(selection.matchId)
+		if (!match?.id || !match.home_team || !match.away_team) {
+			throw new Error('Choose a valid upcoming game from the list.')
+		}
+		if (
+			match.commence_time &&
+			new Date(match.commence_time).getTime() <= Date.now()
+		) {
+			throw new Error(
+				'That game has already started. Choose another game.',
+			)
+		}
+
+		const outcomes = await this.parlayApi.getEventOutcomes(
+			match.sport ?? 'nba',
+			match.id,
+		)
+		const marketOutcomes = outcomes.filter(
+			(outcome) => outcome.market_key === selection.marketKey,
+		)
+		const outcome = this.selectOutcome(
+			marketOutcomes,
+			selection.side,
+			match.home_team,
+			match.away_team,
+		)
+		if (!outcome?.uuid || outcome.price === undefined) {
+			throw new Error(
+				'That selection is no longer available. Try another leg.',
+			)
+		}
+
+		const selectionDisplay = this.selectionDisplay(
+			selection.marketKey,
+			selection.side,
+			match.home_team,
+			match.away_team,
+			outcome.point,
+		)
+		return {
+			event_id: match.id,
+			outcome_uuid: outcome.uuid,
+			market_key: selection.marketKey,
+			selection_display: selectionDisplay,
+			odds_american: outcome.price,
+			point: outcome.point ?? null,
+			commence_time: match.commence_time ?? new Date().toISOString(),
+		}
+	}
+
+	private selectOutcome(
+		outcomes: EventOutcome[],
+		side: ParlaySide,
+		homeTeam: string,
+		awayTeam: string,
+	): EventOutcome | undefined {
+		return outcomes.find((outcome) => {
+			const name = outcome.name?.trim().toLowerCase()
+			const position = outcome.position?.toLowerCase()
+			const outcomeType = outcome.outcome_type?.toLowerCase()
+			if (side === 'over' || side === 'under') {
+				return name === side || outcomeType === side
+			}
+			const team = side === 'home' ? homeTeam : awayTeam
+			return (
+				name === team.toLowerCase() ||
+				position === side ||
+				outcomeType === `team_${side}`
+			)
+		})
+	}
+
+	private selectionDisplay(
+		market: ParlayMarketKey,
+		side: ParlaySide,
+		homeTeam: string,
+		awayTeam: string,
+		point?: number | null,
+	): string {
+		if (market === 'totals')
+			return `${side === 'over' ? 'Over' : 'Under'}${point === undefined || point === null ? '' : ` ${point}`}`
+		const team = side === 'home' ? homeTeam : awayTeam
+		return market === 'spreads' && point !== undefined && point !== null
+			? `${team} ${point > 0 ? '+' : ''}${point}`
+			: team
+	}
+
+	validateForPlacement(session: ParlayBuilderSession): void {
+		if (session.legs.length < 2) {
+			throw new Error('Add at least 2 different games before confirming.')
+		}
+		if (session.legs.length > PARLAY_BUILDER_MAX_LEGS) {
+			throw new Error('A parlay can contain at most 6 legs.')
+		}
+		if (!session.stake)
+			throw new Error('Set a stake before confirming your parlay.')
+	}
+
+	getOddsSummary(session: ParlayBuilderSession): {
+		american: number
+		decimal: number
+		potentialPayout: number | null
+	} {
+		if (session.legs.length === 0) {
+			return { american: 0, decimal: 1, potentialPayout: null }
+		}
+		const combined = combineAmericanOdds(
+			session.legs.map((leg) => leg.odds_american),
+		)
+		return {
+			...combined,
+			potentialPayout:
+				session.stake === null
+					? null
+					: Math.round(session.stake * combined.decimal * 100) / 100,
+		}
+	}
+
+	render(session: ParlayBuilderSession): InteractionEditReplyOptions {
+		const summary = this.getOddsSummary(session)
+		const container = new ContainerBuilder().setAccentColor(0x5865f2)
+		container.addTextDisplayComponents((text) =>
+			text.setContent('## 🎲 Build your parlay'),
+		)
+		if (session.legs.length === 0) {
+			container.addTextDisplayComponents((text) =>
+				text.setContent(
+					'Add 2–6 legs from different upcoming games to get started.',
+				),
+			)
+		}
+		for (const [index, leg] of session.legs.entries()) {
+			const section = new SectionBuilder()
+				.addTextDisplayComponents((text) =>
+					text.setContent(
+						`**${index + 1}. ${leg.selection_display}**\n${leg.market_key} • ${leg.odds_american > 0 ? '+' : ''}${leg.odds_american} • <t:${Math.floor(new Date(leg.commence_time).getTime() / 1000)}:f>`,
+					),
+				)
+				.setButtonAccessory(
+					new ButtonBuilder()
+						.setCustomId(`parlay_btn_remove_${index}`)
+						.setLabel('Remove')
+						.setStyle(ButtonStyle.Danger),
+				)
+			container.addSectionComponents(section)
+		}
+		container.addSeparatorComponents((separator) =>
+			separator.setDivider(true).setSpacing(SeparatorSpacingSize.Small),
+		)
+		const payoutText =
+			summary.potentialPayout === null
+				? 'Set a stake to calculate potential payout.'
+				: `Potential payout: **$${summary.potentialPayout.toFixed(2)}**`
+		container.addTextDisplayComponents((text) =>
+			text.setContent(
+				`Combined odds: **${summary.american > 0 ? '+' : ''}${summary.american || '—'}** (${summary.decimal.toFixed(2)}x)\nStake: **${session.stake === null ? 'Not set' : `$${session.stake.toFixed(2)}`}**\n${payoutText}`,
+			),
+		)
+		container.addActionRowComponents((row) =>
+			row.addComponents(
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_add')
+					.setLabel('Add Leg')
+					.setStyle(ButtonStyle.Primary),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_stake')
+					.setLabel('Set Stake')
+					.setStyle(ButtonStyle.Secondary),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_confirm')
+					.setLabel('Confirm')
+					.setStyle(ButtonStyle.Success)
+					.setDisabled(
+						session.legs.length < 2 || session.stake === null,
+					),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_cancel')
+					.setLabel('Cancel')
+					.setStyle(ButtonStyle.Danger),
+			),
+		)
+		return { components: [container], flags: MessageFlags.IsComponentsV2 }
+	}
+
+	renderMessage(
+		content: string,
+		color = 0xed4245,
+	): InteractionEditReplyOptions {
+		const container = new ContainerBuilder()
+			.setAccentColor(color)
+			.addTextDisplayComponents((text) => text.setContent(content))
+		return { components: [container], flags: MessageFlags.IsComponentsV2 }
+	}
+}
+
+export function logParlayBuilderError(
+	error: unknown,
+	metadata: Record<string, unknown>,
+): void {
+	logger.error('parlay_builder_error', {
+		...metadata,
+		error: error instanceof Error ? error.message : String(error),
+	})
+}
+
+export function getParlayErrorMessage(error: unknown): string {
+	const responseData = (error as { response?: { data?: unknown } })?.response
+		?.data
+	if (typeof responseData === 'object' && responseData !== null) {
+		const message = (responseData as { message?: unknown }).message
+		if (typeof message === 'string') return message
+		if (
+			Array.isArray(message) &&
+			message.every((item) => typeof item === 'string')
+		) {
+			return message.join(', ')
+		}
+	}
+	return error instanceof Error
+		? error.message
+		: 'Unable to process your parlay.'
+}

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../utils/logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getMatch: vi.fn(), getMatches: vi.fn() }
+	}),
+}))
+
+vi.mock('../../utils/api/Khronos/parlays/ParlayApiWrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getEventOutcomes: vi.fn() }
+	}),
+}))
+
+vi.mock('../../utils/cache/cache-manager.js', () => ({
+	CacheManager: vi.fn(),
+}))
+
+const {
+	PARLAY_BUILDER_MAX_LEGS,
+	PARLAY_BUILDER_TTL_SECONDS,
+	ParlayBuilderService,
+} = await import('../ParlayBuilderService.js')
+
+type CacheStub = {
+	get: ReturnType<typeof vi.fn>
+	set: ReturnType<typeof vi.fn>
+	remove: ReturnType<typeof vi.fn>
+}
+
+const makeCache = (): CacheStub => ({
+	get: vi.fn(),
+	set: vi.fn().mockResolvedValue(true),
+	remove: vi.fn().mockResolvedValue(true),
+})
+
+const makeSession = (legs = 0) => ({
+	legs: Array.from({ length: legs }, (_, index) => ({
+		event_id: `event-${index}`,
+		outcome_uuid: `outcome-${index}`,
+		market_key: 'h2h' as const,
+		selection_display: `Team ${index}`,
+		odds_american: 100,
+		point: null,
+		commence_time: '2099-01-01T00:00:00.000Z',
+	})),
+	stake: null,
+})
+
+describe('ParlayBuilderService', () => {
+	let cache: CacheStub
+	let matchCache: { getMatch: ReturnType<typeof vi.fn> }
+	let parlayApi: { getEventOutcomes: ReturnType<typeof vi.fn> }
+	let service: InstanceType<typeof ParlayBuilderService>
+
+	beforeEach(() => {
+		cache = makeCache()
+		matchCache = { getMatch: vi.fn() }
+		parlayApi = { getEventOutcomes: vi.fn() }
+		service = new ParlayBuilderService(
+			cache as never,
+			matchCache as never,
+			parlayApi as never,
+		)
+	})
+
+	it('stores one user session with the 15 minute TTL', async () => {
+		await service.start('user-1')
+
+		expect(cache.set).toHaveBeenCalledWith(
+			'parlay-builder:user-1',
+			{ legs: [], stake: null },
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	})
+
+	it('rejects duplicate events and the seventh leg', async () => {
+		cache.get.mockResolvedValue(makeSession(1))
+		await expect(
+			service.addLeg('user-1', {
+				matchId: 'event-0',
+				marketKey: 'h2h',
+				side: 'home',
+			}),
+		).rejects.toThrow('different game')
+
+		cache.get.mockResolvedValue(makeSession(PARLAY_BUILDER_MAX_LEGS))
+		await expect(
+			service.addLeg('user-1', {
+				matchId: 'event-new',
+				marketKey: 'h2h',
+				side: 'home',
+			}),
+		).rejects.toThrow('at most 6')
+	})
+
+	it('resolves a home moneyline outcome from Khronos', async () => {
+		cache.get.mockResolvedValue(makeSession())
+		matchCache.getMatch.mockResolvedValue({
+			id: 'event-1',
+			home_team: 'Home Team',
+			away_team: 'Away Team',
+			sport: 'basketball_nba',
+			commence_time: '2099-01-01T00:00:00.000Z',
+		})
+		parlayApi.getEventOutcomes.mockResolvedValue([
+			{
+				uuid: 'outcome-1',
+				market_key: 'h2h',
+				name: 'Home Team',
+				price: -110,
+			},
+		])
+
+		const result = await service.addLeg('user-1', {
+			matchId: 'event-1',
+			marketKey: 'h2h',
+			side: 'home',
+		})
+
+		expect(result.legs[0]).toMatchObject({
+			event_id: 'event-1',
+			outcome_uuid: 'outcome-1',
+			selection_display: 'Home Team',
+			odds_american: -110,
+		})
+		expect(cache.set).toHaveBeenLastCalledWith(
+			'parlay-builder:user-1',
+			expect.objectContaining({ legs: expect.any(Array) }),
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	})
+
+	it('calculates combined odds and stake-aware payout', async () => {
+		const session = {
+			...makeSession(2),
+			stake: 10,
+		}
+		const summary = service.getOddsSummary(session)
+
+		expect(summary.decimal).toBe(4)
+		expect(summary.american).toBe(300)
+		expect(summary.potentialPayout).toBe(40)
+	})
+
+	it('requires two legs and a stake before placement', () => {
+		expect(() => service.validateForPlacement(makeSession(1))).toThrow(
+			'at least 2',
+		)
+		expect(() =>
+			service.validateForPlacement({ ...makeSession(2), stake: null }),
+		).toThrow('Set a stake')
+	})
+
+	it('renders a Components V2 card with per-leg remove controls', () => {
+		const response = service.render({ ...makeSession(2), stake: 10 })
+		const container = response.components?.[0]
+		const json = (container as { toJSON: () => unknown }).toJSON()
+
+		expect(response.flags).toBeDefined()
+		expect(JSON.stringify(json)).toContain('parlay_btn_remove_0')
+		expect(JSON.stringify(json)).toContain('parlay_btn_confirm')
+	})
+})

--- a/src/utils/api/Khronos/bets/BetslipsManager.ts
+++ b/src/utils/api/Khronos/bets/BetslipsManager.ts
@@ -300,6 +300,42 @@ export class BetslipManager {
 		}
 	}
 
+	/**
+	 * Announce a successfully placed parlay through the same guild betting
+	 * channel pathway used by singles.
+	 */
+	public async announceParlayPlaced(
+		interaction: CommandInteraction | ButtonInteraction,
+		details: {
+			parlayId: string
+			legCount: number
+			stake: number
+			potentialPayout: number
+		},
+	): Promise<void> {
+		try {
+			if (!interaction.guildId) {
+				logger.warn('Cannot announce parlay - no guild context')
+				return
+			}
+
+			const publicEmbed = new EmbedBuilder()
+				.setDescription(
+					`<@${interaction.user.id}> placed a **${details.legCount}-leg parlay** for **\`$${details.stake.toFixed(2)}\`**!`,
+				)
+				.setColor(embedColors.success)
+				.setFooter({
+					text: `Potential payout: $${details.potentialPayout.toFixed(2)} • Parlay ${details.parlayId.slice(0, 8)}`,
+				})
+
+			await new GuildWrapper().sendToBettingChannel(interaction.guildId, {
+				embeds: [publicEmbed],
+			})
+		} catch (error) {
+			logger.warn('Failed to announce parlay placed', { error })
+		}
+	}
+
 	private formatBetStr(betAmount: string, payout: string, profit: string) {
 		const b = '**'
 		const formattedBetData = `${b}${betAmount}${b} -> ${b}${payout}${b}\n${b}Profit:${b} ${b}${profit}${b}`

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -1,0 +1,137 @@
+import type { AxiosRequestConfig } from 'axios'
+import { AxiosKhronosInstance } from '../../common/axios-config.js'
+
+export type ParlayMarketKey = 'h2h' | 'spreads' | 'totals'
+
+export interface ParlayLegInput {
+	event_id: string
+	outcome_uuid: string
+}
+
+export interface InitParlayRequest {
+	legs: ParlayLegInput[]
+	stake: number
+	guild_id: string
+	user_id: string
+}
+
+export interface ParlayLegPreview {
+	event_id: string
+	outcome_uuid: string
+	market_key: ParlayMarketKey
+	selection_display: string
+	odds_american: number
+	point: number | null
+	commence_time: string
+}
+
+export interface InitParlayResponse {
+	init_token: string
+	combined_odds_american: number
+	potential_payout: number
+	legs: ParlayLegPreview[]
+	expires_at: string
+}
+
+export interface PlacedParlayLeg extends ParlayLegPreview {
+	id: string
+	result: 'pending' | 'won' | 'lost' | 'push' | 'void'
+	settled_at: string | null
+}
+
+export interface ParlayResponse {
+	id: string
+	user_id: string
+	guild_id: string
+	stake: number
+	combined_odds_american: number
+	potential_payout: number
+	actual_payout: number | null
+	status: 'pending' | 'won' | 'lost' | 'push_refunded' | 'cancelled'
+	leg_count: number
+	created_at: string
+	settled_at: string | null
+	legs: PlacedParlayLeg[]
+}
+
+export interface UserParlaysResponse {
+	parlays: ParlayResponse[]
+	page: number
+	limit: number
+	total: number
+	total_pages: number
+}
+
+export interface EventOutcome {
+	uuid?: string
+	event_id?: string
+	market_key?: string
+	name?: string
+	description?: string
+	price?: number
+	point?: number | null
+	position?: string
+	outcome_type?: string
+	event_context?: {
+		commence_time?: string
+		home_team?: string
+		away_team?: string
+	}
+}
+
+export default class ParlayApiWrapper {
+	private readonly requestConfig: AxiosRequestConfig = {
+		validateStatus: (status) => status >= 200 && status < 300,
+	}
+
+	async init(payload: InitParlayRequest): Promise<InitParlayResponse> {
+		const response = await AxiosKhronosInstance.post<InitParlayResponse>(
+			'/parlays/init',
+			payload,
+			this.requestConfig,
+		)
+		return response.data
+	}
+
+	async place(initToken: string): Promise<ParlayResponse> {
+		const response = await AxiosKhronosInstance.post<ParlayResponse>(
+			'/parlays/place',
+			{ init_token: initToken },
+			this.requestConfig,
+		)
+		return response.data
+	}
+
+	async getUserParlays(
+		userId: string,
+		options: { page?: number; limit?: number; status?: string } = {},
+	): Promise<UserParlaysResponse> {
+		const response = await AxiosKhronosInstance.get<UserParlaysResponse>(
+			`/parlays/user/${encodeURIComponent(userId)}`,
+			{ ...this.requestConfig, params: options },
+		)
+		return response.data
+	}
+
+	async cancel(parlayId: string, userId: string): Promise<ParlayResponse> {
+		const response = await AxiosKhronosInstance.delete<ParlayResponse>(
+			`/parlays/${encodeURIComponent(parlayId)}`,
+			{
+				...this.requestConfig,
+				data: { user_id: userId },
+			},
+		)
+		return response.data
+	}
+
+	async getEventOutcomes(
+		sport: string,
+		eventId: string,
+	): Promise<EventOutcome[]> {
+		const response = await AxiosKhronosInstance.get<EventOutcome[]>(
+			`/outcomes/event/${encodeURIComponent(sport)}/${encodeURIComponent(eventId)}`,
+			this.requestConfig,
+		)
+		return response.data
+	}
+}

--- a/src/utils/betting/american-odds.ts
+++ b/src/utils/betting/american-odds.ts
@@ -1,0 +1,43 @@
+/**
+ * American odds helpers used while the parlay builder is running locally.
+ *
+ * Khronos remains the source of truth at init/place time. Keeping the
+ * conversion here only lets the card show a useful running estimate before
+ * the server snapshots the leg prices.
+ */
+export function americanToDecimal(american: number): number {
+	if (!Number.isFinite(american) || american === 0) {
+		throw new Error('American odds must be a non-zero finite number')
+	}
+
+	return american > 0 ? 1 + american / 100 : 1 + 100 / Math.abs(american)
+}
+
+export function decimalToAmerican(decimal: number): number {
+	if (!Number.isFinite(decimal) || decimal <= 1) {
+		throw new Error('Decimal odds must be greater than 1')
+	}
+
+	return decimal >= 2
+		? Math.round((decimal - 1) * 100)
+		: Math.round(-100 / (decimal - 1))
+}
+
+export function combineAmericanOdds(legs: number[]): {
+	american: number
+	decimal: number
+} {
+	if (legs.length === 0) {
+		throw new Error('At least one odds leg is required')
+	}
+
+	const decimal = legs.reduce(
+		(combined, leg) => combined * americanToDecimal(leg),
+		1,
+	)
+
+	return {
+		american: decimalToAmerican(decimal),
+		decimal,
+	}
+}


### PR DESCRIPTION
## Summary

Implements Linear TF-968 (C6) against `dev/parlays-props`.

- Adds `/parlay` Components V2 card with per-leg sections and remove controls.
- Adds Redis `parlay-builder:{userId}` sessions with a 15-minute TTL and 2–6 distinct-event guards.
- Adds Label-wrapped game/market/side selects and whole-dollar stake modal.
- Resolves concrete outcomes through Khronos, then calls `/parlays/init` → `/parlays/place`.
- Reuses the guild betting-channel pathway for placement announcements.
- Adds focused builder/odds tests and human-readable API failure handling.

## Verification

- `pnpm test:run` — 9 files, 64 tests passed
- `pnpm typecheck` — passed
- `pnpm build` — 203 files compiled
- `pnpm exec biome check` on changed files — passed

Khronos API client package 3.4.3 does not yet expose parlay operations, so this PR keeps the adapter at the existing Axios boundary; payloads and routes match the live Khronos `dev-parlays-props` controller. No production branch touched.

Linear: TF-968 (left In Progress pending review)