### PR TITLE
feat(parlays): integrate parlays into mybets

### DIFF
--- a/src/commands/betting/mybets.ts
+++ b/src/commands/betting/mybets.ts
@@ -36,6 +36,7 @@ export class UserCommand extends Command {
 			const historyPage = this.paginationService.getHistoryPage(
 				betsData.historyBets,
 				1,
+				betsData.historyParlays,
 			)
 			const groupedBets = this.paginationService.groupBetsByDate(
 				historyPage.bets,
@@ -44,6 +45,8 @@ export class UserCommand extends Command {
 			const displayData: MyBetsDisplayData = {
 				userId,
 				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
 				historyPage,
 				groupedBets,
 			}

--- a/src/interaction-handlers/my-bets-pagination-handler.ts
+++ b/src/interaction-handlers/my-bets-pagination-handler.ts
@@ -103,6 +103,7 @@ export class MyBetsPaginationHandler extends InteractionHandler {
 			const historyPage = this.paginationService.getHistoryPage(
 				betsData.historyBets,
 				targetPage,
+				betsData.historyParlays,
 			)
 			const groupedBets = this.paginationService.groupBetsByDate(
 				historyPage.bets,
@@ -111,6 +112,8 @@ export class MyBetsPaginationHandler extends InteractionHandler {
 			const displayData: MyBetsDisplayData = {
 				userId,
 				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
 				historyPage,
 				groupedBets,
 			}

--- a/src/interaction-handlers/parlay-cancel-handler.ts
+++ b/src/interaction-handlers/parlay-cancel-handler.ts
@@ -1,0 +1,99 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import { type ButtonInteraction } from 'discord.js'
+import {
+	type MyBetsDisplayData,
+	MyBetsFormatterService,
+} from '../utils/api/Khronos/bets/mybets-formatter.service.js'
+import { MyBetsPaginationService } from '../utils/api/Khronos/bets/mybets-pagination.service.js'
+import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+
+const parlayCancelPrefix = 'parlay_cancel_'
+
+const getParlayErrorMessage = (error: unknown): string => {
+	const data = (error as { response?: { data?: unknown } })?.response?.data
+	if (typeof data === 'object' && data !== null) {
+		const message = (data as { message?: unknown }).message
+		if (typeof message === 'string') return message
+		if (
+			Array.isArray(message) &&
+			message.every((item) => typeof item === 'string')
+		) {
+			return message.join(', ')
+		}
+	}
+	return error instanceof Error ? error.message : 'Unable to cancel parlay.'
+}
+
+export class ParlayCancelHandler extends InteractionHandler {
+	private readonly parlayApi = new ParlayApiWrapper()
+	private readonly paginationService = new MyBetsPaginationService()
+	private readonly formatterService = new MyBetsFormatterService()
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.Button,
+		})
+	}
+
+	public override async parse(interaction: ButtonInteraction) {
+		if (!interaction.customId.startsWith(parlayCancelPrefix))
+			return this.none()
+		const parlayId = interaction.customId.slice(parlayCancelPrefix.length)
+		if (!parlayId) return this.none()
+		await interaction.deferUpdate()
+		return this.some({ parlayId })
+	}
+
+	public async run(
+		interaction: ButtonInteraction,
+		payload: { parlayId: string },
+	) {
+		try {
+			await this.parlayApi.cancel(payload.parlayId, interaction.user.id)
+			const betsData = await this.paginationService.fetchUserBets(
+				interaction.user.id,
+			)
+			const historyPage = this.paginationService.getHistoryPage(
+				betsData.historyBets,
+				1,
+				betsData.historyParlays,
+			)
+			const displayData: MyBetsDisplayData = {
+				userId: interaction.user.id,
+				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
+				historyPage,
+				groupedBets: this.paginationService.groupBetsByDate(
+					historyPage.bets,
+				),
+			}
+			await interaction.editReply(
+				await this.formatterService.buildEmbedResponse(
+					displayData,
+					interaction.guild ?? undefined,
+				),
+			)
+		} catch (error) {
+			this.container.logger.error({
+				message: 'Failed to cancel parlay',
+				metadata: {
+					userId: interaction.user.id,
+					parlayId: payload.parlayId,
+					error: getParlayErrorMessage(error),
+				},
+			})
+			await interaction.editReply({
+				content: `Unable to cancel this parlay: ${getParlayErrorMessage(error)}`,
+				components: [],
+			})
+		}
+	}
+}

--- a/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
+++ b/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../betslip-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getUserBetslips: vi.fn() }
+	}),
+}))
+
+vi.mock('../../parlays/ParlayApiWrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getUserParlays: vi.fn() }
+	}),
+}))
+
+const { MyBetsFormatterService } = await import(
+	'../mybets-formatter.service.js'
+)
+const { MyBetsPaginationService } = await import(
+	'../mybets-pagination.service.js'
+)
+
+const parlay = (overrides: Record<string, unknown> = {}) => ({
+	id: 'parlay-123456',
+	user_id: 'user-1',
+	guild_id: 'guild-1',
+	stake: 10,
+	combined_odds_american: 300,
+	potential_payout: 40,
+	actual_payout: null,
+	status: 'pending' as const,
+	leg_count: 3,
+	created_at: '2026-07-11T12:00:00.000Z',
+	settled_at: null,
+	legs: [
+		{
+			id: 'leg-late',
+			event_id: 'event-late',
+			outcome_uuid: 'outcome-late',
+			market_key: 'h2h' as const,
+			selection_display: 'Late Team',
+			odds_american: 100,
+			point: null,
+			commence_time: '2026-07-13T12:00:00.000Z',
+			result: 'pending' as const,
+			settled_at: null,
+		},
+		{
+			id: 'leg-early',
+			event_id: 'event-early',
+			outcome_uuid: 'outcome-early',
+			market_key: 'totals' as const,
+			selection_display: 'Over 220.5',
+			odds_american: -110,
+			point: 220.5,
+			commence_time: '2026-07-12T12:00:00.000Z',
+			result: 'pending' as const,
+			settled_at: null,
+		},
+	],
+	...overrides,
+})
+
+describe('MyBetsFormatterService parlays', () => {
+	const formatter = new MyBetsFormatterService()
+
+	it('orders parlay legs by commence time and renders pending glyphs', () => {
+		const line = formatter.formatPendingParlayLine(parlay())
+
+		expect(line.indexOf('Over 220.5')).toBeLessThan(
+			line.indexOf('Late Team'),
+		)
+		expect(line).toContain('⏳')
+		expect(line).toContain('Odds: `+300`')
+	})
+
+	it('highlights the lost leg in resolved history and renders push as neutral', () => {
+		const line = formatter.formatHistoryParlayLine(
+			parlay({
+				status: 'lost',
+				actual_payout: 0,
+				legs: parlay().legs.map((leg, index) => ({
+					...leg,
+					result: index === 0 ? ('lost' as const) : ('push' as const),
+				})),
+			}),
+		)
+
+		expect(line).toContain('busted')
+		expect(line).toContain('❌')
+		expect(line).toContain('➖')
+	})
+
+	it('only exposes pending parlays before the earliest leg starts', () => {
+		const pending = parlay({
+			legs: parlay().legs.map((leg) => ({
+				...leg,
+				commence_time: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+		const started = parlay({
+			legs: parlay().legs.map((leg, index) => ({
+				...leg,
+				commence_time:
+					index === 0
+						? '2020-01-01T00:00:00.000Z'
+						: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+
+		expect(formatter.canCancelParlay(pending)).toBe(true)
+		expect(formatter.canCancelParlay(started)).toBe(false)
+	})
+
+	it('adds a cancel button for cancellable pending parlays', async () => {
+		const pending = parlay({
+			legs: parlay().legs.map((leg) => ({
+				...leg,
+				commence_time: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+		const response = await formatter.buildEmbedResponse({
+			userId: 'user-1',
+			pendingBets: [],
+			pendingParlays: [pending],
+			historyParlays: [],
+			historyPage: {
+				bets: [],
+				parlays: [],
+				entries: [],
+				page: 1,
+				totalPages: 1,
+			},
+			groupedBets: [],
+		})
+
+		expect(JSON.stringify(response.components)).toContain(
+			'parlay_cancel_parlay-123456',
+		)
+	})
+})
+
+describe('MyBetsPaginationService parlay history', () => {
+	it('fetches singles and parlays together', async () => {
+		const betsWrapper = {
+			getUserBetslips: vi.fn().mockResolvedValue([
+				{ betresult: 'pending', dateofbet: '2026-07-11T00:00:00.000Z' },
+				{ betresult: 'won', dateofbet: '2026-07-10T00:00:00.000Z' },
+			]),
+		}
+		const parlaysWrapper = {
+			getUserParlays: vi.fn().mockResolvedValue({
+				parlays: [
+					parlay({ status: 'pending' }),
+					parlay({ status: 'lost' }),
+				],
+			}),
+		}
+		const service = new MyBetsPaginationService(
+			betsWrapper as never,
+			parlaysWrapper as never,
+		)
+
+		const result = await service.fetchUserBets('user-1')
+		expect(result.pendingBets).toHaveLength(1)
+		expect(result.historyBets).toHaveLength(1)
+		expect(result.pendingParlays).toHaveLength(1)
+		expect(result.historyParlays).toHaveLength(1)
+	})
+
+	it('paginates singles and parlays together in date order', () => {
+		const service = new MyBetsPaginationService(
+			{ getUserBetslips: vi.fn() } as never,
+			{ getUserParlays: vi.fn() } as never,
+		)
+		const page = service.getHistoryPage(
+			[
+				{
+					dateofbet: '2026-07-10T00:00:00.000Z',
+				} as never,
+			],
+			1,
+			[
+				parlay({
+					created_at: '2026-07-11T00:00:00.000Z',
+					status: 'lost',
+				}),
+			],
+		)
+
+		expect(page.entries).toHaveLength(2)
+		expect(page.entries[0]?.kind).toBe('parlay')
+		expect(page.entries[1]?.kind).toBe('bet')
+	})
+})

--- a/src/utils/api/Khronos/bets/mybets-formatter.service.ts
+++ b/src/utils/api/Khronos/bets/mybets-formatter.service.ts
@@ -17,11 +17,14 @@ import {
 	buildMyBetsNavCustomId,
 	mybetsNavPageId,
 } from '../../../../lib/interfaces/interaction-handlers/interaction-handlers.interface.js'
+import type { UserParlay } from '../parlays/ParlayApiWrapper.js'
 import type { BetsByDate, HistoryPage } from './mybets-pagination.service.js'
 
 export interface MyBetsDisplayData {
 	userId: string
 	pendingBets: PlacedBetslip[]
+	pendingParlays: UserParlay[]
+	historyParlays: UserParlay[]
 	historyPage: HistoryPage
 	groupedBets: BetsByDate[]
 }
@@ -73,6 +76,61 @@ export class MyBetsFormatterService {
 		return `${teamEmoji} ${shortName}`.trim()
 	}
 
+	private getParlayLegGlyph(
+		result: UserParlay['legs'][number]['result'],
+	): string {
+		switch (result) {
+			case 'won':
+				return '✅'
+			case 'lost':
+				return '❌'
+			case 'push':
+			case 'void':
+				return '➖'
+			default:
+				return '⏳'
+		}
+	}
+
+	private formatParlayLegs(parlay: UserParlay): string {
+		return [...parlay.legs]
+			.sort(
+				(a, b) =>
+					new Date(a.commence_time).getTime() -
+					new Date(b.commence_time).getTime(),
+			)
+			.map((leg) => {
+				const busted = parlay.status === 'lost' && leg.result === 'lost'
+				return `${this.getParlayLegGlyph(leg.result)} ${busted ? `**${leg.selection_display} (busted)**` : leg.selection_display} • ${leg.market_key} • <t:${Math.floor(new Date(leg.commence_time).getTime() / 1000)}:d>`
+			})
+			.join('\n')
+	}
+
+	formatPendingParlayLine(parlay: UserParlay): string {
+		return `**🎲 ${parlay.leg_count}-leg Parlay**\nStake: \`$${Number(parlay.stake).toFixed(2)}\` • Odds: \`${parlay.combined_odds_american > 0 ? '+' : ''}${parlay.combined_odds_american}\` • Potential: \`$${Number(parlay.potential_payout).toFixed(2)}\`\n${this.formatParlayLegs(parlay)}`
+	}
+
+	formatHistoryParlayLine(parlay: UserParlay): string {
+		const payout =
+			parlay.actual_payout === null
+				? 'N/A'
+				: `$${Number(parlay.actual_payout).toFixed(2)}`
+		const status = parlay.status.replace('_', ' ')
+		return `**${parlay.status === 'won' ? '✅' : parlay.status === 'lost' ? '❌' : '➖'} ${parlay.leg_count}-leg Parlay — ${status}**\nStake: \`$${Number(parlay.stake).toFixed(2)}\` • Actual payout: \`${payout}\`\n${this.formatParlayLegs(parlay)}`
+	}
+
+	canCancelParlay(parlay: UserParlay, now = Date.now()): boolean {
+		return (
+			parlay.status === 'pending' &&
+			parlay.legs.length > 0 &&
+			Math.min(
+				...parlay.legs.map((leg) =>
+					new Date(leg.commence_time).getTime(),
+				),
+			) > now
+		)
+	}
+
 	formatPendingBetLine(bet: PlacedBetslip, guild?: Guild): string {
 		const team = this.formatTeamName(bet.team ?? 'Unknown', guild)
 		const amount = this.formatMoney(bet.amount)
@@ -111,18 +169,24 @@ export class MyBetsFormatterService {
 	async buildPendingEmbed(
 		pendingBets: PlacedBetslip[],
 		guild?: Guild,
+		pendingParlays: UserParlay[] = [],
 	): Promise<EmbedBuilder> {
 		const embed = new EmbedBuilder()
 			.setTitle('⏳ Pending Bets')
 			.setColor(embedColors.PlutoYellow)
 
-		if (pendingBets.length === 0) {
+		if (pendingBets.length === 0 && pendingParlays.length === 0) {
 			embed.setDescription('You have no pending bets.')
 			return embed
 		}
 
 		const lines = pendingBets.map((bet) =>
 			this.formatPendingBetLine(bet, guild),
+		)
+		lines.push(
+			...pendingParlays.map((parlay) =>
+				this.formatPendingParlayLine(parlay),
+			),
 		)
 		embed.setDescription(lines.join('\n\n'))
 		return embed
@@ -150,6 +214,9 @@ export class MyBetsFormatterService {
 			for (const bet of group.bets) {
 				lines.push(this.formatHistoryBetLine(bet, guild))
 			}
+		}
+		for (const parlay of historyPage.parlays) {
+			lines.push(this.formatHistoryParlayLine(parlay))
 		}
 
 		embed.setDescription(lines.join('\n\n'))
@@ -199,7 +266,7 @@ export class MyBetsFormatterService {
 		)
 
 		// Pending Bets Section
-		if (data.pendingBets.length > 0) {
+		if (data.pendingBets.length > 0 || data.pendingParlays.length > 0) {
 			container.addTextDisplayComponents((text) =>
 				text.setContent('## ⏳ Pending Bets'),
 			)
@@ -207,6 +274,11 @@ export class MyBetsFormatterService {
 			for (const bet of data.pendingBets) {
 				container.addTextDisplayComponents((text) =>
 					text.setContent(this.formatPendingBetLine(bet, guild)),
+				)
+			}
+			for (const parlay of data.pendingParlays) {
+				container.addTextDisplayComponents((text) =>
+					text.setContent(this.formatPendingParlayLine(parlay)),
 				)
 			}
 
@@ -222,7 +294,10 @@ export class MyBetsFormatterService {
 			),
 		)
 
-		if (data.historyPage.bets.length === 0) {
+		if (
+			data.historyPage.bets.length === 0 &&
+			data.historyPage.parlays.length === 0
+		) {
 			container.addTextDisplayComponents((text) =>
 				text.setContent(
 					'*No bet history found. Place some bets to see them here!*',
@@ -238,6 +313,11 @@ export class MyBetsFormatterService {
 						text.setContent(this.formatHistoryBetLine(bet, guild)),
 					)
 				}
+			}
+			for (const parlay of data.historyPage.parlays) {
+				container.addTextDisplayComponents((text) =>
+					text.setContent(this.formatHistoryParlayLine(parlay)),
+				)
 			}
 		}
 
@@ -267,6 +347,7 @@ export class MyBetsFormatterService {
 		const pendingEmbed = await this.buildPendingEmbed(
 			data.pendingBets,
 			guild,
+			data.pendingParlays,
 		)
 		embeds.push(pendingEmbed)
 
@@ -285,6 +366,21 @@ export class MyBetsFormatterService {
 				this.buildPaginationButtons(
 					data.historyPage.page,
 					data.historyPage.totalPages,
+				),
+			)
+		}
+		const cancellable = data.pendingParlays.filter((parlay) =>
+			this.canCancelParlay(parlay),
+		)
+		for (let index = 0; index < cancellable.length; index += 5) {
+			components.push(
+				new ActionRowBuilder<ButtonBuilder>().addComponents(
+					...cancellable.slice(index, index + 5).map((parlay) =>
+						new ButtonBuilder()
+							.setCustomId(`parlay_cancel_${parlay.id}`)
+							.setLabel(`Cancel ${parlay.id.slice(0, 6)}`)
+							.setStyle(ButtonStyle.Danger),
+					),
 				),
 			)
 		}

--- a/src/utils/api/Khronos/bets/mybets-pagination.service.ts
+++ b/src/utils/api/Khronos/bets/mybets-pagination.service.ts
@@ -2,16 +2,27 @@ import type { PlacedBetslip } from '@pluto-khronos/api-client'
 import { PlacedBetslipBetresultEnum } from '@pluto-khronos/api-client'
 import { format, isValid, parseISO } from 'date-fns'
 import { logger } from '../../../logging/WinstonLogger.js'
+import ParlayApiWrapper, {
+	type UserParlay,
+} from '../parlays/ParlayApiWrapper.js'
 import BetslipWrapper from './betslip-wrapper.js'
 
 export interface MyBetsData {
 	pendingBets: PlacedBetslip[]
 	historyBets: PlacedBetslip[]
+	pendingParlays: UserParlay[]
+	historyParlays: UserParlay[]
 	totalPages: number
 }
 
+export type HistoryEntry =
+	| { kind: 'bet'; bet: PlacedBetslip }
+	| { kind: 'parlay'; parlay: UserParlay }
+
 export interface HistoryPage {
 	bets: PlacedBetslip[]
+	parlays: UserParlay[]
+	entries: HistoryEntry[]
 	page: number
 	totalPages: number
 }
@@ -24,27 +35,65 @@ export interface BetsByDate {
 export class MyBetsPaginationService {
 	private readonly PAGE_SIZE = 10
 	private betslipWrapper: BetslipWrapper
+	private parlayWrapper: ParlayApiWrapper
 
-	constructor(betslipWrapper?: BetslipWrapper) {
+	constructor(
+		betslipWrapper?: BetslipWrapper,
+		parlayWrapper?: ParlayApiWrapper,
+	) {
 		this.betslipWrapper = betslipWrapper ?? new BetslipWrapper()
+		this.parlayWrapper = parlayWrapper ?? new ParlayApiWrapper()
 	}
 
 	async fetchUserBets(userId: string): Promise<MyBetsData> {
 		try {
-			const allBets = await this.betslipWrapper.getUserBetslips({
-				userid: userId,
-			})
+			const [betsResult, parlaysResult] = await Promise.allSettled([
+				this.betslipWrapper.getUserBetslips({ userid: userId }),
+				this.parlayWrapper.getUserParlays(userId, { limit: 100 }),
+			])
+			if (betsResult.status === 'rejected') throw betsResult.reason
+			const allBets = betsResult.value
+			const parlayResponse =
+				parlaysResult.status === 'fulfilled'
+					? parlaysResult.value
+					: { parlays: [] }
+			if (parlaysResult.status === 'rejected') {
+				logger.warn(
+					'Failed to fetch user parlays; showing singles only',
+					{
+						source: this.fetchUserBets.name,
+						userId,
+						error:
+							parlaysResult.reason instanceof Error
+								? parlaysResult.reason.message
+								: String(parlaysResult.reason),
+					},
+				)
+			}
 
 			const { pending, history } = this.splitBetsByStatus(allBets)
+			const pendingParlays = parlayResponse.parlays.filter(
+				(parlay) => parlay.status === 'pending',
+			)
+			const historyParlays = parlayResponse.parlays.filter(
+				(parlay) => parlay.status !== 'pending',
+			)
 			const sortedHistory = this.sortByDateDesc(history)
+			const sortedHistoryParlays =
+				this.sortParlaysByDateDesc(historyParlays)
 			const totalPages = Math.max(
 				1,
-				Math.ceil(sortedHistory.length / this.PAGE_SIZE),
+				Math.ceil(
+					(sortedHistory.length + sortedHistoryParlays.length) /
+						this.PAGE_SIZE,
+				),
 			)
 
 			return {
 				pendingBets: pending,
 				historyBets: sortedHistory,
+				pendingParlays,
+				historyParlays: sortedHistoryParlays,
 				totalPages,
 			}
 		} catch (error) {
@@ -86,17 +135,51 @@ export class MyBetsPaginationService {
 		})
 	}
 
-	getHistoryPage(historyBets: PlacedBetslip[], page: number): HistoryPage {
+	private sortParlaysByDateDesc(parlays: UserParlay[]): UserParlay[] {
+		return [...parlays].sort(
+			(a, b) =>
+				new Date(b.created_at).getTime() -
+				new Date(a.created_at).getTime(),
+		)
+	}
+
+	getHistoryPage(
+		historyBets: PlacedBetslip[],
+		page: number,
+		historyParlays: UserParlay[] = [],
+	): HistoryPage {
+		const entries: HistoryEntry[] = [
+			...historyBets.map((bet) => ({ kind: 'bet' as const, bet })),
+			...historyParlays.map((parlay) => ({
+				kind: 'parlay' as const,
+				parlay,
+			})),
+		].sort((a, b) => {
+			const dateA =
+				a.kind === 'bet' ? a.bet.dateofbet : a.parlay.created_at
+			const dateB =
+				b.kind === 'bet' ? b.bet.dateofbet : b.parlay.created_at
+			return (
+				new Date(dateB ?? 0).getTime() - new Date(dateA ?? 0).getTime()
+			)
+		})
 		const totalPages = Math.max(
 			1,
-			Math.ceil(historyBets.length / this.PAGE_SIZE),
+			Math.ceil(entries.length / this.PAGE_SIZE),
 		)
 		const clampedPage = Math.max(1, Math.min(page, totalPages))
 		const start = (clampedPage - 1) * this.PAGE_SIZE
 		const end = start + this.PAGE_SIZE
+		const pageEntries = entries.slice(start, end)
 
 		return {
-			bets: historyBets.slice(start, end),
+			bets: pageEntries.flatMap((entry) =>
+				entry.kind === 'bet' ? [entry.bet] : [],
+			),
+			parlays: pageEntries.flatMap((entry) =>
+				entry.kind === 'parlay' ? [entry.parlay] : [],
+			),
+			entries: pageEntries,
 			page: clampedPage,
 			totalPages,
 		}

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -135,3 +135,8 @@ export default class ParlayApiWrapper {
 		return response.data
 	}
 }
+
+/** Alias used by mybets surfaces (TF-969). */
+export type UserParlay = ParlayResponse
+/** Alias used by mybets leg formatting (TF-969). */
+export type ParlayLeg = PlacedParlayLeg

--- a/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
+++ b/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const get = vi.fn()
+const del = vi.fn()
+
+vi.mock('../../../common/axios-config.js', () => ({
+	AxiosKhronosInstance: { get, delete: del },
+}))
+
+const { default: ParlayApiWrapper } = await import('../ParlayApiWrapper.js')
+
+describe('ParlayApiWrapper', () => {
+	it('fetches user parlays with pagination parameters', async () => {
+		get.mockResolvedValueOnce({ data: { parlays: [], page: 2 } })
+
+		const result = await new ParlayApiWrapper().getUserParlays('user/1', {
+			page: 2,
+			limit: 25,
+			status: 'pending',
+		})
+
+		expect(result.parlays).toEqual([])
+		expect(get).toHaveBeenCalledWith(
+			'/parlays/user/user%2F1',
+			expect.objectContaining({
+				params: { page: 2, limit: 25, status: 'pending' },
+			}),
+		)
+	})
+
+	it('cancels a parlay with an ownership payload', async () => {
+		del.mockResolvedValueOnce({
+			data: { id: 'parlay-1', status: 'cancelled' },
+		})
+
+		await new ParlayApiWrapper().cancel('parlay/1', 'user-1')
+
+		expect(del).toHaveBeenCalledWith(
+			'/parlays/parlay%2F1',
+			expect.objectContaining({ data: { user_id: 'user-1' } }),
+		)
+	})
+})


### PR DESCRIPTION
## Summary

Implements Linear TF-969 (C7) against `dev/parlays-props`.

- Fetches user parlays alongside singles through a dedicated Khronos adapter.
- Paginates combined history records by creation time without changing singles behavior.
- Renders pending/history parlay sections with ordered leg glyphs, odds, stake, potential/actual payout, and busted-leg highlighting.
- Adds cancellation-window aware `parlay_cancel_*` buttons and a Sapphire handler calling `DELETE /parlays/:id` with ownership.
- Adds graceful singles-only fallback when the parlay list endpoint is unavailable.
- Adds focused wrapper, formatter, pagination, and cancel-window tests.

## Verification

- `pnpm test:run` — 10 files, 67 tests passed
- `pnpm typecheck` — passed
- `pnpm build` — 200 files compiled
- Changed-file Biome — passed

Khronos API client package 3.4.3 does not yet expose parlay operations, so this PR keeps the adapter at the existing Axios boundary; routes match the live Khronos `dev-parlays-props` controller. No production branch touched.

Linear: TF-969 (left In Progress pending review)