### PR TITLE
feat(props): return daily message references (TF-970)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"@koa/cors": "^5.0.0",
 		"@koa/router": "^15.5.0",
 		"@pluto-khronos/api-client": "3.4.3",
-		"@pluto-khronos/types": "3.4.3",
+		"@pluto-khronos/types": "3.5.1",
 		"@sapphire/decorators": "^6.1.1",
 		"@sapphire/discord-utilities": "^4.0.0",
 		"@sapphire/discord.js-utilities": "^7.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 3.4.3
         version: 3.4.3
       '@pluto-khronos/types':
-        specifier: 3.4.3
-        version: 3.4.3(discord.js@14.26.3)
+        specifier: 3.5.1
+        version: 3.5.1(discord.js@14.26.3)
       '@sapphire/decorators':
         specifier: ^6.1.1
         version: 6.2.0
@@ -1842,8 +1842,8 @@ packages:
   '@pluto-khronos/api-client@3.4.3':
     resolution: {integrity: sha512-5r387yyxvpmJpbq+3K+OGHrEEo7VrYftTm94TCFz0AdypLIU5YxMpW2B8wVXcfCQwS+WFNtYRPtkr+bacx45dg==}
 
-  '@pluto-khronos/types@3.4.3':
-    resolution: {integrity: sha512-nbpTwpFuInMAqs+3aswc7kD0Gwpumrr1jjpdPwO0Or+pyi3dvRh5Wusd4c4W5HYRhKc7L6Mln9VlmYCfVaaLLg==}
+  '@pluto-khronos/types@3.5.1':
+    resolution: {integrity: sha512-yRV2ckWCVAGlOcb42ugy6/77LNSlnFvwBWS17jA3i9Jup1j6ruLUeFvKwfe7qEcc5XMUognWwhcp0ZpjdqwXAg==}
     peerDependencies:
       discord.js: ^14.0.0
 
@@ -8705,7 +8705,7 @@ snapshots:
 
   '@pluto-khronos/api-client@3.4.3': {}
 
-  '@pluto-khronos/types@3.4.3(discord.js@14.26.3)':
+  '@pluto-khronos/types@3.5.1(discord.js@14.26.3)':
     dependencies:
       discord.js: 14.26.3
       resolve-team: 2.0.4

--- a/src/commands/betting/mybets.ts
+++ b/src/commands/betting/mybets.ts
@@ -36,6 +36,7 @@ export class UserCommand extends Command {
 			const historyPage = this.paginationService.getHistoryPage(
 				betsData.historyBets,
 				1,
+				betsData.historyParlays,
 			)
 			const groupedBets = this.paginationService.groupBetsByDate(
 				historyPage.bets,
@@ -44,6 +45,8 @@ export class UserCommand extends Command {
 			const displayData: MyBetsDisplayData = {
 				userId,
 				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
 				historyPage,
 				groupedBets,
 			}

--- a/src/commands/betting/parlay.ts
+++ b/src/commands/betting/parlay.ts
@@ -1,0 +1,52 @@
+import { ApplyOptions } from '@sapphire/decorators'
+import { Command } from '@sapphire/framework'
+import { InteractionContextType, MessageFlags } from 'discord.js'
+import { ParlayBuilderService } from '../../services/ParlayBuilderService.js'
+import { ErrorEmbeds } from '../../utils/common/errors/global.js'
+
+@ApplyOptions<Command.Options>({
+	description: '🎲 Build a multi-game parlay',
+})
+export class UserCommand extends Command {
+	private builderService?: ParlayBuilderService
+
+	private getService(): ParlayBuilderService {
+		return (this.builderService ??= new ParlayBuilderService())
+	}
+
+	public override registerApplicationCommands(registry: Command.Registry) {
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName(this.name)
+				.setDescription(this.description)
+				.setContexts(InteractionContextType.Guild),
+		)
+	}
+
+	public override async chatInputRun(
+		interaction: Command.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral })
+		try {
+			const service = this.getService()
+			const session = await service.start(interaction.user.id)
+			return interaction.editReply(service.render(session))
+		} catch (error) {
+			this.container.logger.error({
+				message: 'Failed to start parlay builder',
+				metadata: {
+					userId: interaction.user.id,
+					error:
+						error instanceof Error ? error.message : String(error),
+				},
+			})
+			return interaction.editReply({
+				embeds: [
+					await ErrorEmbeds.internalErr(
+						'Unable to start your parlay. Please try again.',
+					),
+				],
+			})
+		}
+	}
+}

--- a/src/commands/predictions/__tests__/predictions.test.ts
+++ b/src/commands/predictions/__tests__/predictions.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetLeaderboard = vi.fn()
+const mockGetActivePredictionsForUser = vi.fn()
+
+vi.mock(
+	'../../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js',
+	() => ({
+		default: vi.fn().mockImplementation(function () {
+			return { getLeaderboard: mockGetLeaderboard }
+		}),
+	}),
+)
+
+vi.mock(
+	'../../../utils/api/Khronos/prediction/predictionApiWrapper.js',
+	() => ({
+		default: vi.fn().mockImplementation(function () {
+			return {
+				getActivePredictionsForUser: mockGetActivePredictionsForUser,
+			}
+		}),
+	}),
+)
+
+vi.mock('../../../utils/api/Khronos/props/props-api-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getPropByUuid: vi.fn() }
+	}),
+}))
+
+vi.mock('../../../utils/common/TeamInfo.js', () => ({
+	default: {
+		resolveTeamIdentifier: vi.fn().mockResolvedValue({
+			away_team: 'AWY',
+			home_team: 'HME',
+		}),
+	},
+}))
+
+vi.mock('../../../utils/bot_res/ClientTools.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { resolveMember: vi.fn() }
+	}),
+}))
+
+vi.mock('@sapphire/discord.js-utilities', () => ({
+	PaginatedMessageEmbedFields: vi.fn().mockImplementation(function () {
+		return {
+			setItems: vi.fn().mockReturnThis(),
+			setItemsPerPage: vi.fn().mockReturnThis(),
+			make: vi.fn().mockReturnValue({ run: vi.fn() }),
+		}
+	}),
+}))
+
+const { SlashCommandBuilder } = await import('discord.js')
+const { UserCommand } = await import('../predictions.js')
+
+function makeInteraction() {
+	return {
+		guildId: 'guild-1',
+		user: { id: 'user-1', username: 'Fenix' },
+		deferReply: vi.fn().mockResolvedValue(undefined),
+		editReply: vi.fn().mockResolvedValue(undefined),
+		options: {
+			getUser: vi.fn().mockReturnValue(null),
+			getString: vi.fn().mockReturnValue(null),
+		},
+	}
+}
+
+describe('/predictions', () => {
+	let command: InstanceType<typeof UserCommand>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		command = Object.create(UserCommand.prototype) as InstanceType<
+			typeof UserCommand
+		>
+		Object.defineProperty(command, 'container', {
+			configurable: true,
+			value: { logger: { error: vi.fn(), warn: vi.fn() } },
+		})
+	})
+
+	it('registers guild-only history, stats, and leaderboard subcommands', () => {
+		const registry = {
+			registerChatInputCommand: vi.fn(),
+		}
+		Object.defineProperties(command, {
+			name: { configurable: true, value: 'predictions' },
+			description: {
+				configurable: true,
+				value: 'View prediction history, stats, and leaderboard',
+			},
+		})
+
+		command.registerApplicationCommands(registry as never)
+
+		expect(registry.registerChatInputCommand).toHaveBeenCalledTimes(1)
+		const [builder, options] =
+			registry.registerChatInputCommand.mock.calls[0]
+		const json = builder(new SlashCommandBuilder()).toJSON()
+
+		expect(json.name).toBe('predictions')
+		expect(json.contexts).toEqual([0])
+		expect(json.options?.map((option) => option.name)).toEqual([
+			'history',
+			'stats',
+			'leaderboard',
+		])
+		expect(options.idHints).toEqual(['1298280482123026537'])
+	})
+
+	it('renders server-calculated stats and pending count', async () => {
+		mockGetLeaderboard.mockResolvedValue({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+				},
+			],
+			total_users: 1,
+		})
+		mockGetActivePredictionsForUser.mockResolvedValue([
+			{ id: 'pending-1', guild_id: 'guild-1' },
+			{ id: 'pending-2', guild_id: 'guild-1' },
+		])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(mockGetLeaderboard).toHaveBeenCalledWith({ guildId: 'guild-1' })
+		expect(mockGetActivePredictionsForUser).toHaveBeenCalledWith({
+			userId: 'user-1',
+		})
+		const [{ embeds }] = interaction.editReply.mock.calls.find(
+			([payload]) => payload.embeds,
+		) as [{ embeds: Array<{ toJSON: () => unknown }> }]
+		const embed = embeds[0].toJSON() as {
+			title?: string
+			description?: string
+			fields?: unknown[]
+		}
+		expect(embed.title).toBe('📊 Prediction Statistics')
+		expect(embed.description).toContain('Server stats')
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'Total Predictions',
+					value: '`12`',
+				}),
+				expect.objectContaining({ name: 'Win Rate', value: '`75.0%`' }),
+				expect.objectContaining({ name: '⏳ Pending', value: '`2`' }),
+			]),
+		)
+	})
+
+	it('returns friendly empty copy when server stats and pending data are empty', async () => {
+		mockGetLeaderboard.mockResolvedValue({ entries: [], total_users: 0 })
+		mockGetActivePredictionsForUser.mockResolvedValue([])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			content: "You haven't made any predictions yet.",
+		})
+	})
+
+	it('does not count pending predictions from another guild', async () => {
+		mockGetLeaderboard.mockResolvedValue({ entries: [], total_users: 0 })
+		mockGetActivePredictionsForUser.mockResolvedValue([
+			{ id: 'pending-other-guild', guild_id: 'guild-2' },
+		])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			content: "You haven't made any predictions yet.",
+		})
+	})
+})

--- a/src/commands/predictions/history.ts
+++ b/src/commands/predictions/history.ts
@@ -1,233 +1,31 @@
-import {
-	type AllUserPredictionsDto,
-	GetAllPredictionsFilteredStatusEnum,
-} from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
-import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
 import { Command } from '@sapphire/framework'
-import type { User } from 'discord.js'
-import { EmbedBuilder, InteractionContextType } from 'discord.js'
-import _ from 'lodash'
-import embedColors from '../../lib/colorsConfig.js'
-import { MarketKeyAbbreviations } from '../../utils/api/common/interfaces/market-abbreviations.js'
-import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
-import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
-import { DateManager } from '../../utils/common/DateManager.js'
-import TeamInfo from '../../utils/common/TeamInfo.js'
+import { InteractionContextType } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
+/**
+ * @deprecated Use /predictions history. Kept for one release as a pointer.
+ */
 @ApplyOptions<Command.Options>({
-	description: 'View your prediction history',
+	description: 'View your prediction history (legacy alias)',
 })
 export class UserCommand extends Command {
-	private readonly dateManager = new DateManager()
-
-	public constructor(context: Command.Context, options: Command.Options) {
-		super(context, {
-			...options,
-			description: 'View your prediction history.',
-		})
-	}
-
 	public override registerApplicationCommands(registry: Command.Registry) {
-		registry.registerChatInputCommand(
-			(builder) =>
-				builder //
-					.setName(this.name)
-					.setDescription(this.description)
-					.setContexts(InteractionContextType.Guild)
-					.addUserOption((option) =>
-						option
-							.setName('user')
-							.setDescription(
-								'[Optional] The user to view history for (default: yourself)',
-							)
-							.setRequired(false),
-					)
-					.addStringOption((option) =>
-						option
-							.setName('status')
-							.setDescription(
-								'[Optional] Filter predictions by status',
-							)
-							.setRequired(false)
-							.addChoices(
-								{
-									name: 'Pending',
-									value: GetAllPredictionsFilteredStatusEnum.Pending,
-								},
-								{
-									name: 'Completed',
-									value: GetAllPredictionsFilteredStatusEnum.Completed,
-								},
-							),
-					),
-			{ idHints: ['1298280482123026536'] },
+		// No id hint: the former history hint was shared with /prediction.
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName(this.name)
+				.setDescription(this.description)
+				.setContexts(InteractionContextType.Guild),
 		)
 	}
 
 	public override async chatInputRun(
 		interaction: Command.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const user = interaction.options.getUser('user') || interaction.user
-		const status = interaction.options.getString(
-			'status',
-		) as GetAllPredictionsFilteredStatusEnum | null
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions = await (status
-				? predictionApiWrapper.getPredictionsFiltered({
-						userId: user.id,
-						status,
-					})
-				: predictionApiWrapper.getPredictionsForUser({
-						userId: user.id,
-					}))
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: 'No predictions found for the specified criteria.',
-				})
-			}
-			const descStr = status ? `Filtered by: \`${status}\`` : null
-			const templateEmbed = new EmbedBuilder()
-				.setTitle(`Prediction History | ${user.username}`)
-				.setDescription(descStr)
-				.setColor(embedColors.PlutoBlue)
-
-			const propsApiWrapper = new PropsApiWrapper()
-			let hadFormattingFailures = false
-			const formattedPredictions = (
-				await Promise.allSettled(
-					usersPredictions.map((prediction) =>
-						this.createPredictionField(prediction, propsApiWrapper),
-					),
-				)
-			).flatMap((result, index) => {
-				if (result.status === 'fulfilled') {
-					return result.value ? [result.value] : []
-				}
-				hadFormattingFailures = true
-				const prediction = usersPredictions[index]
-				this.container.logger.error(
-					`Failed to create prediction field for prediction ${prediction?.id || 'unknown'} (user: ${user.id})`,
-					result.reason,
-				)
-				return []
-			})
-
-			if (formattedPredictions.length === 0) {
-				const baseDescription = descStr ? `${descStr}\n\n` : ''
-				const message = hadFormattingFailures
-					? 'We were unable to load details for your predictions. Please try again later.'
-					: 'No prediction history found. Your predictions will appear here once you make them.'
-
-				templateEmbed.setDescription(baseDescription + message)
-				return interaction.editReply({ embeds: [templateEmbed] })
-			}
-
-			const paginatedMsg = new PaginatedMessageEmbedFields({
-				template: { embeds: [templateEmbed] },
-			})
-				.setItems(formattedPredictions)
-				.setItemsPerPage(10)
-				.make()
-
-			await paginatedMsg.run(interaction)
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content:
-					'An error occurred while fetching the prediction history.',
-			})
-		}
-	}
-
-	private async createPredictionField(
-		prediction: AllUserPredictionsDto,
-		propsApiWrapper: PropsApiWrapper,
-	): Promise<{ name: string; value: string; inline: boolean } | null> {
-		const outcomeEmoji = this.getOutcomeEmoji(prediction)
-		const parsedMatchString = await this.parseMatchString(
-			prediction.match_string,
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions history',
 		)
-		const parsedChoice = this.parseChoice(prediction.choice)
-		const prop = await propsApiWrapper.getPropByUuid(
-			prediction.outcome_uuid,
-		)
-		const outcome = prop.outcomes.find(
-			(o) => o.outcome_uuid === prediction.outcome_uuid,
-		)
-		if (!outcome) {
-			this.container.logger.warn(
-				`Missing outcome for prediction ${prediction.id} (market_key: ${prop.market_key}, outcome_uuid: ${prediction.outcome_uuid})`,
-			)
-			return null
-		}
-		const { market_key } = prop
-		const point = outcome.point ?? null
-		let parsedMarketKey = MarketKeyAbbreviations[market_key] || market_key
-		parsedMarketKey = _.startCase(parsedMarketKey)
-		const outcomeStr = (emoji: string) => {
-			if (emoji === '⏳') {
-				return 'Pending ⏳'
-			}
-			if (emoji === '✅') {
-				return 'Correct ✅'
-			}
-			if (emoji === '❌') {
-				return 'Incorrect ❌'
-			}
-			return emoji
-		}
-		const date = this.dateManager.toMMDDYYYY(
-			prop.event_context.commence_time,
-		)
-		const pointText = point ?? ''
-		const formattedChoice =
-			pointText === ''
-				? `\`${parsedChoice}\``
-				: `\`${parsedChoice} ${pointText}\``
-		let value = `**Date**: ${date}\n**Status**: ${outcomeStr(outcomeEmoji)}\n**Choice**: ${formattedChoice}\n**Market**: ${parsedMarketKey} `
-
-		if (prediction.description && prediction.description.trim() !== '') {
-			value += `\n**Player:** ${prediction.description}`
-		}
-
-		return {
-			name: `${parsedMatchString}`,
-			value: value,
-			inline: false,
-		}
-	}
-
-	private getOutcomeEmoji(prediction: AllUserPredictionsDto): string {
-		if (
-			prediction.status !== GetAllPredictionsFilteredStatusEnum.Completed
-		) {
-			return '⏳'
-		}
-		if (prediction.is_correct === null) {
-			return '⏳'
-		}
-		return prediction?.is_correct ? '✅' : '❌'
-	}
-
-	private async parseMatchString(matchString: string) {
-		const [awayTeam, homeTeam] = matchString.split(' vs. ')
-		if (!awayTeam || !homeTeam) {
-			return matchString
-		}
-		const result = await TeamInfo.resolveTeamIdentifier({
-			away_team: awayTeam,
-			home_team: homeTeam,
-		})
-
-		return `${result.away_team} vs. ${result.home_team}`
-	}
-	private parseChoice(choice: string) {
-		return choice.charAt(0).toUpperCase() + choice.slice(1).toLowerCase()
 	}
 }

--- a/src/commands/predictions/prediction-leaderboard.ts
+++ b/src/commands/predictions/prediction-leaderboard.ts
@@ -1,16 +1,13 @@
-import type { SimpleLeaderboardResponseDto } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
 import { Command } from '@sapphire/framework'
-import { EmbedBuilder, InteractionContextType, type Message } from 'discord.js'
-import _ from 'lodash'
-import embedColors from '../../lib/colorsConfig.js'
-import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
-import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
-import ClientTools from '../../utils/bot_res/ClientTools.js'
-import Pagination from '../../utils/embeds/pagination.js'
+import { InteractionContextType } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
+/**
+ * @deprecated Use /predictions leaderboard. Kept for one release as a pointer.
+ */
 @ApplyOptions<Command.Options>({
-	description: 'View the leaderboard for accuracy challenge',
+	description: 'View the prediction leaderboard (legacy alias)',
 })
 export class UserCommand extends Command {
 	public override registerApplicationCommands(registry: Command.Registry) {
@@ -20,255 +17,16 @@ export class UserCommand extends Command {
 					.setName('accuracy_leaderboard')
 					.setDescription(this.description)
 					.setContexts([InteractionContextType.Guild]),
-			{
-				idHints: ['1297933995123933225'],
-			},
+			{ idHints: ['1297933995123933225'] },
 		)
 	}
 
 	public override async chatInputRun(
 		interaction: Command.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply()
-
-		try {
-			const guildId = interaction.guildId
-
-			await interaction.editReply({
-				content: 'Fetching leaderboard data...',
-			})
-
-			const leaderboardWrapper = new LeaderboardWrapper()
-			const leaderboard = await leaderboardWrapper.getLeaderboard({
-				guildId,
-			})
-
-			if (!leaderboard || _.isEmpty(leaderboard.entries)) {
-				return interaction.editReply({
-					content: 'No leaderboard data found.',
-				})
-			}
-
-			await this.container.logger.info({
-				leaderboardEntries: leaderboard.entries.length,
-			})
-
-			await interaction.editReply({
-				content: 'Processing leaderboard data...',
-			})
-
-			const thumbnail = interaction.guild?.iconURL({ extension: 'png' })
-			const parsedLeaderboard = this.parseLeaderboardData(leaderboard)
-
-			const embed = await this.createLeaderboardEmbed({
-				leaderboardData: parsedLeaderboard,
-				currentPage: 1,
-				metadata: { thumbnail },
-			})
-
-			const pagination = new Pagination()
-			const components = pagination.createPaginationButtons(
-				1,
-				Math.ceil(parsedLeaderboard.length / 20),
-			)
-
-			const reply = await interaction.editReply({
-				content: null,
-				embeds: [embed],
-				components,
-			})
-
-			await this.handlePagination(interaction, reply, parsedLeaderboard)
-		} catch (error) {
-			if (error instanceof EmptyDataException) {
-				return interaction.editReply({
-					content: error.message,
-				})
-			}
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching the leaderboard.',
-			})
-		}
-	}
-
-	private parseLeaderboardData(
-		leaderboardData: SimpleLeaderboardResponseDto,
-	): ParsedLeaderboardEntry[] {
-		if (!leaderboardData.entries || leaderboardData.entries.length === 0) {
-			return []
-		}
-
-		// Entries are already aggregated and sorted by the backend
-		// Calculate score using the formula: (correct * 10) + (incorrect * -2)
-		// Default values from ScoringService as per predictions/prediction-system.md
-		return leaderboardData.entries.map((entry, index) => {
-			const score =
-				entry.correct_predictions * LEADERBOARD_SCORING.CORRECT_POINTS +
-				entry.incorrect_predictions *
-					LEADERBOARD_SCORING.INCORRECT_PENALTY
-
-			return {
-				userId: entry.user_id,
-				score,
-				correctPredictions: entry.correct_predictions,
-				incorrectPredictions: entry.incorrect_predictions,
-				position: index + 1,
-			}
-		})
-	}
-
-	async createLeaderboardEmbed(
-		params: CreateLeaderboardEmbedParams,
-	): Promise<EmbedBuilder> {
-		if (
-			!params.leaderboardData ||
-			params.leaderboardData.length === 0 ||
-			_.isEmpty(params.leaderboardData)
-		) {
-			throw new EmptyDataException('the leaderboard')
-		}
-
-		const currentPage = params.currentPage || 1
-		const startIndex = (currentPage - 1) * 20
-		const endIndex = startIndex + 20
-		const pageEntries = params.leaderboardData.slice(startIndex, endIndex)
-		const totalPages = Math.ceil(params.leaderboardData.length / 20)
-
-		// Process user data in parallel with proper error handling
-		const descriptionLines = await Promise.all(
-			pageEntries.map(async (entry) => {
-				try {
-					const member = await this.getMember(entry.userId)
-					const username = member ? member.username : entry.userId
-					const total =
-						entry.correctPredictions + entry.incorrectPredictions
-					return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
-				} catch (error) {
-					this.container.logger.error(
-						`Error processing user ${entry.userId}:`,
-						error,
-					)
-					return `${entry.position}. Unknown User - **\`${entry.score}\`** *(${entry.correctPredictions}/${entry.correctPredictions + entry.incorrectPredictions})*`
-				}
-			}),
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions leaderboard',
 		)
-
-		const embed = new EmbedBuilder()
-			.setTitle(
-				`Accuracy Leaderboard${params.title ? ` | ${params.title}` : ''}`,
-			)
-			.setColor(embedColors.PlutoBlue)
-			.setDescription(descriptionLines.join('\n'))
-			.setFooter({
-				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${params.leaderboardData.length}`,
-			})
-
-		if (params.metadata?.thumbnail) {
-			embed.setThumbnail(params.metadata.thumbnail)
-		}
-
-		return embed
-	}
-
-	private async getMember(userId: string) {
-		try {
-			return await new ClientTools(this.container).resolveMember(userId)
-		} catch (error) {
-			this.container.logger.error(
-				`Failed to resolve member ${userId}:`,
-				error,
-			)
-			return null
-		}
-	}
-
-	private async handlePagination(
-		interaction: Command.ChatInputCommandInteraction,
-		reply: Message,
-		leaderboard: ParsedLeaderboardEntry[],
-	) {
-		const totalPages = Math.ceil(leaderboard.length / 20)
-		let currentPage = 1
-
-		const collector = reply.createMessageComponentCollector({ time: 60000 })
-
-		collector.on('collect', async (i) => {
-			if (i.user.id !== interaction.user.id) {
-				await i.followUp({
-					content:
-						'Only the original user can interact with these buttons.',
-					ephemeral: true,
-				})
-				return
-			}
-
-			switch (i.customId) {
-				case 'first':
-					currentPage = 1
-					break
-				case 'previous':
-					currentPage = Math.max(1, currentPage - 1)
-					break
-				case 'next':
-					currentPage = Math.min(totalPages, currentPage + 1)
-					break
-				case 'last':
-					currentPage = totalPages
-					break
-			}
-
-			const newEmbed = await this.createLeaderboardEmbed({
-				leaderboardData: leaderboard,
-				currentPage,
-			})
-			const pagination = new Pagination()
-			const newComponents = pagination.createPaginationButtons(
-				currentPage,
-				totalPages,
-			)
-
-			await i.update({ embeds: [newEmbed], components: newComponents })
-		})
-
-		collector.on('end', async () => {
-			const pagination = new Pagination()
-			const disabledComponents = pagination
-				.createPaginationButtons(currentPage, totalPages)
-				.map((row) => {
-					for (const button of row.components) {
-						button.setDisabled(true)
-					}
-					return row
-				})
-
-			await reply.edit({ components: disabledComponents })
-		})
-	}
-	private validateOptions(interaction: Command.ChatInputCommandInteraction) {}
-}
-
-interface ParsedLeaderboardEntry {
-	position: number
-	userId: string
-	score: number
-	correctPredictions: number
-	incorrectPredictions: number
-}
-
-class CreateLeaderboardEmbedParams {
-	leaderboardData: ParsedLeaderboardEntry[]
-	currentPage?: number = 1
-	title?: string
-	metadata?: {
-		thumbnail?: string
-	}
-}
-
-class EmptyDataException extends Error {
-	constructor(message: string) {
-		super(message)
-		this.name = 'EmptyDataException'
-		this.message = `No data found for ${message}.`
 	}
 }

--- a/src/commands/predictions/prediction.ts
+++ b/src/commands/predictions/prediction.ts
@@ -1,26 +1,15 @@
-import type { AllUserPredictionsDto } from '@pluto-khronos/api-client'
-import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
-import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities'
 import { Subcommand } from '@sapphire/plugin-subcommands'
-import {
-	EmbedBuilder,
-	InteractionContextType,
-	PermissionFlagsBits,
-} from 'discord.js'
-import _ from 'lodash'
-import { teamResolver } from 'resolve-team'
-import embedColors from '../../lib/colorsConfig.js'
-import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
-import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
-import TeamInfo from '../../utils/common/TeamInfo.js'
+import { InteractionContextType, PermissionFlagsBits } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
 /**
- * User-facing prediction command for viewing personal prediction history and stats
+ * @deprecated Use /predictions history or /predictions stats. Kept for one
+ * release so existing command registrations have a clear migration path.
  */
 @ApplyOptions<Subcommand.Options>({
 	name: 'prediction',
-	description: 'View your predictions',
+	description: 'View your predictions (legacy alias)',
 	requiredClientPermissions: [
 		PermissionFlagsBits.SendMessages,
 		PermissionFlagsBits.EmbedLinks,
@@ -41,452 +30,36 @@ export class UserCommand extends Subcommand {
 					.addSubcommand((subcommand) =>
 						subcommand
 							.setName('history')
-							.setDescription('View your prediction history')
-							.addStringOption((option) =>
-								option
-									.setName('view')
-									.setDescription('Which predictions to view')
-									.setRequired(true)
-									.addChoices(
-										{
-											name: '⏳ Pending',
-											value: 'pending',
-										},
-										{
-											name: '✅ Completed',
-											value: 'completed',
-										},
-									),
+							.setDescription(
+								'Legacy alias for /predictions history',
 							),
 					)
 					.addSubcommand((subcommand) =>
 						subcommand
 							.setName('stats')
-							.setDescription('View your prediction statistics'),
+							.setDescription(
+								'Legacy alias for /predictions stats',
+							),
 					),
 			{ idHints: ['1298280482123026536'] },
 		)
 	}
 
-	/**
-	 * Handle /predictions history subcommand
-	 */
 	public async handleHistory(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const view = interaction.options.getString('view', true) as
-			| 'pending'
-			| 'completed'
-		const user = interaction.user
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions =
-				await predictionApiWrapper.getPredictionsForUser({
-					userId: user.id,
-				})
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: "You haven't made any predictions yet.",
-				})
-			}
-
-			switch (view) {
-				case 'pending':
-					return this.showPendingView(interaction, usersPredictions)
-				case 'completed':
-					return this.showCompletedView(interaction, usersPredictions)
-			}
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching your predictions.',
-			})
-		}
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions history',
+		)
 	}
 
-	/**
-	 * Handle /predictions stats subcommand
-	 */
 	public async handleStats(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const user = interaction.user
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions =
-				await predictionApiWrapper.getPredictionsForUser({
-					userId: user.id,
-				})
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: "You haven't made any predictions yet.",
-				})
-			}
-
-			// Calculate statistics
-			const totalPredictions = usersPredictions.length
-			const completedPredictions = usersPredictions.filter(
-				(p) =>
-					p.status === GetAllPredictionsFilteredStatusEnum.Completed,
-			)
-			const pendingPredictions = usersPredictions.filter(
-				(p) => p.status === GetAllPredictionsFilteredStatusEnum.Pending,
-			)
-
-			const correctPredictions = completedPredictions.filter(
-				(p) => p.is_correct === true,
-			)
-			const incorrectPredictions = completedPredictions.filter(
-				(p) => p.is_correct === false,
-			)
-
-			const winRate =
-				completedPredictions.length > 0
-					? (
-							(correctPredictions.length /
-								completedPredictions.length) *
-							100
-						).toFixed(1)
-					: '0.0'
-
-			const embed = new EmbedBuilder()
-				.setTitle('📊 Prediction Statistics')
-				.setColor(embedColors.PlutoBlue)
-				.setDescription(`Stats for ${user.username}`)
-				.addFields(
-					{
-						name: 'Total Predictions',
-						value: `\`${totalPredictions}\``,
-						inline: true,
-					},
-					{
-						name: 'Win Rate',
-						value: `\`${winRate}%\``,
-						inline: true,
-					},
-					{ name: '\u200B', value: '\u200B', inline: true },
-					{
-						name: '✅ Correct',
-						value: `\`${correctPredictions.length}\``,
-						inline: true,
-					},
-					{
-						name: '❌ Incorrect',
-						value: `\`${incorrectPredictions.length}\``,
-						inline: true,
-					},
-					{
-						name: '⏳ Pending',
-						value: `\`${pendingPredictions.length}\``,
-						inline: true,
-					},
-				)
-				.setTimestamp()
-
-			return interaction.editReply({ embeds: [embed] })
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching your statistics.',
-			})
-		}
-	}
-
-	/**
-	 * Show pending predictions view with detailed format
-	 */
-	private async showPendingView(
-		interaction: Subcommand.ChatInputCommandInteraction,
-		predictions: AllUserPredictionsDto[],
-	) {
-		const pending = predictions.filter(
-			(p) => p.status === GetAllPredictionsFilteredStatusEnum.Pending,
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions stats',
 		)
-
-		if (pending.length === 0) {
-			return interaction.editReply({
-				content: 'You have no pending predictions.',
-			})
-		}
-
-		type FormattedPrediction = {
-			formattedText: string
-		}
-
-		const formattedPredictions = await Promise.all(
-			pending.map(async (p): Promise<FormattedPrediction> => {
-				const outcome = await this.getOutcomeDetails(p.outcome_uuid)
-				const formattedText = await this.formatPredictionCompact(
-					p,
-					outcome,
-					null,
-				)
-
-				return {
-					formattedText,
-				}
-			}),
-		)
-
-		const templateEmbed = new EmbedBuilder()
-			.setTitle('⏳ Your Pending Predictions')
-			.setDescription(
-				`You have ${pending.length} active prediction${
-					pending.length !== 1 ? 's' : ''
-				}`,
-			)
-			.setColor(embedColors.PlutoYellow)
-
-		const paginatedMsg =
-			new PaginatedFieldMessageEmbed<FormattedPrediction>()
-				.setTitleField('\u200B')
-				.setTemplate(templateEmbed)
-				.setItems(formattedPredictions)
-				.setItemsPerPage(5)
-				.formatItems((item) => item.formattedText)
-				.make()
-
-		return paginatedMsg.run(interaction)
-	}
-
-	/**
-	 * Show completed predictions view with compact format
-	 */
-	private async showCompletedView(
-		interaction: Subcommand.ChatInputCommandInteraction,
-		predictions: AllUserPredictionsDto[],
-	) {
-		const completed = predictions.filter(
-			(p) => p.status !== GetAllPredictionsFilteredStatusEnum.Pending,
-		)
-
-		if (completed.length === 0) {
-			return interaction.editReply({
-				content: 'You have no completed predictions yet.',
-			})
-		}
-
-		const correct = completed.filter(
-			(p) =>
-				p.status === GetAllPredictionsFilteredStatusEnum.Completed &&
-				p.is_correct === true,
-		).length
-		const incorrect = completed.length - correct
-
-		type FormattedCompletedPrediction = {
-			formattedText: string
-		}
-
-		const formattedPredictions = await Promise.all(
-			completed.map(async (p): Promise<FormattedCompletedPrediction> => {
-				// Determine if prediction is correct (only for Completed status)
-				let isCorrect: boolean | null = null
-				if (
-					p.status === GetAllPredictionsFilteredStatusEnum.Completed
-				) {
-					isCorrect = p.is_correct === true
-				}
-				const outcome = await this.getOutcomeDetails(p.outcome_uuid)
-				const formattedText = await this.formatPredictionCompact(
-					p,
-					outcome,
-					isCorrect,
-				)
-
-				return {
-					formattedText,
-				}
-			}),
-		)
-
-		const templateEmbed = new EmbedBuilder()
-			.setTitle('📊 Your Completed Predictions')
-			.setDescription(`${correct} correct • ${incorrect} incorrect`)
-			.setColor(embedColors.PlutoBlue)
-
-		const paginatedMsg =
-			new PaginatedFieldMessageEmbed<FormattedCompletedPrediction>()
-				.setTitleField('\u200B')
-				.setTemplate(templateEmbed)
-				.setItems(formattedPredictions)
-				.setItemsPerPage(8)
-				.formatItems((item) => item.formattedText)
-				.make()
-
-		return paginatedMsg.run(interaction)
-	}
-
-	/**
-	 * Get outcome details from prop API
-	 */
-	private async getOutcomeDetails(outcomeUuid: string): Promise<{
-		name: string
-		description?: string
-		point: number
-		market_key: string
-		event_context: {
-			home_team: string
-			away_team: string
-		}
-	} | null> {
-		try {
-			const propApiWrapper = new PropsApiWrapper()
-			const prop = await propApiWrapper.getPropByUuid(outcomeUuid)
-
-			const outcome = prop.outcomes.find(
-				(o) => o.outcome_uuid === outcomeUuid,
-			)
-
-			if (!outcome) return null
-
-			return {
-				name: outcome.name,
-				description: outcome.description,
-				point: outcome.point,
-				market_key: prop.market_key,
-				event_context: prop.event_context,
-			}
-		} catch (error) {
-			this.container.logger.error(
-				'Failed to fetch outcome details:',
-				error,
-			)
-			return null
-		}
-	}
-
-	/**
-	 * Formats a prediction choice with point and market information
-	 */
-	private formatPredictionChoice(
-		choice: string,
-		point: number | undefined,
-		marketKey: string,
-	): string {
-		const upperChoice = choice.toUpperCase()
-		const marketName = _.startCase(marketKey.replace('player_', ''))
-
-		if (point !== null && point !== undefined) {
-			return `${upperChoice} ${point} ${marketName}`
-		}
-
-		return `${upperChoice} ${marketName}`
-	}
-
-	/**
-	 * Format prediction in compact view format
-	 * Player format: **✅ Player Name** (ABBREV vs. ABBREV)\nProp Type • **PICK Line**\n*<t:TIMESTAMP:d>*
-	 * Team format: **✅ Team Name**\nProp Type • **PICK Line**\n*<t:TIMESTAMP:d>*
-	 */
-	private async formatPredictionCompact(
-		prediction: AllUserPredictionsDto,
-		outcome: {
-			name: string
-			description?: string
-			point: number
-			market_key: string
-			event_context: {
-				home_team: string
-				away_team: string
-			}
-		} | null,
-		isCorrect: boolean | null,
-	): Promise<string> {
-		if (!outcome) {
-			return 'Unknown prediction'
-		}
-
-		const result =
-			isCorrect === true ? '✅' : isCorrect === false ? '❌' : '⏳'
-		const isPlayerPrediction =
-			outcome.description && outcome.description.trim() !== ''
-
-		let entityLine: string
-		if (isPlayerPrediction) {
-			const playerName = outcome.description!
-			let matchupString: string
-			if (prediction.match_string) {
-				const [awayTeam, homeTeam] =
-					prediction.match_string.split(' vs. ')
-				const awayTeamData = await teamResolver.resolve(
-					awayTeam || outcome.event_context.away_team,
-					{ full: true },
-				)
-				const homeTeamData = await teamResolver.resolve(
-					homeTeam || outcome.event_context.home_team,
-					{ full: true },
-				)
-				const awayAbbrev =
-					awayTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(
-						awayTeam || outcome.event_context.away_team,
-					)
-				const homeAbbrev =
-					homeTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(
-						homeTeam || outcome.event_context.home_team,
-					)
-				matchupString = `${awayAbbrev} vs. ${homeAbbrev}`
-			} else {
-				const awayTeamData = await teamResolver.resolve(
-					outcome.event_context.away_team,
-					{ full: true },
-				)
-				const homeTeamData = await teamResolver.resolve(
-					outcome.event_context.home_team,
-					{ full: true },
-				)
-				const awayAbbrev =
-					awayTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(outcome.event_context.away_team)
-				const homeAbbrev =
-					homeTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(outcome.event_context.home_team)
-				matchupString = `${awayAbbrev} vs. ${homeAbbrev}`
-			}
-			entityLine = `**${result} ${playerName}** (${matchupString})`
-		} else {
-			const teamName = TeamInfo.getTeamShortName(outcome.name)
-			entityLine = `**${result} ${teamName}**`
-		}
-
-		const propType = _.startCase(
-			outcome.market_key.replace('player_', '').replace('_', ' '),
-		)
-
-		const pick = prediction.choice.toUpperCase()
-		const line =
-			outcome.point !== null && outcome.point !== undefined
-				? outcome.point.toString()
-				: ''
-
-		const timestamp = Math.floor(
-			new Date(prediction.created_at).getTime() / 1000,
-		)
-		const formattedDate = `<t:${timestamp}:d>`
-
-		const propLine = line
-			? `${propType} • **${pick} ${line}**`
-			: `${propType} • **${pick}**`
-
-		return `${entityLine}\n${propLine}\n*${formattedDate}*`
-	}
-
-	private async parseMatchString(matchString: string) {
-		const [awayTeam, homeTeam] = matchString.split(' vs. ')
-		const result = await TeamInfo.resolveTeamIdentifier({
-			away_team: awayTeam,
-			home_team: homeTeam,
-		})
-
-		return `${result.away_team} vs. ${result.home_team}`
 	}
 }

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -1,0 +1,481 @@
+import type {
+	AllUserPredictionsDto,
+	SimpleLeaderboardResponseDto,
+} from '@pluto-khronos/api-client'
+import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
+import { ApplyOptions } from '@sapphire/decorators'
+import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
+import { Subcommand } from '@sapphire/plugin-subcommands'
+import {
+	EmbedBuilder,
+	InteractionContextType,
+	type Message,
+	PermissionFlagsBits,
+} from 'discord.js'
+import _ from 'lodash'
+import { teamResolver } from 'resolve-team'
+import embedColors from '../../lib/colorsConfig.js'
+import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
+import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
+import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
+import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
+import ClientTools from '../../utils/bot_res/ClientTools.js'
+import { DateManager } from '../../utils/common/DateManager.js'
+import TeamInfo from '../../utils/common/TeamInfo.js'
+import Pagination from '../../utils/embeds/pagination.js'
+
+/**
+ * Reserved command id for the consolidated group. Legacy aliases retain their
+ * existing hints for one release and are removed with the alias pieces after
+ * the migration window.
+ */
+const PREDICTIONS_COMMAND_ID_HINTS = ['1298280482123026537']
+
+@ApplyOptions<Subcommand.Options>({
+	name: 'predictions',
+	description: 'View prediction history, stats, and leaderboard',
+	requiredClientPermissions: [
+		PermissionFlagsBits.SendMessages,
+		PermissionFlagsBits.EmbedLinks,
+	],
+	subcommands: [
+		{ name: 'history', chatInputRun: 'handleHistory' },
+		{ name: 'stats', chatInputRun: 'handleStats' },
+		{ name: 'leaderboard', chatInputRun: 'handleLeaderboard' },
+	],
+})
+export class UserCommand extends Subcommand {
+	private readonly dateManager = new DateManager()
+
+	public override registerApplicationCommands(registry: Subcommand.Registry) {
+		registry.registerChatInputCommand(
+			(builder) =>
+				builder
+					.setName(this.name)
+					.setDescription(this.description)
+					.setContexts(InteractionContextType.Guild)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('history')
+							.setDescription('View prediction history')
+							.addUserOption((option) =>
+								option
+									.setName('user')
+									.setDescription(
+										'[Optional] The user to view history for (default: yourself)',
+									)
+									.setRequired(false),
+							)
+							.addStringOption((option) =>
+								option
+									.setName('status')
+									.setDescription(
+										'Filter predictions by status',
+									)
+									.setRequired(false)
+									.addChoices(
+										{
+											name: 'Pending',
+											value: GetAllPredictionsFilteredStatusEnum.Pending,
+										},
+										{
+											name: 'Completed',
+											value: GetAllPredictionsFilteredStatusEnum.Completed,
+										},
+									),
+							),
+					)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('stats')
+							.setDescription(
+								'View server-calculated prediction statistics',
+							),
+					)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('leaderboard')
+							.setDescription(
+								'View the prediction accuracy leaderboard',
+							),
+					),
+			{ idHints: PREDICTIONS_COMMAND_ID_HINTS },
+		)
+	}
+
+	public async handleHistory(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ ephemeral: true })
+
+		const user = interaction.options.getUser('user') || interaction.user
+		const status = interaction.options.getString(
+			'status',
+		) as GetAllPredictionsFilteredStatusEnum | null
+
+		try {
+			const predictionApiWrapper = new PredictionApiWrapper()
+			const predictions = await (status
+				? predictionApiWrapper.getPredictionsFiltered({
+						userId: user.id,
+						status,
+					})
+				: predictionApiWrapper.getPredictionsForUser({
+						userId: user.id,
+					}))
+
+			if (!predictions || predictions.length === 0) {
+				return interaction.editReply({
+					content: 'No predictions found for the specified criteria.',
+				})
+			}
+
+			const description = status
+				? `Filtered by: \`${status}\``
+				: undefined
+			const templateEmbed = new EmbedBuilder()
+				.setTitle(`Prediction History | ${user.username}`)
+				.setColor(embedColors.PlutoBlue)
+			if (description) templateEmbed.setDescription(description)
+
+			const propsApiWrapper = new PropsApiWrapper()
+			let hadFormattingFailures = false
+			const formattedPredictions = (
+				await Promise.allSettled(
+					predictions.map((prediction) =>
+						this.createPredictionField(prediction, propsApiWrapper),
+					),
+				)
+			).flatMap((result, index) => {
+				if (result.status === 'fulfilled') {
+					return result.value ? [result.value] : []
+				}
+				hadFormattingFailures = true
+				this.container.logger.error(
+					`Failed to create prediction field for prediction ${predictions[index]?.id || 'unknown'} (user: ${user.id})`,
+					result.reason,
+				)
+				return []
+			})
+
+			if (formattedPredictions.length === 0) {
+				const message = hadFormattingFailures
+					? 'We were unable to load details for your predictions. Please try again later.'
+					: 'No prediction history found. Your predictions will appear here once you make them.'
+				templateEmbed.setDescription(
+					description ? `${description}\n\n${message}` : message,
+				)
+				return interaction.editReply({ embeds: [templateEmbed] })
+			}
+
+			const paginatedMessage = new PaginatedMessageEmbedFields({
+				template: { embeds: [templateEmbed] },
+			})
+				.setItems(formattedPredictions)
+				.setItemsPerPage(10)
+				.make()
+
+			return paginatedMessage.run(interaction)
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content:
+					'An error occurred while fetching the prediction history.',
+			})
+		}
+	}
+
+	public async handleStats(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ ephemeral: true })
+
+		const guildId = interaction.guildId
+		if (!guildId) {
+			return interaction.editReply({
+				content: 'This command can only be used in a guild.',
+			})
+		}
+
+		try {
+			const [leaderboard, allPending] = await Promise.all([
+				new LeaderboardWrapper().getLeaderboard({ guildId }),
+				new PredictionApiWrapper().getActivePredictionsForUser({
+					userId: interaction.user.id,
+				}),
+			])
+			const pending = allPending.filter(
+				(prediction) => prediction.guild_id === guildId,
+			)
+
+			const entry = leaderboard.entries.find(
+				(candidate) => candidate.user_id === interaction.user.id,
+			)
+			if (!entry && pending.length === 0) {
+				return interaction.editReply({
+					content: "You haven't made any predictions yet.",
+				})
+			}
+
+			const totalPredictions = entry?.total_predictions ?? 0
+			const correctPredictions = entry?.correct_predictions ?? 0
+			const incorrectPredictions = entry?.incorrect_predictions ?? 0
+			const winRate = entry?.success_rate ?? 0
+			const embed = new EmbedBuilder()
+				.setTitle('📊 Prediction Statistics')
+				.setColor(embedColors.PlutoBlue)
+				.setDescription(`Server stats for ${interaction.user.username}`)
+				.addFields(
+					{
+						name: 'Total Predictions',
+						value: `\`${totalPredictions}\``,
+						inline: true,
+					},
+					{
+						name: 'Win Rate',
+						value: `\`${winRate.toFixed(1)}%\``,
+						inline: true,
+					},
+					{ name: '\u200B', value: '\u200B', inline: true },
+					{
+						name: '✅ Correct',
+						value: `\`${correctPredictions}\``,
+						inline: true,
+					},
+					{
+						name: '❌ Incorrect',
+						value: `\`${incorrectPredictions}\``,
+						inline: true,
+					},
+					{
+						name: '⏳ Pending',
+						value: `\`${pending.length}\``,
+						inline: true,
+					},
+				)
+				.setFooter({
+					text: 'Streaks will appear here after the engagement rollout.',
+				})
+				.setTimestamp()
+
+			return interaction.editReply({ embeds: [embed] })
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content: 'An error occurred while fetching your statistics.',
+			})
+		}
+	}
+
+	public async handleLeaderboard(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply()
+		const guildId = interaction.guildId
+		if (!guildId) {
+			return interaction.editReply({
+				content: 'This command can only be used in a guild.',
+			})
+		}
+
+		try {
+			const leaderboard = await new LeaderboardWrapper().getLeaderboard({
+				guildId,
+			})
+			if (!leaderboard.entries.length) {
+				return interaction.editReply({
+					content: 'No leaderboard data found.',
+				})
+			}
+
+			const parsed = this.parseLeaderboardData(leaderboard)
+			const totalPages = Math.ceil(parsed.length / 20)
+			const embed = await this.createLeaderboardEmbed(parsed, 1)
+			const pagination = new Pagination()
+			const reply = await interaction.editReply({
+				content: null,
+				embeds: [embed],
+				components: pagination.createPaginationButtons(1, totalPages),
+			})
+
+			await this.handlePagination(interaction, reply, parsed)
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content: 'An error occurred while fetching the leaderboard.',
+			})
+		}
+	}
+
+	private async createPredictionField(
+		prediction: AllUserPredictionsDto,
+		propsApiWrapper: PropsApiWrapper,
+	): Promise<{ name: string; value: string; inline: boolean } | null> {
+		const prop = await propsApiWrapper.getPropByUuid(
+			prediction.outcome_uuid,
+		)
+		const outcome = prop.outcomes.find(
+			(candidate) => candidate.outcome_uuid === prediction.outcome_uuid,
+		)
+		if (!outcome) return null
+
+		const parsedMatch = await this.parseMatchString(prediction.match_string)
+		const point = outcome.point ?? null
+		const choice =
+			prediction.choice.charAt(0).toUpperCase() +
+			prediction.choice.slice(1).toLowerCase()
+		const status =
+			prediction.status !== GetAllPredictionsFilteredStatusEnum.Completed
+				? 'Pending ⏳'
+				: prediction.is_correct === true
+					? 'Correct ✅'
+					: prediction.is_correct === false
+						? 'Incorrect ❌'
+						: 'Pending ⏳'
+		const market = _.startCase(prop.market_key.replace('player_', ''))
+		const date = this.dateManager.toMMDDYYYY(
+			prop.event_context.commence_time,
+		)
+		const value = [
+			`**Date**: ${date}`,
+			`**Status**: ${status}`,
+			`**Choice**: \`${choice}${point === null ? '' : ` ${point}`}\``,
+			`**Market**: ${market}`,
+			prediction.description?.trim()
+				? `**Player:** ${prediction.description}`
+				: null,
+		]
+			.filter((line): line is string => Boolean(line))
+			.join('\n')
+
+		return { name: parsedMatch, value, inline: false }
+	}
+
+	private async parseMatchString(matchString: string) {
+		const [awayTeam, homeTeam] = matchString.split(' vs. ')
+		if (!awayTeam || !homeTeam) return matchString
+		const result = await TeamInfo.resolveTeamIdentifier({
+			away_team: awayTeam,
+			home_team: homeTeam,
+		})
+		return `${result.away_team} vs. ${result.home_team}`
+	}
+
+	private parseLeaderboardData(
+		leaderboard: SimpleLeaderboardResponseDto,
+	): ParsedLeaderboardEntry[] {
+		return leaderboard.entries.map((entry, index) => ({
+			userId: entry.user_id,
+			position: index + 1,
+			score:
+				entry.correct_predictions * LEADERBOARD_SCORING.CORRECT_POINTS +
+				entry.incorrect_predictions *
+					LEADERBOARD_SCORING.INCORRECT_PENALTY,
+			correctPredictions: entry.correct_predictions,
+			incorrectPredictions: entry.incorrect_predictions,
+		}))
+	}
+
+	private async createLeaderboardEmbed(
+		leaderboard: ParsedLeaderboardEntry[],
+		currentPage: number,
+	): Promise<EmbedBuilder> {
+		const startIndex = (currentPage - 1) * 20
+		const pageEntries = leaderboard.slice(startIndex, startIndex + 20)
+		const totalPages = Math.ceil(leaderboard.length / 20)
+		const description = await Promise.all(
+			pageEntries.map(async (entry) => {
+				const member = await this.getMember(entry.userId)
+				const username = member?.username ?? entry.userId
+				const total =
+					entry.correctPredictions + entry.incorrectPredictions
+				return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
+			}),
+		)
+
+		return new EmbedBuilder()
+			.setTitle('Prediction Accuracy Leaderboard')
+			.setColor(embedColors.PlutoBlue)
+			.setDescription(description.join('\n'))
+			.setFooter({
+				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length}`,
+			})
+	}
+
+	private async getMember(userId: string) {
+		try {
+			return await new ClientTools(this.container).resolveMember(userId)
+		} catch (error) {
+			this.container.logger.error(
+				`Failed to resolve member ${userId}:`,
+				error,
+			)
+			return null
+		}
+	}
+
+	private async handlePagination(
+		interaction: Subcommand.ChatInputCommandInteraction,
+		reply: Message,
+		leaderboard: ParsedLeaderboardEntry[],
+	) {
+		const totalPages = Math.ceil(leaderboard.length / 20)
+		let currentPage = 1
+		const collector = reply.createMessageComponentCollector({ time: 60000 })
+
+		collector.on('collect', async (buttonInteraction) => {
+			if (buttonInteraction.user.id !== interaction.user.id) {
+				await buttonInteraction.followUp({
+					content:
+						'Only the original user can interact with these buttons.',
+					ephemeral: true,
+				})
+				return
+			}
+			switch (buttonInteraction.customId) {
+				case 'first':
+					currentPage = 1
+					break
+				case 'previous':
+					currentPage = Math.max(1, currentPage - 1)
+					break
+				case 'next':
+					currentPage = Math.min(totalPages, currentPage + 1)
+					break
+				case 'last':
+					currentPage = totalPages
+					break
+			}
+			const embed = await this.createLeaderboardEmbed(
+				leaderboard,
+				currentPage,
+			)
+			await buttonInteraction.update({
+				embeds: [embed],
+				components: new Pagination().createPaginationButtons(
+					currentPage,
+					totalPages,
+				),
+			})
+		})
+
+		collector.on('end', async () => {
+			const disabled = new Pagination()
+				.createPaginationButtons(currentPage, totalPages)
+				.map((row) => {
+					for (const button of row.components)
+						button.setDisabled(true)
+					return row
+				})
+			await reply.edit({ components: disabled })
+		})
+	}
+}
+
+interface ParsedLeaderboardEntry {
+	position: number
+	userId: string
+	score: number
+	correctPredictions: number
+	incorrectPredictions: number
+}

--- a/src/interaction-handlers/my-bets-pagination-handler.ts
+++ b/src/interaction-handlers/my-bets-pagination-handler.ts
@@ -103,6 +103,7 @@ export class MyBetsPaginationHandler extends InteractionHandler {
 			const historyPage = this.paginationService.getHistoryPage(
 				betsData.historyBets,
 				targetPage,
+				betsData.historyParlays,
 			)
 			const groupedBets = this.paginationService.groupBetsByDate(
 				historyPage.bets,
@@ -111,6 +112,8 @@ export class MyBetsPaginationHandler extends InteractionHandler {
 			const displayData: MyBetsDisplayData = {
 				userId,
 				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
 				historyPage,
 				groupedBets,
 			}

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -1,0 +1,249 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import {
+	type ButtonInteraction,
+	LabelBuilder,
+	MessageFlags,
+	ModalBuilder,
+	StringSelectMenuBuilder,
+	TextInputBuilder,
+	TextInputStyle,
+} from 'discord.js'
+import {
+	getParlayErrorMessage,
+	logParlayBuilderError,
+	ParlayBuilderService,
+} from '../services/ParlayBuilderService.js'
+import { BetsCacheService } from '../utils/api/common/bets/BetsCacheService.js'
+import { BetslipManager } from '../utils/api/Khronos/bets/BetslipsManager.js'
+import BetslipWrapper from '../utils/api/Khronos/bets/betslip-wrapper.js'
+import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+
+const removeId = /^parlay_btn_remove_(\d+)$/
+
+export class ParlayButtonHandler extends InteractionHandler {
+	private readonly builderService = new ParlayBuilderService()
+	private readonly parlayApi = new ParlayApiWrapper()
+	private readonly matchCache = new MatchCacheService(new CacheManager())
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.Button,
+		})
+	}
+
+	public override async parse(interaction: ButtonInteraction) {
+		if (!interaction.customId.startsWith('parlay_btn_')) return this.none()
+		if (interaction.customId === 'parlay_btn_add') {
+			try {
+				await interaction.showModal(await this.buildAddLegModal())
+			} catch (error) {
+				logParlayBuilderError(error, {
+					action: 'open_add_leg_modal',
+					userId: interaction.user.id,
+				})
+				await interaction.reply({
+					content:
+						error instanceof Error
+							? error.message
+							: 'No upcoming games are available right now.',
+					ephemeral: true,
+				})
+			}
+			return this.none()
+		}
+		if (interaction.customId === 'parlay_btn_stake') {
+			await interaction.showModal(this.buildStakeModal())
+			return this.none()
+		}
+		const removeMatch = removeId.exec(interaction.customId)
+		if (removeMatch) {
+			await interaction.deferUpdate()
+			return this.some({
+				action: 'remove',
+				index: Number(removeMatch[1]),
+			})
+		}
+		if (interaction.customId === 'parlay_btn_cancel') {
+			await interaction.deferUpdate()
+			return this.some({ action: 'cancel' })
+		}
+		if (interaction.customId === 'parlay_btn_confirm') {
+			await interaction.deferUpdate()
+			return this.some({ action: 'confirm' })
+		}
+		return this.none()
+	}
+
+	public async run(
+		interaction: ButtonInteraction,
+		payload:
+			| { action: 'remove'; index: number }
+			| { action: 'cancel' }
+			| { action: 'confirm' },
+	) {
+		const userId = interaction.user.id
+		try {
+			if (payload.action === 'cancel') {
+				await this.builderService.clear(userId)
+				return interaction.editReply(
+					this.builderService.renderMessage(
+						'Parlay builder cancelled.',
+					),
+				)
+			}
+			if (payload.action === 'remove') {
+				const session = await this.builderService.removeLeg(
+					userId,
+					payload.index,
+				)
+				return interaction.editReply(
+					this.builderService.render(session),
+				)
+			}
+			const session = await this.builderService.get(userId)
+			if (!session)
+				throw new Error(
+					'Your parlay builder expired. Run `/parlay` to start again.',
+				)
+			this.builderService.validateForPlacement(session)
+			const initialized = await this.parlayApi.init({
+				legs: session.legs.map(({ event_id, outcome_uuid }) => ({
+					event_id,
+					outcome_uuid,
+				})),
+				stake: session.stake!,
+				guild_id: interaction.guildId!,
+				user_id: userId,
+			})
+			const placed = await this.parlayApi.place(initialized.init_token)
+			await new BetslipManager(
+				new BetslipWrapper(),
+				new BetsCacheService(new CacheManager()),
+			).announceParlayPlaced(interaction, {
+				parlayId: placed.id,
+				legCount: placed.leg_count,
+				stake: Number(placed.stake),
+				potentialPayout: Number(placed.potential_payout),
+			})
+			await this.builderService.clear(userId)
+			return interaction.editReply(
+				this.builderService.renderMessage(
+					`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
+					0x57f287,
+				),
+			)
+		} catch (error) {
+			logParlayBuilderError(error, { action: payload.action, userId })
+			const message = getParlayErrorMessage(error)
+			return interaction.editReply({
+				...this.builderService.renderMessage(message),
+				flags: MessageFlags.IsComponentsV2,
+			})
+		}
+	}
+
+	private async buildAddLegModal(): Promise<ModalBuilder> {
+		const matches = ((await this.matchCache.getMatches()) ?? [])
+			.filter((match) => match.id && match.home_team && match.away_team)
+			.filter(
+				(match) =>
+					!match.commence_time ||
+					new Date(match.commence_time).getTime() > Date.now(),
+			)
+			.slice(0, 25)
+		if (matches.length === 0)
+			throw new Error('No upcoming games are available right now.')
+		const gameSelect = new StringSelectMenuBuilder()
+			.setCustomId('parlay_game')
+			.setPlaceholder('Choose an upcoming game')
+			.setRequired(true)
+			.addOptions(
+				matches.map((match) => ({
+					label: `${match.away_team} @ ${match.home_team}`.slice(
+						0,
+						100,
+					),
+					value: match.id!,
+					description: match.commence_time
+						? new Date(match.commence_time).toLocaleString(
+								'en-US',
+								{
+									month: 'short',
+									day: 'numeric',
+									hour: 'numeric',
+									minute: '2-digit',
+								},
+							)
+						: 'Start time TBD',
+				})),
+			)
+		return new ModalBuilder()
+			.setCustomId('parlay_modal_add_leg')
+			.setTitle('Add a parlay leg')
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Game')
+					.setDescription('Choose an upcoming game')
+					.setStringSelectMenuComponent(gameSelect),
+			)
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Market')
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder()
+							.setCustomId('parlay_market')
+							.setPlaceholder('Choose market')
+							.addOptions(
+								{ label: 'Moneyline', value: 'h2h' },
+								{ label: 'Spread', value: 'spreads' },
+								{ label: 'Total', value: 'totals' },
+							)
+							.setRequired(true),
+					),
+			)
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Side')
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder()
+							.setCustomId('parlay_side')
+							.setPlaceholder('Choose side')
+							.addOptions(
+								{ label: 'Home team', value: 'home' },
+								{ label: 'Away team', value: 'away' },
+								{ label: 'Over', value: 'over' },
+								{ label: 'Under', value: 'under' },
+							)
+							.setRequired(true),
+					),
+			)
+	}
+
+	private buildStakeModal(): ModalBuilder {
+		return new ModalBuilder()
+			.setCustomId('parlay_modal_stake')
+			.setTitle('Set parlay stake')
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Stake (whole dollars)')
+					.setTextInputComponent(
+						new TextInputBuilder()
+							.setCustomId('parlay_stake')
+							.setStyle(TextInputStyle.Short)
+							.setPlaceholder('10')
+							.setRequired(true)
+							.setMinLength(1)
+							.setMaxLength(6),
+					),
+			)
+	}
+}

--- a/src/interaction-handlers/parlay-cancel-handler.ts
+++ b/src/interaction-handlers/parlay-cancel-handler.ts
@@ -1,0 +1,99 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import { type ButtonInteraction } from 'discord.js'
+import {
+	type MyBetsDisplayData,
+	MyBetsFormatterService,
+} from '../utils/api/Khronos/bets/mybets-formatter.service.js'
+import { MyBetsPaginationService } from '../utils/api/Khronos/bets/mybets-pagination.service.js'
+import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+
+const parlayCancelPrefix = 'parlay_cancel_'
+
+const getParlayErrorMessage = (error: unknown): string => {
+	const data = (error as { response?: { data?: unknown } })?.response?.data
+	if (typeof data === 'object' && data !== null) {
+		const message = (data as { message?: unknown }).message
+		if (typeof message === 'string') return message
+		if (
+			Array.isArray(message) &&
+			message.every((item) => typeof item === 'string')
+		) {
+			return message.join(', ')
+		}
+	}
+	return error instanceof Error ? error.message : 'Unable to cancel parlay.'
+}
+
+export class ParlayCancelHandler extends InteractionHandler {
+	private readonly parlayApi = new ParlayApiWrapper()
+	private readonly paginationService = new MyBetsPaginationService()
+	private readonly formatterService = new MyBetsFormatterService()
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.Button,
+		})
+	}
+
+	public override async parse(interaction: ButtonInteraction) {
+		if (!interaction.customId.startsWith(parlayCancelPrefix))
+			return this.none()
+		const parlayId = interaction.customId.slice(parlayCancelPrefix.length)
+		if (!parlayId) return this.none()
+		await interaction.deferUpdate()
+		return this.some({ parlayId })
+	}
+
+	public async run(
+		interaction: ButtonInteraction,
+		payload: { parlayId: string },
+	) {
+		try {
+			await this.parlayApi.cancel(payload.parlayId, interaction.user.id)
+			const betsData = await this.paginationService.fetchUserBets(
+				interaction.user.id,
+			)
+			const historyPage = this.paginationService.getHistoryPage(
+				betsData.historyBets,
+				1,
+				betsData.historyParlays,
+			)
+			const displayData: MyBetsDisplayData = {
+				userId: interaction.user.id,
+				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
+				historyPage,
+				groupedBets: this.paginationService.groupBetsByDate(
+					historyPage.bets,
+				),
+			}
+			await interaction.editReply(
+				await this.formatterService.buildEmbedResponse(
+					displayData,
+					interaction.guild ?? undefined,
+				),
+			)
+		} catch (error) {
+			this.container.logger.error({
+				message: 'Failed to cancel parlay',
+				metadata: {
+					userId: interaction.user.id,
+					parlayId: payload.parlayId,
+					error: getParlayErrorMessage(error),
+				},
+			})
+			await interaction.editReply({
+				content: `Unable to cancel this parlay: ${getParlayErrorMessage(error)}`,
+				components: [],
+			})
+		}
+	}
+}

--- a/src/interaction-handlers/parlay-modal-handler.ts
+++ b/src/interaction-handlers/parlay-modal-handler.ts
@@ -1,0 +1,102 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import { type ModalSubmitInteraction } from 'discord.js'
+import {
+	getParlayErrorMessage,
+	logParlayBuilderError,
+	ParlayBuilderService,
+} from '../services/ParlayBuilderService.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+
+export class ParlayModalHandler extends InteractionHandler {
+	private readonly builderService = new ParlayBuilderService()
+	private readonly matchCache = new MatchCacheService(new CacheManager())
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.ModalSubmit,
+		})
+	}
+
+	public override parse(interaction: ModalSubmitInteraction) {
+		if (!interaction.customId.startsWith('parlay_modal_'))
+			return this.none()
+		const kind = interaction.customId.replace('parlay_modal_', '')
+		if (kind !== 'add_leg' && kind !== 'stake') return this.none()
+		return this.some({
+			kind,
+		})
+	}
+
+	public async run(
+		interaction: ModalSubmitInteraction,
+		payload: { kind: 'add_leg' | 'stake' },
+	) {
+		await interaction.deferReply({ ephemeral: true })
+		const userId = interaction.user.id
+		try {
+			if (payload.kind === 'stake') {
+				const rawStake = interaction.fields
+					.getTextInputValue('parlay_stake')
+					.trim()
+				if (!/^\d+$/.test(rawStake))
+					throw new Error('Stake must be a whole number. Try again.')
+				const session = await this.builderService.setStake(
+					userId,
+					Number(rawStake),
+				)
+				return interaction.editReply(
+					this.builderService.render(session),
+				)
+			}
+
+			const gameId =
+				interaction.fields.getStringSelectValues('parlay_game')[0]
+			const marketKey = interaction.fields.getStringSelectValues(
+				'parlay_market',
+			)[0] as 'h2h' | 'spreads' | 'totals'
+			const side = interaction.fields.getStringSelectValues(
+				'parlay_side',
+			)[0] as 'home' | 'away' | 'over' | 'under'
+			if (!gameId || !marketKey || !side)
+				throw new Error('Choose a game, market, and side.')
+			const match = await this.matchCache.getMatch(gameId)
+			if (!match) throw new Error('Choose a valid game from the list.')
+			if (marketKey === 'h2h' && (side === 'over' || side === 'under')) {
+				throw new Error(
+					'Over/Under is only valid for totals. Choose a team for moneyline.',
+				)
+			}
+			if (
+				(marketKey === 'spreads' || marketKey === 'h2h') &&
+				(side === 'over' || side === 'under')
+			) {
+				throw new Error('That side is not valid for this market.')
+			}
+			if (
+				marketKey === 'totals' &&
+				(side === 'home' || side === 'away')
+			) {
+				throw new Error('Totals require Over or Under.')
+			}
+			const session = await this.builderService.addLeg(userId, {
+				matchId: gameId,
+				marketKey,
+				side,
+			})
+			return interaction.editReply(this.builderService.render(session))
+		} catch (error) {
+			logParlayBuilderError(error, { userId, modal: payload.kind })
+			return interaction.editReply(
+				this.builderService.renderMessage(getParlayErrorMessage(error)),
+			)
+		}
+	}
+}

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -1,0 +1,367 @@
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ContainerBuilder,
+	type InteractionEditReplyOptions,
+	MessageFlags,
+	SectionBuilder,
+	SeparatorSpacingSize,
+} from 'discord.js'
+import ParlayApiWrapper, {
+	type EventOutcome,
+	type ParlayLegInput,
+	type ParlayMarketKey,
+} from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { combineAmericanOdds } from '../utils/betting/american-odds.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+import { logger } from '../utils/logging/WinstonLogger.js'
+
+export const PARLAY_BUILDER_TTL_SECONDS = 15 * 60
+export const PARLAY_BUILDER_MAX_LEGS = 6
+
+export interface ParlayBuilderLeg extends ParlayLegInput {
+	market_key: ParlayMarketKey
+	selection_display: string
+	odds_american: number
+	point: number | null
+	commence_time: string
+}
+
+export interface ParlayBuilderSession {
+	legs: ParlayBuilderLeg[]
+	stake: number | null
+}
+
+export type ParlaySide = 'home' | 'away' | 'over' | 'under'
+
+export interface AddParlayLegSelection {
+	matchId: string
+	marketKey: ParlayMarketKey
+	side: ParlaySide
+}
+
+export const parlayBuilderKey = (userId: string): string =>
+	`parlay-builder:${userId}`
+
+export class ParlayBuilderService {
+	constructor(
+		private readonly cache: CacheManager = new CacheManager(),
+		private readonly matchCache = new MatchCacheService(new CacheManager()),
+		private readonly parlayApi = new ParlayApiWrapper(),
+	) {}
+
+	async get(userId: string): Promise<ParlayBuilderSession | null> {
+		const value = await this.cache.get(parlayBuilderKey(userId))
+		if (!value || typeof value !== 'object') return null
+		const session = value as Partial<ParlayBuilderSession>
+		if (!Array.isArray(session.legs)) return null
+		return {
+			legs: session.legs as ParlayBuilderLeg[],
+			stake: typeof session.stake === 'number' ? session.stake : null,
+		}
+	}
+
+	async start(userId: string): Promise<ParlayBuilderSession> {
+		const session: ParlayBuilderSession = { legs: [], stake: null }
+		await this.save(userId, session)
+		return session
+	}
+
+	async save(userId: string, session: ParlayBuilderSession): Promise<void> {
+		await this.cache.set(
+			parlayBuilderKey(userId),
+			session,
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	}
+
+	async clear(userId: string): Promise<void> {
+		await this.cache.remove(parlayBuilderKey(userId))
+	}
+
+	async setStake(
+		userId: string,
+		stake: number,
+	): Promise<ParlayBuilderSession> {
+		if (!Number.isSafeInteger(stake) || stake <= 0) {
+			throw new Error('Stake must be a whole number greater than $0.')
+		}
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		const updated = { ...session, stake }
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async removeLeg(
+		userId: string,
+		index: number,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		if (index < 0 || index >= session.legs.length) {
+			throw new Error('That parlay leg is no longer available.')
+		}
+		const updated = {
+			...session,
+			legs: session.legs.filter((_, i) => i !== index),
+		}
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async addLeg(
+		userId: string,
+		selection: AddParlayLegSelection,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
+			throw new Error('A parlay can contain at most 6 legs.')
+		}
+		if (session.legs.some((leg) => leg.event_id === selection.matchId)) {
+			throw new Error('Each parlay leg must use a different game.')
+		}
+
+		const leg = await this.resolveLeg(selection)
+		const updated = { ...session, legs: [...session.legs, leg] }
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async resolveLeg(
+		selection: AddParlayLegSelection,
+	): Promise<ParlayBuilderLeg> {
+		const match = await this.matchCache.getMatch(selection.matchId)
+		if (!match?.id || !match.home_team || !match.away_team) {
+			throw new Error('Choose a valid upcoming game from the list.')
+		}
+		if (
+			match.commence_time &&
+			new Date(match.commence_time).getTime() <= Date.now()
+		) {
+			throw new Error(
+				'That game has already started. Choose another game.',
+			)
+		}
+
+		const outcomes = await this.parlayApi.getEventOutcomes(
+			match.sport ?? 'nba',
+			match.id,
+		)
+		const marketOutcomes = outcomes.filter(
+			(outcome) => outcome.market_key === selection.marketKey,
+		)
+		const outcome = this.selectOutcome(
+			marketOutcomes,
+			selection.side,
+			match.home_team,
+			match.away_team,
+		)
+		if (!outcome?.uuid || outcome.price === undefined) {
+			throw new Error(
+				'That selection is no longer available. Try another leg.',
+			)
+		}
+
+		const selectionDisplay = this.selectionDisplay(
+			selection.marketKey,
+			selection.side,
+			match.home_team,
+			match.away_team,
+			outcome.point,
+		)
+		return {
+			event_id: match.id,
+			outcome_uuid: outcome.uuid,
+			market_key: selection.marketKey,
+			selection_display: selectionDisplay,
+			odds_american: outcome.price,
+			point: outcome.point ?? null,
+			commence_time: match.commence_time ?? new Date().toISOString(),
+		}
+	}
+
+	private selectOutcome(
+		outcomes: EventOutcome[],
+		side: ParlaySide,
+		homeTeam: string,
+		awayTeam: string,
+	): EventOutcome | undefined {
+		return outcomes.find((outcome) => {
+			const name = outcome.name?.trim().toLowerCase()
+			const position = outcome.position?.toLowerCase()
+			const outcomeType = outcome.outcome_type?.toLowerCase()
+			if (side === 'over' || side === 'under') {
+				return name === side || outcomeType === side
+			}
+			const team = side === 'home' ? homeTeam : awayTeam
+			return (
+				name === team.toLowerCase() ||
+				position === side ||
+				outcomeType === `team_${side}`
+			)
+		})
+	}
+
+	private selectionDisplay(
+		market: ParlayMarketKey,
+		side: ParlaySide,
+		homeTeam: string,
+		awayTeam: string,
+		point?: number | null,
+	): string {
+		if (market === 'totals')
+			return `${side === 'over' ? 'Over' : 'Under'}${point === undefined || point === null ? '' : ` ${point}`}`
+		const team = side === 'home' ? homeTeam : awayTeam
+		return market === 'spreads' && point !== undefined && point !== null
+			? `${team} ${point > 0 ? '+' : ''}${point}`
+			: team
+	}
+
+	validateForPlacement(session: ParlayBuilderSession): void {
+		if (session.legs.length < 2) {
+			throw new Error('Add at least 2 different games before confirming.')
+		}
+		if (session.legs.length > PARLAY_BUILDER_MAX_LEGS) {
+			throw new Error('A parlay can contain at most 6 legs.')
+		}
+		if (!session.stake)
+			throw new Error('Set a stake before confirming your parlay.')
+	}
+
+	getOddsSummary(session: ParlayBuilderSession): {
+		american: number
+		decimal: number
+		potentialPayout: number | null
+	} {
+		if (session.legs.length === 0) {
+			return { american: 0, decimal: 1, potentialPayout: null }
+		}
+		const combined = combineAmericanOdds(
+			session.legs.map((leg) => leg.odds_american),
+		)
+		return {
+			...combined,
+			potentialPayout:
+				session.stake === null
+					? null
+					: Math.round(session.stake * combined.decimal * 100) / 100,
+		}
+	}
+
+	render(session: ParlayBuilderSession): InteractionEditReplyOptions {
+		const summary = this.getOddsSummary(session)
+		const container = new ContainerBuilder().setAccentColor(0x5865f2)
+		container.addTextDisplayComponents((text) =>
+			text.setContent('## 🎲 Build your parlay'),
+		)
+		if (session.legs.length === 0) {
+			container.addTextDisplayComponents((text) =>
+				text.setContent(
+					'Add 2–6 legs from different upcoming games to get started.',
+				),
+			)
+		}
+		for (const [index, leg] of session.legs.entries()) {
+			const section = new SectionBuilder()
+				.addTextDisplayComponents((text) =>
+					text.setContent(
+						`**${index + 1}. ${leg.selection_display}**\n${leg.market_key} • ${leg.odds_american > 0 ? '+' : ''}${leg.odds_american} • <t:${Math.floor(new Date(leg.commence_time).getTime() / 1000)}:f>`,
+					),
+				)
+				.setButtonAccessory(
+					new ButtonBuilder()
+						.setCustomId(`parlay_btn_remove_${index}`)
+						.setLabel('Remove')
+						.setStyle(ButtonStyle.Danger),
+				)
+			container.addSectionComponents(section)
+		}
+		container.addSeparatorComponents((separator) =>
+			separator.setDivider(true).setSpacing(SeparatorSpacingSize.Small),
+		)
+		const payoutText =
+			summary.potentialPayout === null
+				? 'Set a stake to calculate potential payout.'
+				: `Potential payout: **$${summary.potentialPayout.toFixed(2)}**`
+		container.addTextDisplayComponents((text) =>
+			text.setContent(
+				`Combined odds: **${summary.american > 0 ? '+' : ''}${summary.american || '—'}** (${summary.decimal.toFixed(2)}x)\nStake: **${session.stake === null ? 'Not set' : `$${session.stake.toFixed(2)}`}**\n${payoutText}`,
+			),
+		)
+		container.addActionRowComponents((row) =>
+			row.addComponents(
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_add')
+					.setLabel('Add Leg')
+					.setStyle(ButtonStyle.Primary),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_stake')
+					.setLabel('Set Stake')
+					.setStyle(ButtonStyle.Secondary),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_confirm')
+					.setLabel('Confirm')
+					.setStyle(ButtonStyle.Success)
+					.setDisabled(
+						session.legs.length < 2 || session.stake === null,
+					),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_cancel')
+					.setLabel('Cancel')
+					.setStyle(ButtonStyle.Danger),
+			),
+		)
+		return { components: [container], flags: MessageFlags.IsComponentsV2 }
+	}
+
+	renderMessage(
+		content: string,
+		color = 0xed4245,
+	): InteractionEditReplyOptions {
+		const container = new ContainerBuilder()
+			.setAccentColor(color)
+			.addTextDisplayComponents((text) => text.setContent(content))
+		return { components: [container], flags: MessageFlags.IsComponentsV2 }
+	}
+}
+
+export function logParlayBuilderError(
+	error: unknown,
+	metadata: Record<string, unknown>,
+): void {
+	logger.error('parlay_builder_error', {
+		...metadata,
+		error: error instanceof Error ? error.message : String(error),
+	})
+}
+
+export function getParlayErrorMessage(error: unknown): string {
+	const responseData = (error as { response?: { data?: unknown } })?.response
+		?.data
+	if (typeof responseData === 'object' && responseData !== null) {
+		const message = (responseData as { message?: unknown }).message
+		if (typeof message === 'string') return message
+		if (
+			Array.isArray(message) &&
+			message.every((item) => typeof item === 'string')
+		) {
+			return message.join(', ')
+		}
+	}
+	return error instanceof Error
+		? error.message
+		: 'Unable to process your parlay.'
+}

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../utils/logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getMatch: vi.fn(), getMatches: vi.fn() }
+	}),
+}))
+
+vi.mock('../../utils/api/Khronos/parlays/ParlayApiWrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getEventOutcomes: vi.fn() }
+	}),
+}))
+
+vi.mock('../../utils/cache/cache-manager.js', () => ({
+	CacheManager: vi.fn(),
+}))
+
+const {
+	PARLAY_BUILDER_MAX_LEGS,
+	PARLAY_BUILDER_TTL_SECONDS,
+	ParlayBuilderService,
+} = await import('../ParlayBuilderService.js')
+
+type CacheStub = {
+	get: ReturnType<typeof vi.fn>
+	set: ReturnType<typeof vi.fn>
+	remove: ReturnType<typeof vi.fn>
+}
+
+const makeCache = (): CacheStub => ({
+	get: vi.fn(),
+	set: vi.fn().mockResolvedValue(true),
+	remove: vi.fn().mockResolvedValue(true),
+})
+
+const makeSession = (legs = 0) => ({
+	legs: Array.from({ length: legs }, (_, index) => ({
+		event_id: `event-${index}`,
+		outcome_uuid: `outcome-${index}`,
+		market_key: 'h2h' as const,
+		selection_display: `Team ${index}`,
+		odds_american: 100,
+		point: null,
+		commence_time: '2099-01-01T00:00:00.000Z',
+	})),
+	stake: null,
+})
+
+describe('ParlayBuilderService', () => {
+	let cache: CacheStub
+	let matchCache: { getMatch: ReturnType<typeof vi.fn> }
+	let parlayApi: { getEventOutcomes: ReturnType<typeof vi.fn> }
+	let service: InstanceType<typeof ParlayBuilderService>
+
+	beforeEach(() => {
+		cache = makeCache()
+		matchCache = { getMatch: vi.fn() }
+		parlayApi = { getEventOutcomes: vi.fn() }
+		service = new ParlayBuilderService(
+			cache as never,
+			matchCache as never,
+			parlayApi as never,
+		)
+	})
+
+	it('stores one user session with the 15 minute TTL', async () => {
+		await service.start('user-1')
+
+		expect(cache.set).toHaveBeenCalledWith(
+			'parlay-builder:user-1',
+			{ legs: [], stake: null },
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	})
+
+	it('rejects duplicate events and the seventh leg', async () => {
+		cache.get.mockResolvedValue(makeSession(1))
+		await expect(
+			service.addLeg('user-1', {
+				matchId: 'event-0',
+				marketKey: 'h2h',
+				side: 'home',
+			}),
+		).rejects.toThrow('different game')
+
+		cache.get.mockResolvedValue(makeSession(PARLAY_BUILDER_MAX_LEGS))
+		await expect(
+			service.addLeg('user-1', {
+				matchId: 'event-new',
+				marketKey: 'h2h',
+				side: 'home',
+			}),
+		).rejects.toThrow('at most 6')
+	})
+
+	it('resolves a home moneyline outcome from Khronos', async () => {
+		cache.get.mockResolvedValue(makeSession())
+		matchCache.getMatch.mockResolvedValue({
+			id: 'event-1',
+			home_team: 'Home Team',
+			away_team: 'Away Team',
+			sport: 'basketball_nba',
+			commence_time: '2099-01-01T00:00:00.000Z',
+		})
+		parlayApi.getEventOutcomes.mockResolvedValue([
+			{
+				uuid: 'outcome-1',
+				market_key: 'h2h',
+				name: 'Home Team',
+				price: -110,
+			},
+		])
+
+		const result = await service.addLeg('user-1', {
+			matchId: 'event-1',
+			marketKey: 'h2h',
+			side: 'home',
+		})
+
+		expect(result.legs[0]).toMatchObject({
+			event_id: 'event-1',
+			outcome_uuid: 'outcome-1',
+			selection_display: 'Home Team',
+			odds_american: -110,
+		})
+		expect(cache.set).toHaveBeenLastCalledWith(
+			'parlay-builder:user-1',
+			expect.objectContaining({ legs: expect.any(Array) }),
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	})
+
+	it('calculates combined odds and stake-aware payout', async () => {
+		const session = {
+			...makeSession(2),
+			stake: 10,
+		}
+		const summary = service.getOddsSummary(session)
+
+		expect(summary.decimal).toBe(4)
+		expect(summary.american).toBe(300)
+		expect(summary.potentialPayout).toBe(40)
+	})
+
+	it('requires two legs and a stake before placement', () => {
+		expect(() => service.validateForPlacement(makeSession(1))).toThrow(
+			'at least 2',
+		)
+		expect(() =>
+			service.validateForPlacement({ ...makeSession(2), stake: null }),
+		).toThrow('Set a stake')
+	})
+
+	it('renders a Components V2 card with per-leg remove controls', () => {
+		const response = service.render({ ...makeSession(2), stake: 10 })
+		const container = response.components?.[0]
+		const json = (container as { toJSON: () => unknown }).toJSON()
+
+		expect(response.flags).toBeDefined()
+		expect(JSON.stringify(json)).toContain('parlay_btn_remove_0')
+		expect(JSON.stringify(json)).toContain('parlay_btn_confirm')
+	})
+})

--- a/src/utils/admin-handlers/admin-predictions-handler.ts
+++ b/src/utils/admin-handlers/admin-predictions-handler.ts
@@ -119,7 +119,8 @@ export class AdminPredictionsHandler {
 				return
 			}
 
-			// Delete the prediction
+			// The admin input resolves to the unique prediction UUID, so use the
+			// explicit DELETE /prediction/by-id/:prediction_id route.
 			await predictionApiWrapper.deletePredictionById({
 				predictionId: matchedPrediction.id,
 				userId: user.id,

--- a/src/utils/api/Khronos/bets/BetslipsManager.ts
+++ b/src/utils/api/Khronos/bets/BetslipsManager.ts
@@ -300,6 +300,42 @@ export class BetslipManager {
 		}
 	}
 
+	/**
+	 * Announce a successfully placed parlay through the same guild betting
+	 * channel pathway used by singles.
+	 */
+	public async announceParlayPlaced(
+		interaction: CommandInteraction | ButtonInteraction,
+		details: {
+			parlayId: string
+			legCount: number
+			stake: number
+			potentialPayout: number
+		},
+	): Promise<void> {
+		try {
+			if (!interaction.guildId) {
+				logger.warn('Cannot announce parlay - no guild context')
+				return
+			}
+
+			const publicEmbed = new EmbedBuilder()
+				.setDescription(
+					`<@${interaction.user.id}> placed a **${details.legCount}-leg parlay** for **\`$${details.stake.toFixed(2)}\`**!`,
+				)
+				.setColor(embedColors.success)
+				.setFooter({
+					text: `Potential payout: $${details.potentialPayout.toFixed(2)} • Parlay ${details.parlayId.slice(0, 8)}`,
+				})
+
+			await new GuildWrapper().sendToBettingChannel(interaction.guildId, {
+				embeds: [publicEmbed],
+			})
+		} catch (error) {
+			logger.warn('Failed to announce parlay placed', { error })
+		}
+	}
+
 	private formatBetStr(betAmount: string, payout: string, profit: string) {
 		const b = '**'
 		const formattedBetData = `${b}${betAmount}${b} -> ${b}${payout}${b}\n${b}Profit:${b} ${b}${profit}${b}`

--- a/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
+++ b/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../betslip-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getUserBetslips: vi.fn() }
+	}),
+}))
+
+vi.mock('../../parlays/ParlayApiWrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getUserParlays: vi.fn() }
+	}),
+}))
+
+const { MyBetsFormatterService } = await import(
+	'../mybets-formatter.service.js'
+)
+const { MyBetsPaginationService } = await import(
+	'../mybets-pagination.service.js'
+)
+
+const parlay = (overrides: Record<string, unknown> = {}) => ({
+	id: 'parlay-123456',
+	user_id: 'user-1',
+	guild_id: 'guild-1',
+	stake: 10,
+	combined_odds_american: 300,
+	potential_payout: 40,
+	actual_payout: null,
+	status: 'pending' as const,
+	leg_count: 3,
+	created_at: '2026-07-11T12:00:00.000Z',
+	settled_at: null,
+	legs: [
+		{
+			id: 'leg-late',
+			event_id: 'event-late',
+			outcome_uuid: 'outcome-late',
+			market_key: 'h2h' as const,
+			selection_display: 'Late Team',
+			odds_american: 100,
+			point: null,
+			commence_time: '2026-07-13T12:00:00.000Z',
+			result: 'pending' as const,
+			settled_at: null,
+		},
+		{
+			id: 'leg-early',
+			event_id: 'event-early',
+			outcome_uuid: 'outcome-early',
+			market_key: 'totals' as const,
+			selection_display: 'Over 220.5',
+			odds_american: -110,
+			point: 220.5,
+			commence_time: '2026-07-12T12:00:00.000Z',
+			result: 'pending' as const,
+			settled_at: null,
+		},
+	],
+	...overrides,
+})
+
+describe('MyBetsFormatterService parlays', () => {
+	const formatter = new MyBetsFormatterService()
+
+	it('orders parlay legs by commence time and renders pending glyphs', () => {
+		const line = formatter.formatPendingParlayLine(parlay())
+
+		expect(line.indexOf('Over 220.5')).toBeLessThan(
+			line.indexOf('Late Team'),
+		)
+		expect(line).toContain('⏳')
+		expect(line).toContain('Odds: `+300`')
+	})
+
+	it('highlights the lost leg in resolved history and renders push as neutral', () => {
+		const line = formatter.formatHistoryParlayLine(
+			parlay({
+				status: 'lost',
+				actual_payout: 0,
+				legs: parlay().legs.map((leg, index) => ({
+					...leg,
+					result: index === 0 ? ('lost' as const) : ('push' as const),
+				})),
+			}),
+		)
+
+		expect(line).toContain('busted')
+		expect(line).toContain('❌')
+		expect(line).toContain('➖')
+	})
+
+	it('only exposes pending parlays before the earliest leg starts', () => {
+		const pending = parlay({
+			legs: parlay().legs.map((leg) => ({
+				...leg,
+				commence_time: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+		const started = parlay({
+			legs: parlay().legs.map((leg, index) => ({
+				...leg,
+				commence_time:
+					index === 0
+						? '2020-01-01T00:00:00.000Z'
+						: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+
+		expect(formatter.canCancelParlay(pending)).toBe(true)
+		expect(formatter.canCancelParlay(started)).toBe(false)
+	})
+
+	it('adds a cancel button for cancellable pending parlays', async () => {
+		const pending = parlay({
+			legs: parlay().legs.map((leg) => ({
+				...leg,
+				commence_time: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+		const response = await formatter.buildEmbedResponse({
+			userId: 'user-1',
+			pendingBets: [],
+			pendingParlays: [pending],
+			historyParlays: [],
+			historyPage: {
+				bets: [],
+				parlays: [],
+				entries: [],
+				page: 1,
+				totalPages: 1,
+			},
+			groupedBets: [],
+		})
+
+		expect(JSON.stringify(response.components)).toContain(
+			'parlay_cancel_parlay-123456',
+		)
+	})
+})
+
+describe('MyBetsPaginationService parlay history', () => {
+	it('fetches singles and parlays together', async () => {
+		const betsWrapper = {
+			getUserBetslips: vi.fn().mockResolvedValue([
+				{ betresult: 'pending', dateofbet: '2026-07-11T00:00:00.000Z' },
+				{ betresult: 'won', dateofbet: '2026-07-10T00:00:00.000Z' },
+			]),
+		}
+		const parlaysWrapper = {
+			getUserParlays: vi.fn().mockResolvedValue({
+				parlays: [
+					parlay({ status: 'pending' }),
+					parlay({ status: 'lost' }),
+				],
+			}),
+		}
+		const service = new MyBetsPaginationService(
+			betsWrapper as never,
+			parlaysWrapper as never,
+		)
+
+		const result = await service.fetchUserBets('user-1')
+		expect(result.pendingBets).toHaveLength(1)
+		expect(result.historyBets).toHaveLength(1)
+		expect(result.pendingParlays).toHaveLength(1)
+		expect(result.historyParlays).toHaveLength(1)
+	})
+
+	it('paginates singles and parlays together in date order', () => {
+		const service = new MyBetsPaginationService(
+			{ getUserBetslips: vi.fn() } as never,
+			{ getUserParlays: vi.fn() } as never,
+		)
+		const page = service.getHistoryPage(
+			[
+				{
+					dateofbet: '2026-07-10T00:00:00.000Z',
+				} as never,
+			],
+			1,
+			[
+				parlay({
+					created_at: '2026-07-11T00:00:00.000Z',
+					status: 'lost',
+				}),
+			],
+		)
+
+		expect(page.entries).toHaveLength(2)
+		expect(page.entries[0]?.kind).toBe('parlay')
+		expect(page.entries[1]?.kind).toBe('bet')
+	})
+})

--- a/src/utils/api/Khronos/bets/mybets-formatter.service.ts
+++ b/src/utils/api/Khronos/bets/mybets-formatter.service.ts
@@ -17,11 +17,14 @@ import {
 	buildMyBetsNavCustomId,
 	mybetsNavPageId,
 } from '../../../../lib/interfaces/interaction-handlers/interaction-handlers.interface.js'
+import type { UserParlay } from '../parlays/ParlayApiWrapper.js'
 import type { BetsByDate, HistoryPage } from './mybets-pagination.service.js'
 
 export interface MyBetsDisplayData {
 	userId: string
 	pendingBets: PlacedBetslip[]
+	pendingParlays: UserParlay[]
+	historyParlays: UserParlay[]
 	historyPage: HistoryPage
 	groupedBets: BetsByDate[]
 }
@@ -73,6 +76,61 @@ export class MyBetsFormatterService {
 		return `${teamEmoji} ${shortName}`.trim()
 	}
 
+	private getParlayLegGlyph(
+		result: UserParlay['legs'][number]['result'],
+	): string {
+		switch (result) {
+			case 'won':
+				return '✅'
+			case 'lost':
+				return '❌'
+			case 'push':
+			case 'void':
+				return '➖'
+			default:
+				return '⏳'
+		}
+	}
+
+	private formatParlayLegs(parlay: UserParlay): string {
+		return [...parlay.legs]
+			.sort(
+				(a, b) =>
+					new Date(a.commence_time).getTime() -
+					new Date(b.commence_time).getTime(),
+			)
+			.map((leg) => {
+				const busted = parlay.status === 'lost' && leg.result === 'lost'
+				return `${this.getParlayLegGlyph(leg.result)} ${busted ? `**${leg.selection_display} (busted)**` : leg.selection_display} • ${leg.market_key} • <t:${Math.floor(new Date(leg.commence_time).getTime() / 1000)}:d>`
+			})
+			.join('\n')
+	}
+
+	formatPendingParlayLine(parlay: UserParlay): string {
+		return `**🎲 ${parlay.leg_count}-leg Parlay**\nStake: \`$${Number(parlay.stake).toFixed(2)}\` • Odds: \`${parlay.combined_odds_american > 0 ? '+' : ''}${parlay.combined_odds_american}\` • Potential: \`$${Number(parlay.potential_payout).toFixed(2)}\`\n${this.formatParlayLegs(parlay)}`
+	}
+
+	formatHistoryParlayLine(parlay: UserParlay): string {
+		const payout =
+			parlay.actual_payout === null
+				? 'N/A'
+				: `$${Number(parlay.actual_payout).toFixed(2)}`
+		const status = parlay.status.replace('_', ' ')
+		return `**${parlay.status === 'won' ? '✅' : parlay.status === 'lost' ? '❌' : '➖'} ${parlay.leg_count}-leg Parlay — ${status}**\nStake: \`$${Number(parlay.stake).toFixed(2)}\` • Actual payout: \`${payout}\`\n${this.formatParlayLegs(parlay)}`
+	}
+
+	canCancelParlay(parlay: UserParlay, now = Date.now()): boolean {
+		return (
+			parlay.status === 'pending' &&
+			parlay.legs.length > 0 &&
+			Math.min(
+				...parlay.legs.map((leg) =>
+					new Date(leg.commence_time).getTime(),
+				),
+			) > now
+		)
+	}
+
 	formatPendingBetLine(bet: PlacedBetslip, guild?: Guild): string {
 		const team = this.formatTeamName(bet.team ?? 'Unknown', guild)
 		const amount = this.formatMoney(bet.amount)
@@ -111,18 +169,24 @@ export class MyBetsFormatterService {
 	async buildPendingEmbed(
 		pendingBets: PlacedBetslip[],
 		guild?: Guild,
+		pendingParlays: UserParlay[] = [],
 	): Promise<EmbedBuilder> {
 		const embed = new EmbedBuilder()
 			.setTitle('⏳ Pending Bets')
 			.setColor(embedColors.PlutoYellow)
 
-		if (pendingBets.length === 0) {
+		if (pendingBets.length === 0 && pendingParlays.length === 0) {
 			embed.setDescription('You have no pending bets.')
 			return embed
 		}
 
 		const lines = pendingBets.map((bet) =>
 			this.formatPendingBetLine(bet, guild),
+		)
+		lines.push(
+			...pendingParlays.map((parlay) =>
+				this.formatPendingParlayLine(parlay),
+			),
 		)
 		embed.setDescription(lines.join('\n\n'))
 		return embed
@@ -150,6 +214,9 @@ export class MyBetsFormatterService {
 			for (const bet of group.bets) {
 				lines.push(this.formatHistoryBetLine(bet, guild))
 			}
+		}
+		for (const parlay of historyPage.parlays) {
+			lines.push(this.formatHistoryParlayLine(parlay))
 		}
 
 		embed.setDescription(lines.join('\n\n'))
@@ -199,7 +266,7 @@ export class MyBetsFormatterService {
 		)
 
 		// Pending Bets Section
-		if (data.pendingBets.length > 0) {
+		if (data.pendingBets.length > 0 || data.pendingParlays.length > 0) {
 			container.addTextDisplayComponents((text) =>
 				text.setContent('## ⏳ Pending Bets'),
 			)
@@ -207,6 +274,11 @@ export class MyBetsFormatterService {
 			for (const bet of data.pendingBets) {
 				container.addTextDisplayComponents((text) =>
 					text.setContent(this.formatPendingBetLine(bet, guild)),
+				)
+			}
+			for (const parlay of data.pendingParlays) {
+				container.addTextDisplayComponents((text) =>
+					text.setContent(this.formatPendingParlayLine(parlay)),
 				)
 			}
 
@@ -222,7 +294,10 @@ export class MyBetsFormatterService {
 			),
 		)
 
-		if (data.historyPage.bets.length === 0) {
+		if (
+			data.historyPage.bets.length === 0 &&
+			data.historyPage.parlays.length === 0
+		) {
 			container.addTextDisplayComponents((text) =>
 				text.setContent(
 					'*No bet history found. Place some bets to see them here!*',
@@ -238,6 +313,11 @@ export class MyBetsFormatterService {
 						text.setContent(this.formatHistoryBetLine(bet, guild)),
 					)
 				}
+			}
+			for (const parlay of data.historyPage.parlays) {
+				container.addTextDisplayComponents((text) =>
+					text.setContent(this.formatHistoryParlayLine(parlay)),
+				)
 			}
 		}
 
@@ -267,6 +347,7 @@ export class MyBetsFormatterService {
 		const pendingEmbed = await this.buildPendingEmbed(
 			data.pendingBets,
 			guild,
+			data.pendingParlays,
 		)
 		embeds.push(pendingEmbed)
 
@@ -285,6 +366,21 @@ export class MyBetsFormatterService {
 				this.buildPaginationButtons(
 					data.historyPage.page,
 					data.historyPage.totalPages,
+				),
+			)
+		}
+		const cancellable = data.pendingParlays.filter((parlay) =>
+			this.canCancelParlay(parlay),
+		)
+		for (let index = 0; index < cancellable.length; index += 5) {
+			components.push(
+				new ActionRowBuilder<ButtonBuilder>().addComponents(
+					...cancellable.slice(index, index + 5).map((parlay) =>
+						new ButtonBuilder()
+							.setCustomId(`parlay_cancel_${parlay.id}`)
+							.setLabel(`Cancel ${parlay.id.slice(0, 6)}`)
+							.setStyle(ButtonStyle.Danger),
+					),
 				),
 			)
 		}

--- a/src/utils/api/Khronos/bets/mybets-pagination.service.ts
+++ b/src/utils/api/Khronos/bets/mybets-pagination.service.ts
@@ -2,16 +2,27 @@ import type { PlacedBetslip } from '@pluto-khronos/api-client'
 import { PlacedBetslipBetresultEnum } from '@pluto-khronos/api-client'
 import { format, isValid, parseISO } from 'date-fns'
 import { logger } from '../../../logging/WinstonLogger.js'
+import ParlayApiWrapper, {
+	type UserParlay,
+} from '../parlays/ParlayApiWrapper.js'
 import BetslipWrapper from './betslip-wrapper.js'
 
 export interface MyBetsData {
 	pendingBets: PlacedBetslip[]
 	historyBets: PlacedBetslip[]
+	pendingParlays: UserParlay[]
+	historyParlays: UserParlay[]
 	totalPages: number
 }
 
+export type HistoryEntry =
+	| { kind: 'bet'; bet: PlacedBetslip }
+	| { kind: 'parlay'; parlay: UserParlay }
+
 export interface HistoryPage {
 	bets: PlacedBetslip[]
+	parlays: UserParlay[]
+	entries: HistoryEntry[]
 	page: number
 	totalPages: number
 }
@@ -24,27 +35,65 @@ export interface BetsByDate {
 export class MyBetsPaginationService {
 	private readonly PAGE_SIZE = 10
 	private betslipWrapper: BetslipWrapper
+	private parlayWrapper: ParlayApiWrapper
 
-	constructor(betslipWrapper?: BetslipWrapper) {
+	constructor(
+		betslipWrapper?: BetslipWrapper,
+		parlayWrapper?: ParlayApiWrapper,
+	) {
 		this.betslipWrapper = betslipWrapper ?? new BetslipWrapper()
+		this.parlayWrapper = parlayWrapper ?? new ParlayApiWrapper()
 	}
 
 	async fetchUserBets(userId: string): Promise<MyBetsData> {
 		try {
-			const allBets = await this.betslipWrapper.getUserBetslips({
-				userid: userId,
-			})
+			const [betsResult, parlaysResult] = await Promise.allSettled([
+				this.betslipWrapper.getUserBetslips({ userid: userId }),
+				this.parlayWrapper.getUserParlays(userId, { limit: 100 }),
+			])
+			if (betsResult.status === 'rejected') throw betsResult.reason
+			const allBets = betsResult.value
+			const parlayResponse =
+				parlaysResult.status === 'fulfilled'
+					? parlaysResult.value
+					: { parlays: [] }
+			if (parlaysResult.status === 'rejected') {
+				logger.warn(
+					'Failed to fetch user parlays; showing singles only',
+					{
+						source: this.fetchUserBets.name,
+						userId,
+						error:
+							parlaysResult.reason instanceof Error
+								? parlaysResult.reason.message
+								: String(parlaysResult.reason),
+					},
+				)
+			}
 
 			const { pending, history } = this.splitBetsByStatus(allBets)
+			const pendingParlays = parlayResponse.parlays.filter(
+				(parlay) => parlay.status === 'pending',
+			)
+			const historyParlays = parlayResponse.parlays.filter(
+				(parlay) => parlay.status !== 'pending',
+			)
 			const sortedHistory = this.sortByDateDesc(history)
+			const sortedHistoryParlays =
+				this.sortParlaysByDateDesc(historyParlays)
 			const totalPages = Math.max(
 				1,
-				Math.ceil(sortedHistory.length / this.PAGE_SIZE),
+				Math.ceil(
+					(sortedHistory.length + sortedHistoryParlays.length) /
+						this.PAGE_SIZE,
+				),
 			)
 
 			return {
 				pendingBets: pending,
 				historyBets: sortedHistory,
+				pendingParlays,
+				historyParlays: sortedHistoryParlays,
 				totalPages,
 			}
 		} catch (error) {
@@ -86,17 +135,51 @@ export class MyBetsPaginationService {
 		})
 	}
 
-	getHistoryPage(historyBets: PlacedBetslip[], page: number): HistoryPage {
+	private sortParlaysByDateDesc(parlays: UserParlay[]): UserParlay[] {
+		return [...parlays].sort(
+			(a, b) =>
+				new Date(b.created_at).getTime() -
+				new Date(a.created_at).getTime(),
+		)
+	}
+
+	getHistoryPage(
+		historyBets: PlacedBetslip[],
+		page: number,
+		historyParlays: UserParlay[] = [],
+	): HistoryPage {
+		const entries: HistoryEntry[] = [
+			...historyBets.map((bet) => ({ kind: 'bet' as const, bet })),
+			...historyParlays.map((parlay) => ({
+				kind: 'parlay' as const,
+				parlay,
+			})),
+		].sort((a, b) => {
+			const dateA =
+				a.kind === 'bet' ? a.bet.dateofbet : a.parlay.created_at
+			const dateB =
+				b.kind === 'bet' ? b.bet.dateofbet : b.parlay.created_at
+			return (
+				new Date(dateB ?? 0).getTime() - new Date(dateA ?? 0).getTime()
+			)
+		})
 		const totalPages = Math.max(
 			1,
-			Math.ceil(historyBets.length / this.PAGE_SIZE),
+			Math.ceil(entries.length / this.PAGE_SIZE),
 		)
 		const clampedPage = Math.max(1, Math.min(page, totalPages))
 		const start = (clampedPage - 1) * this.PAGE_SIZE
 		const end = start + this.PAGE_SIZE
+		const pageEntries = entries.slice(start, end)
 
 		return {
-			bets: historyBets.slice(start, end),
+			bets: pageEntries.flatMap((entry) =>
+				entry.kind === 'bet' ? [entry.bet] : [],
+			),
+			parlays: pageEntries.flatMap((entry) =>
+				entry.kind === 'parlay' ? [entry.parlay] : [],
+			),
+			entries: pageEntries,
 			page: clampedPage,
 			totalPages,
 		}

--- a/src/utils/api/Khronos/guild/guild-wrapper.ts
+++ b/src/utils/api/Khronos/guild/guild-wrapper.ts
@@ -206,6 +206,7 @@ export default class GuildWrapper {
 	async sendToChannel(
 		channelId: string,
 		options: MessageCreateOptions,
+		expectedGuildId?: string,
 	): Promise<Message> {
 		this.validateSnowflake(channelId, 'prediction', 'unknown')
 
@@ -221,6 +222,11 @@ export default class GuildWrapper {
 		if (!channel || channel.type !== ChannelType.GuildText) {
 			throw new Error(
 				`Prediction channel ${channelId} could not be found or is not a text channel`,
+			)
+		}
+		if (expectedGuildId && channel.guild?.id !== expectedGuildId) {
+			throw new Error(
+				`Prediction channel ${channelId} does not belong to guild ${expectedGuildId}`,
 			)
 		}
 

--- a/src/utils/api/Khronos/guild/guild-wrapper.ts
+++ b/src/utils/api/Khronos/guild/guild-wrapper.ts
@@ -196,6 +196,38 @@ export default class GuildWrapper {
 	}
 
 	/**
+	 * Sends a message to an explicitly supplied Discord text channel.
+	 *
+	 * Khronos includes the resolved prediction channel in its daily props
+	 * payload. Using that channel here keeps the message reference returned to
+	 * Khronos authoritative even when guild configuration changes between
+	 * payload creation and delivery.
+	 */
+	async sendToChannel(
+		channelId: string,
+		options: MessageCreateOptions,
+	): Promise<Message> {
+		this.validateSnowflake(channelId, 'prediction', 'unknown')
+
+		let channel: Channel | null
+		try {
+			channel = await container.client.channels.fetch(channelId)
+		} catch (error) {
+			throw new Error(
+				`Failed to fetch prediction channel ${channelId}: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+
+		if (!channel || channel.type !== ChannelType.GuildText) {
+			throw new Error(
+				`Prediction channel ${channelId} could not be found or is not a text channel`,
+			)
+		}
+
+		return await channel.send(options)
+	}
+
+	/**
 	 * Retrieves the configured betting channel for a guild
 	 * @param guildId - Discord guild ID
 	 * @returns TextChannel for posting bets

--- a/src/utils/api/Khronos/guild/guild-wrapper.ts
+++ b/src/utils/api/Khronos/guild/guild-wrapper.ts
@@ -196,6 +196,43 @@ export default class GuildWrapper {
 	}
 
 	/**
+	 * Sends a message to an explicitly supplied text channel.
+	 *
+	 * This is used by trusted cross-service payloads that carry a channel
+	 * snapshot (for example, the Khronos daily-props delivery contract). The
+	 * configured prediction-channel helper remains the default for commands.
+	 */
+	async sendToChannel(
+		channelId: string,
+		options: MessageCreateOptions,
+		expectedGuildId?: string,
+	): Promise<Message> {
+		let channel: Channel | null
+		try {
+			channel = await container.client.channels.fetch(channelId)
+		} catch (error) {
+			throw new Error(
+				`Failed to fetch target channel ${channelId}: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+
+		if (!channel || channel.type !== ChannelType.GuildText) {
+			throw new Error(
+				`Target channel ${channelId} could not be found or is not a text channel`,
+			)
+		}
+
+		const textChannel = channel as TextChannel
+		if (expectedGuildId && textChannel.guild.id !== expectedGuildId) {
+			throw new Error(
+				`Target channel ${channelId} does not belong to guild ${expectedGuildId}`,
+			)
+		}
+
+		return await textChannel.send(options)
+	}
+
+	/**
 	 * Retrieves the configured betting channel for a guild
 	 * @param guildId - Discord guild ID
 	 * @returns TextChannel for posting bets

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -135,3 +135,8 @@ export default class ParlayApiWrapper {
 		return response.data
 	}
 }
+
+/** Alias used by mybets surfaces (TF-969). */
+export type UserParlay = ParlayResponse
+/** Alias used by mybets leg formatting (TF-969). */
+export type ParlayLeg = PlacedParlayLeg

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -1,0 +1,137 @@
+import type { AxiosRequestConfig } from 'axios'
+import { AxiosKhronosInstance } from '../../common/axios-config.js'
+
+export type ParlayMarketKey = 'h2h' | 'spreads' | 'totals'
+
+export interface ParlayLegInput {
+	event_id: string
+	outcome_uuid: string
+}
+
+export interface InitParlayRequest {
+	legs: ParlayLegInput[]
+	stake: number
+	guild_id: string
+	user_id: string
+}
+
+export interface ParlayLegPreview {
+	event_id: string
+	outcome_uuid: string
+	market_key: ParlayMarketKey
+	selection_display: string
+	odds_american: number
+	point: number | null
+	commence_time: string
+}
+
+export interface InitParlayResponse {
+	init_token: string
+	combined_odds_american: number
+	potential_payout: number
+	legs: ParlayLegPreview[]
+	expires_at: string
+}
+
+export interface PlacedParlayLeg extends ParlayLegPreview {
+	id: string
+	result: 'pending' | 'won' | 'lost' | 'push' | 'void'
+	settled_at: string | null
+}
+
+export interface ParlayResponse {
+	id: string
+	user_id: string
+	guild_id: string
+	stake: number
+	combined_odds_american: number
+	potential_payout: number
+	actual_payout: number | null
+	status: 'pending' | 'won' | 'lost' | 'push_refunded' | 'cancelled'
+	leg_count: number
+	created_at: string
+	settled_at: string | null
+	legs: PlacedParlayLeg[]
+}
+
+export interface UserParlaysResponse {
+	parlays: ParlayResponse[]
+	page: number
+	limit: number
+	total: number
+	total_pages: number
+}
+
+export interface EventOutcome {
+	uuid?: string
+	event_id?: string
+	market_key?: string
+	name?: string
+	description?: string
+	price?: number
+	point?: number | null
+	position?: string
+	outcome_type?: string
+	event_context?: {
+		commence_time?: string
+		home_team?: string
+		away_team?: string
+	}
+}
+
+export default class ParlayApiWrapper {
+	private readonly requestConfig: AxiosRequestConfig = {
+		validateStatus: (status) => status >= 200 && status < 300,
+	}
+
+	async init(payload: InitParlayRequest): Promise<InitParlayResponse> {
+		const response = await AxiosKhronosInstance.post<InitParlayResponse>(
+			'/parlays/init',
+			payload,
+			this.requestConfig,
+		)
+		return response.data
+	}
+
+	async place(initToken: string): Promise<ParlayResponse> {
+		const response = await AxiosKhronosInstance.post<ParlayResponse>(
+			'/parlays/place',
+			{ init_token: initToken },
+			this.requestConfig,
+		)
+		return response.data
+	}
+
+	async getUserParlays(
+		userId: string,
+		options: { page?: number; limit?: number; status?: string } = {},
+	): Promise<UserParlaysResponse> {
+		const response = await AxiosKhronosInstance.get<UserParlaysResponse>(
+			`/parlays/user/${encodeURIComponent(userId)}`,
+			{ ...this.requestConfig, params: options },
+		)
+		return response.data
+	}
+
+	async cancel(parlayId: string, userId: string): Promise<ParlayResponse> {
+		const response = await AxiosKhronosInstance.delete<ParlayResponse>(
+			`/parlays/${encodeURIComponent(parlayId)}`,
+			{
+				...this.requestConfig,
+				data: { user_id: userId },
+			},
+		)
+		return response.data
+	}
+
+	async getEventOutcomes(
+		sport: string,
+		eventId: string,
+	): Promise<EventOutcome[]> {
+		const response = await AxiosKhronosInstance.get<EventOutcome[]>(
+			`/outcomes/event/${encodeURIComponent(sport)}/${encodeURIComponent(eventId)}`,
+			this.requestConfig,
+		)
+		return response.data
+	}
+}

--- a/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
+++ b/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const get = vi.fn()
+const del = vi.fn()
+
+vi.mock('../../../common/axios-config.js', () => ({
+	AxiosKhronosInstance: { get, delete: del },
+}))
+
+const { default: ParlayApiWrapper } = await import('../ParlayApiWrapper.js')
+
+describe('ParlayApiWrapper', () => {
+	it('fetches user parlays with pagination parameters', async () => {
+		get.mockResolvedValueOnce({ data: { parlays: [], page: 2 } })
+
+		const result = await new ParlayApiWrapper().getUserParlays('user/1', {
+			page: 2,
+			limit: 25,
+			status: 'pending',
+		})
+
+		expect(result.parlays).toEqual([])
+		expect(get).toHaveBeenCalledWith(
+			'/parlays/user/user%2F1',
+			expect.objectContaining({
+				params: { page: 2, limit: 25, status: 'pending' },
+			}),
+		)
+	})
+
+	it('cancels a parlay with an ownership payload', async () => {
+		del.mockResolvedValueOnce({
+			data: { id: 'parlay-1', status: 'cancelled' },
+		})
+
+		await new ParlayApiWrapper().cancel('parlay/1', 'user-1')
+
+		expect(del).toHaveBeenCalledWith(
+			'/parlays/parlay%2F1',
+			expect.objectContaining({ data: { user_id: 'user-1' } }),
+		)
+	})
+})

--- a/src/utils/api/Khronos/prediction/__tests__/predictionApiWrapper.test.ts
+++ b/src/utils/api/Khronos/prediction/__tests__/predictionApiWrapper.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	removePrediction: vi.fn(),
+	removePredictionById: vi.fn(),
+}))
+
+vi.mock('@pluto-khronos/api-client', () => ({
+	AccountsApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	BetslipsApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	ChangelogsApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	Configuration: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	DiscordConfigApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	GuildsApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	MatchesApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	PredictionApi: vi.fn().mockImplementation(function () {
+		return mocks
+	}),
+}))
+
+vi.mock('../../../../../lib/startup/env.js', () => ({
+	default: {
+		KH_API_URL: 'https://khronos.test',
+		KH_PLUTO_CLIENT_KEY: 'test-key',
+	},
+}))
+
+const { default: PredictionApiWrapper } = await import(
+	'../predictionApiWrapper.js'
+)
+
+describe('PredictionApiWrapper deletion routes', () => {
+	beforeEach(() => {
+		mocks.removePrediction.mockReset()
+		mocks.removePredictionById.mockReset()
+	})
+
+	it('uses the event-based DELETE route explicitly', async () => {
+		const wrapper = new PredictionApiWrapper()
+		const params = { id: 'event-1', userId: 'user-1' }
+
+		await wrapper.deletePredictionByEvent(params)
+
+		expect(mocks.removePrediction).toHaveBeenCalledWith(params)
+		expect(mocks.removePredictionById).not.toHaveBeenCalled()
+	})
+
+	it('keeps the deprecated event-based deletion alias compatible', async () => {
+		const wrapper = new PredictionApiWrapper()
+		const params = { id: 'event-1', userId: 'user-1' }
+
+		await wrapper.deletePrediction(params)
+
+		expect(mocks.removePrediction).toHaveBeenCalledWith(params)
+	})
+
+	it('uses the prediction-id DELETE route explicitly', async () => {
+		const wrapper = new PredictionApiWrapper()
+		const params = { predictionId: 'prediction-1', userId: 'user-1' }
+
+		await wrapper.deletePredictionById(params)
+
+		expect(mocks.removePredictionById).toHaveBeenCalledWith(params)
+		expect(mocks.removePrediction).not.toHaveBeenCalled()
+	})
+})

--- a/src/utils/api/Khronos/prediction/predictionApiWrapper.ts
+++ b/src/utils/api/Khronos/prediction/predictionApiWrapper.ts
@@ -44,8 +44,23 @@ export default class PredictionApiWrapper {
 		}
 	}
 
-	async deletePrediction(params: RemovePredictionRequest) {
+	/**
+	 * Delete the user's prediction for an event.
+	 *
+	 * Khronos keeps this event-based DELETE route for callers that only have
+	 * the event ID. Keep the route intent in the wrapper name so callers do
+	 * not accidentally use it when they have a prediction ID.
+	 */
+	async deletePredictionByEvent(params: RemovePredictionRequest) {
 		await this.predictionApi.removePrediction(params)
+	}
+
+	/**
+	 * @deprecated Use deletePredictionByEvent so the event-based route is
+	 * explicit. Keep this alias while downstream consumers migrate.
+	 */
+	async deletePrediction(params: RemovePredictionRequest) {
+		return this.deletePredictionByEvent(params)
 	}
 
 	async getPredictionsFiltered(

--- a/src/utils/api/common/endpoints.ts
+++ b/src/utils/api/common/endpoints.ts
@@ -3,6 +3,7 @@ export class Endpoints {
 		bets: {},
 		notifiy: {
 			betResults: '/notifications/bets/results',
+			parlayResults: '/notifications/parlays/results',
 		},
 		channels: {
 			incoming: '/channels/incoming',

--- a/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+
+import {
+	validateDailyPropsPayload,
+	validateNotifyBetUsers,
+} from '../notification-utils.js'
+
+describe('notification payload validators', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('accepts a typed bet-results payload and preserves result discriminators', () => {
+		const result = validateNotifyBetUsers({
+			winners: [
+				{
+					userId: 'user-1',
+					betId: 101,
+					result: {
+						team: 'Home',
+						betAmount: 10,
+						payout: 20,
+						profit: 10,
+						newBalance: 110,
+						oldBalance: 100,
+					},
+				},
+			],
+			losers: null,
+			pushes: [],
+		})
+
+		expect(result?.winners).toHaveLength(1)
+		expect(result?.winners[0].result.outcome).toBe('won')
+		expect(result?.losers).toEqual([])
+		expect(logger.error).not.toHaveBeenCalled()
+	})
+
+	it('rejects a winner without a bet id and logs the schema issues', () => {
+		const result = validateNotifyBetUsers({
+			winners: [
+				{
+					userId: 'user-1',
+					result: { team: 'Home', betAmount: 10 },
+				},
+			],
+			losers: [],
+		})
+
+		expect(result).toBeNull()
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'push_payload_rejected',
+				schema: 'notificationBetResults',
+			}),
+		)
+	})
+
+	it('normalizes legacy flat push entries from the published package', () => {
+		const result = validateNotifyBetUsers({
+			winners: [],
+			losers: [],
+			pushes: [
+				{ userid: 'user-2', amount: 15, betid: 202, team: 'Away' },
+			],
+		})
+
+		expect(result?.pushes).toEqual([
+			{
+				userId: 'user-2',
+				betId: 202,
+				result: { outcome: 'push', team: 'Away', betAmount: 15 },
+			},
+		])
+	})
+
+	it('accepts a realistic daily props payload', () => {
+		const result = validateDailyPropsPayload({
+			props: [
+				{
+					event_id: 'event-1',
+					commence_time: '2026-07-11T00:00:00Z',
+					home_team: 'Home',
+					away_team: 'Away',
+					sport_title: 'NBA',
+					market_key: 'player_points',
+					bookmaker_key: 'draftkings',
+					description: 'Player',
+					point: 20.5,
+					over: {
+						outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+						outcome_name: 'Over',
+						price: -110,
+					},
+					under: {
+						outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+						outcome_name: 'Under',
+						price: -110,
+					},
+				},
+			],
+			guilds: [
+				{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' },
+			],
+		})
+
+		expect(result?.props).toHaveLength(1)
+		expect(logger.error).not.toHaveBeenCalled()
+	})
+
+	it('rejects a daily props payload with an invalid guild channel', () => {
+		const result = validateDailyPropsPayload({
+			props: [],
+			guilds: [{ guild_id: 42, channel_id: 'channel-1', sport: 'nba' }],
+		})
+
+		expect(result).toBeNull()
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'push_payload_rejected',
+				schema: 'dailyPropsPayload',
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.controller.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.controller.parlay.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const processParlayResult = vi.fn()
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../notifications.service.js', () => ({
+	default: class MockNotificationService {
+		processParlayResult = processParlayResult
+	},
+}))
+
+import NotificationRouter from '../notifications.controller.js'
+
+const validPayload = {
+	kind: 'won',
+	parlay_id: '11111111-1111-4111-8111-111111111110',
+	user_id: 'user-1',
+	stake: 10,
+	combined_odds_american: 377,
+	payout: 47.7,
+	actual_payout: 47.7,
+	legs: [
+		{
+			id: 'leg-1',
+			event_id: 'event-1',
+			outcome_uuid: 'outcome-1',
+			market_key: 'h2h',
+			selection_display: 'Lakers',
+			odds_american: -110,
+			point: null,
+			commence_time: '2026-07-11T20:00:00.000Z',
+			result: 'won',
+		},
+		{
+			id: 'leg-2',
+			event_id: 'event-2',
+			outcome_uuid: 'outcome-2',
+			market_key: 'totals',
+			selection_display: 'Over 220.5',
+			odds_american: 105,
+			point: 220.5,
+			commence_time: '2026-07-11T20:00:00.000Z',
+			result: 'won',
+		},
+	],
+}
+
+function getParlayRoute() {
+	const route = NotificationRouter.stack.find(
+		(layer) => layer.path === '/notifications/parlays/results',
+	)
+	if (!route) throw new Error('Parlay notification route not registered')
+	return route.stack[0]
+}
+
+describe('POST /notifications/parlays/results', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns 200 after processing a valid payload', async () => {
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+		}
+
+		await getParlayRoute()(ctx as never, async () => undefined)
+
+		expect(processParlayResult).toHaveBeenCalledOnce()
+		expect(ctx.status).toBe(200)
+		expect(ctx.body).toEqual({ success: true })
+	})
+
+	it('returns 422 and skips delivery for malformed payloads', async () => {
+		const ctx = {
+			request: { body: { ...validPayload, parlay_id: 'not-a-uuid' } },
+			body: undefined as unknown,
+			status: 200,
+		}
+
+		await getParlayRoute()(ctx as never, async () => undefined)
+
+		expect(processParlayResult).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(422)
+		expect(ctx.body).toEqual({
+			success: false,
+			error: 'Invalid parlay notification data. Failed Zod validation.',
+		})
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	send: vi.fn(),
+	fetch: vi.fn(),
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	container: {
+		client: {
+			users: {
+				fetch: mocks.fetch,
+			},
+		},
+	},
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: mocks.logger,
+}))
+
+import NotificationService from '../notifications.service.js'
+
+const baseLeg = {
+	id: '00000000-0000-0000-0000-000000000001',
+	event_id: 'event-1',
+	outcome_uuid: 'outcome-1',
+	market_key: 'h2h' as const,
+	selection_display: 'Lakers',
+	odds_american: 125,
+	point: null,
+	commence_time: new Date('2026-07-11T20:00:00.000Z'),
+	result: 'won' as const,
+}
+
+function makePayload(kind: 'won' | 'busted' | 'push_refunded') {
+	return {
+		kind,
+		parlay_id: '11111111-1111-4111-8111-111111111110',
+		user_id: 'user-1',
+		stake: 10,
+		combined_odds_american: 377,
+		payout: kind === 'won' ? 47.7 : 0,
+		actual_payout:
+			kind === 'won' ? 47.7 : kind === 'push_refunded' ? 10 : 0,
+		refund_amount: kind === 'push_refunded' ? 10 : undefined,
+		old_balance: kind === 'won' ? 100 : undefined,
+		new_balance: kind === 'won' ? 137.7 : undefined,
+		legs: [
+			baseLeg,
+			{
+				...baseLeg,
+				id: '00000000-0000-0000-0000-000000000002',
+				event_id: 'event-2',
+				selection_display: 'Celtics',
+				odds_american: -110,
+				result:
+					kind === 'busted'
+						? ('lost' as const)
+						: kind === 'push_refunded'
+							? ('push' as const)
+							: ('won' as const),
+			},
+		],
+	}
+}
+
+describe('NotificationService.processParlayResult', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.fetch.mockResolvedValue({ send: mocks.send })
+	})
+
+	it.each([
+		['won', '🎉 Parlay Won! 🎉', 0x57f287],
+		['busted', '❌ Parlay Busted', 0xff6961],
+		['push_refunded', '🔄 Parlay Refunded', 0xffa500],
+	] as const)('sends a distinct %s multi-leg embed', async (kind, title, color) => {
+		await new NotificationService().processParlayResult(makePayload(kind))
+
+		expect(mocks.fetch).toHaveBeenCalledWith('user-1')
+		expect(mocks.send).toHaveBeenCalledOnce()
+		const [message] = mocks.send.mock.calls[0] as [
+			{ embeds: Array<{ toJSON: () => Record<string, unknown> }> },
+		]
+		const embed = message.embeds[0].toJSON()
+		expect(embed.title).toBe(title)
+		expect(embed.color).toBe(color)
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: '🧾 Legs' }),
+				expect.objectContaining({
+					name: '📈 Combined Odds',
+					value: '+377',
+				}),
+			]),
+		)
+		const legsField = (
+			embed.fields as Array<{ name: string; value: string }>
+		).find((field) => field.name === '🧾 Legs')
+		expect(legsField?.value).toContain('+125')
+		expect(legsField?.value).toContain('-110')
+	})
+
+	it('logs Discord delivery errors as critical and does not throw', async () => {
+		mocks.fetch.mockRejectedValue(new Error('DMs closed'))
+
+		await expect(
+			new NotificationService().processParlayResult(makePayload('won')),
+		).resolves.toBeUndefined()
+
+		expect(mocks.logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'parlay.notification.delivery_failed',
+				critical: true,
+				parlay_id: '11111111-1111-4111-8111-111111111110',
+			}),
+		)
+	})
+
+	it('falls back to payout and stake when nullable amounts are absent', async () => {
+		const payload = {
+			...makePayload('won'),
+			actual_payout: null,
+			payout: 47.7,
+		}
+		await new NotificationService().processParlayResult(payload)
+		const embed = (
+			mocks.send.mock.calls[0][0].embeds[0] as {
+				toJSON: () => { fields: Array<{ name: string; value: string }> }
+			}
+		).toJSON()
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: '🏆 Payout', value: '$47.70' }),
+			]),
+		)
+	})
+
+	it('keeps every leg field within Discord limits', async () => {
+		const payload = {
+			...makePayload('won'),
+			legs: Array.from({ length: 30 }, (_, index) => ({
+				...baseLeg,
+				id: `leg-${index}`,
+				selection_display: 'A'.repeat(1200),
+			})),
+		}
+		await new NotificationService().processParlayResult(payload)
+		const embed = (
+			mocks.send.mock.calls[0][0].embeds[0] as {
+				toJSON: () => { fields: Array<{ name: string; value: string }> }
+			}
+		).toJSON()
+		for (const field of embed.fields.filter((field) =>
+			field.name.startsWith('🧾 Legs'),
+		)) {
+			expect(field.value.length).toBeLessThanOrEqual(1024)
+		}
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+
+import NotificationService from '../notifications.service.js'
+
+describe('NotificationService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('delivers winners when the wire payload omits optional balances', async () => {
+		const service = new NotificationService()
+		const notifyUser = vi
+			.spyOn(service, 'notifyUser')
+			.mockResolvedValue(undefined)
+
+		await service.processBetResults({
+			winners: [
+				{
+					userId: 'user-1',
+					betId: 101,
+					result: {
+						outcome: 'won',
+						team: 'Home',
+						betAmount: 10,
+						payout: 20,
+						profit: 10,
+					},
+				},
+			],
+			losers: [],
+			pushes: [],
+		})
+
+		expect(notifyUser).toHaveBeenCalledWith(
+			expect.objectContaining({
+				displayResult: expect.objectContaining({
+					displayOldBalance: 'Unavailable',
+					displayNewBalance: 'Unavailable',
+				}),
+			}),
+		)
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'notification_balance_unavailable',
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+import { validateParlayResultNotification } from '../parlay-notification-utils.js'
+
+const validLeg = {
+	id: '00000000-0000-0000-0000-000000000001',
+	event_id: 'event-1',
+	outcome_uuid: 'outcome-1',
+	market_key: 'h2h' as const,
+	selection_display: 'Lakers',
+	odds_american: -110,
+	point: null,
+	commence_time: '2026-07-11T20:00:00.000Z',
+	result: 'won' as const,
+}
+
+const validPayload = {
+	kind: 'won' as const,
+	parlay_id: '11111111-1111-4111-8111-111111111110',
+	user_id: 'user-1',
+	stake: 10,
+	combined_odds_american: 377,
+	payout: 47.7,
+	actual_payout: 47.7,
+	old_balance: 100,
+	new_balance: 137.7,
+	legs: [validLeg, { ...validLeg, id: 'leg-2', event_id: 'event-2' }],
+}
+
+describe('validateParlayResultNotification', () => {
+	it('accepts a strict won payload', () => {
+		const result = validateParlayResultNotification(validPayload)
+		expect(result).not.toBeNull()
+		expect(result).toMatchObject({
+			parlay_id: validPayload.parlay_id,
+			kind: 'won',
+		})
+		expect(result?.legs[0].commence_time).toEqual(
+			new Date(validLeg.commence_time),
+		)
+	})
+
+	it('rejects malformed payloads', () => {
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				parlay_id: 'not-a-uuid',
+			}),
+		).toBeNull()
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				legs: [
+					{
+						...validLeg,
+						commence_time: 'not-a-date',
+					},
+				],
+			}),
+		).toBeNull()
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				payout: undefined,
+				actual_payout: null,
+			}),
+		).toBeNull()
+	})
+})

--- a/src/utils/api/routes/notifications/notification-utils.ts
+++ b/src/utils/api/routes/notifications/notification-utils.ts
@@ -1,8 +1,9 @@
-import { notificationBetResultsSchema } from '@pluto-khronos/types'
-import type {
-	BetNotificationPush,
-	NotifyBetUsers,
-} from './notifications.interface.js'
+import { logger } from '../../../logging/WinstonLogger.js'
+import {
+	dailyPropsPayloadSchema,
+	notificationBetResultsSchema,
+} from '../shared-payload-schemas.js'
+import type { NotifyBetUsers } from './notifications.interface.js'
 
 export function validateNotifyBetUsers(
 	payload: unknown,
@@ -10,30 +11,57 @@ export function validateNotifyBetUsers(
 	const result = notificationBetResultsSchema.safeParse(payload)
 
 	if (!result.success) {
-		console.error({
+		logger.error({
 			method: 'validateNotifyBetUsers',
-			message: 'Invalid notification payload',
+			event: 'push_payload_rejected',
+			schema: 'notificationBetResults',
 			errors: result.error.issues,
 		})
 		return null
 	}
 
-	// Transform Zod output to match our internal types
-	// Transform pushes from IBetslipPush[] to BetNotificationPush[]
-	const transformedPushes: BetNotificationPush[] | undefined =
-		result.data.pushes?.map((push) => ({
-			userId: push.userid,
-			betId: push.betid,
-			result: {
-				outcome: 'push' as const,
-				team: push.team,
-				betAmount: push.amount,
-			},
-		}))
-
 	return {
-		winners: result.data.winners || [],
-		losers: result.data.losers || [],
-		pushes: transformedPushes || [],
+		winners: (result.data.winners ?? []).map((winner) => ({
+			...winner,
+			result: { ...winner.result, outcome: 'won' as const },
+		})),
+		losers: (result.data.losers ?? []).map((loser) => ({
+			...loser,
+			result: { ...loser.result, outcome: 'lost' as const },
+		})),
+		pushes: (result.data.pushes ?? []).map((push) => {
+			if ('userid' in push) {
+				return {
+					userId: push.userid,
+					betId: push.betid,
+					result: {
+						outcome: 'push' as const,
+						team: push.team,
+						betAmount: push.amount,
+					},
+				}
+			}
+
+			return {
+				...push,
+				result: { ...push.result, outcome: 'push' as const },
+			}
+		}),
 	}
+}
+
+export function validateDailyPropsPayload(payload: unknown) {
+	const result = dailyPropsPayloadSchema.safeParse(payload)
+
+	if (!result.success) {
+		logger.error({
+			method: 'validateDailyPropsPayload',
+			event: 'push_payload_rejected',
+			schema: 'dailyPropsPayload',
+			errors: result.error.issues,
+		})
+		return null
+	}
+
+	return result.data
 }

--- a/src/utils/api/routes/notifications/notification-utils.ts
+++ b/src/utils/api/routes/notifications/notification-utils.ts
@@ -21,15 +21,35 @@ export function validateNotifyBetUsers(
 	// Transform Zod output to match our internal types
 	// Transform pushes from IBetslipPush[] to BetNotificationPush[]
 	const transformedPushes: BetNotificationPush[] | undefined =
-		result.data.pushes?.map((push) => ({
-			userId: push.userid,
-			betId: push.betid,
-			result: {
-				outcome: 'push' as const,
-				team: push.team,
-				betAmount: push.amount,
-			},
-		}))
+		result.data.pushes?.map((push) => {
+			if ('userid' in push) {
+				const legacyPush = push as unknown as {
+					userid: string
+					betid: number
+					team: string
+					amount: number
+				}
+				return {
+					userId: legacyPush.userid,
+					betId: legacyPush.betid,
+					result: {
+						outcome: 'push' as const,
+						team: legacyPush.team,
+						betAmount: legacyPush.amount,
+					},
+				}
+			}
+
+			return {
+				userId: push.userId,
+				betId: push.betId,
+				result: {
+					outcome: 'push' as const,
+					team: push.result.team,
+					betAmount: push.result.betAmount,
+				},
+			}
+		})
 
 	return {
 		winners: result.data.winners || [],

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -7,25 +7,20 @@ const NotificationRouter = new Router()
 
 NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 	const rawPayload = ctx.request.body || {}
-	console.debug({
-		method: 'NotificationRouter',
-		message: 'Notification data received.',
-		data: rawPayload,
-	})
 
 	const validatedData = validateNotifyBetUsers(rawPayload)
 
 	if (!validatedData) {
-		console.debug({
+		logger.warn({
 			method: 'NotificationRouter',
-			message: 'Invalid notification data was received.',
-			data: rawPayload,
+			event: 'push_payload_rejected',
+			schema: 'notificationBetResults',
 		})
 		ctx.body = {
 			success: false,
 			error: 'Invalid notification data. Failed Zod validation.',
 		}
-		ctx.status = 400
+		ctx.status = 422
 		return
 	}
 

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -2,6 +2,7 @@ import Router from '@koa/router'
 import { logger } from '../../../logging/WinstonLogger.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
+import { validateParlayResultNotification } from './parlay-notification-utils.js'
 
 const NotificationRouter = new Router()
 
@@ -39,6 +40,43 @@ NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 		ctx.body = {
 			success: false,
 			error: 'Failed to process notifications',
+		}
+		ctx.status = 500
+	}
+})
+
+NotificationRouter.post('/notifications/parlays/results', async (ctx) => {
+	const rawPayload = ctx.request.body || {}
+	const validatedData = validateParlayResultNotification(rawPayload)
+
+	if (!validatedData) {
+		ctx.body = {
+			success: false,
+			error: 'Invalid parlay notification data. Failed Zod validation.',
+		}
+		ctx.status = 422
+		return
+	}
+
+	try {
+		await new NotificationService().processParlayResult(validatedData)
+		ctx.body = {
+			success: true,
+		}
+	} catch (error) {
+		logger.error({
+			method: 'NotificationRouter',
+			event: 'parlay.notification.processing_failed',
+			message: 'CRITICAL: Failed to process parlay result notification',
+			error: error instanceof Error ? error.message : error,
+			critical: true,
+			parlay_id: validatedData.parlay_id,
+			user_id: validatedData.user_id,
+			kind: validatedData.kind,
+		})
+		ctx.body = {
+			success: false,
+			error: 'Failed to process parlay notifications',
 		}
 		ctx.status = 500
 	}

--- a/src/utils/api/routes/notifications/notifications.interface.ts
+++ b/src/utils/api/routes/notifications/notifications.interface.ts
@@ -10,8 +10,8 @@ export interface ResultWon {
 	betAmount: number
 	payout: number
 	profit: number
-	newBalance: number
-	oldBalance: number
+	newBalance?: number
+	oldBalance?: number
 }
 
 export interface ResultLost {

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -13,6 +13,7 @@ import type {
 	DisplayResultWon,
 	NotifyBetUsers,
 } from './notifications.interface.js'
+import type { ParlayResultNotification } from './parlay-notification-contract.js'
 
 export default class NotificationService {
 	async processBetResults(data: NotifyBetUsers): Promise<void> {
@@ -109,6 +110,242 @@ export default class NotificationService {
 
 				await this.notifyUser(displayPush)
 			}
+		}
+	}
+
+	/**
+	 * Deliver one multi-leg parlay resolution to its owner.
+	 *
+	 * Discord delivery failures are intentionally swallowed after structured
+	 * logging, matching the singles notification route's no-retry-storm
+	 * behavior. Khronos still receives a successful HTTP response when Discord
+	 * is unavailable.
+	 */
+	async processParlayResult(data: ParlayResultNotification): Promise<void> {
+		const embeds = this.buildParlayEmbeds(data)
+		await this.sendParlayEmbeds(data.user_id, data, embeds)
+	}
+
+	private buildParlayEmbeds(data: ParlayResultNotification): EmbedBuilder[] {
+		const combinedOdds = this.formatAmericanOdds(
+			data.combined_odds_american,
+		)
+
+		const baseEmbed = new EmbedBuilder()
+			.setTimestamp()
+			.setFooter({ text: `Pluto | Parlay ID: ${data.parlay_id}` })
+			.addFields({
+				name: '📈 Combined Odds',
+				value: combinedOdds,
+				inline: true,
+			})
+
+		switch (data.kind) {
+			case 'won': {
+				baseEmbed
+					.setTitle('🎉 Parlay Won! 🎉')
+					.setColor('#57f287')
+					.addFields(
+						{
+							name: '💰 Stake',
+							value: MoneyFormatter.toUSD(data.stake),
+							inline: true,
+						},
+						{
+							name: '🏆 Payout',
+							value: MoneyFormatter.toUSD(
+								data.actual_payout ?? data.payout ?? 0,
+							),
+							inline: true,
+						},
+					)
+				if (
+					data.old_balance !== undefined &&
+					data.new_balance !== undefined
+				) {
+					baseEmbed.addFields({
+						name: '📊 Balance Update',
+						value: `${MoneyFormatter.toUSD(data.old_balance)} → ${MoneyFormatter.toUSD(data.new_balance)}`,
+						inline: false,
+					})
+				}
+				break
+			}
+			case 'busted':
+			case 'lost':
+				baseEmbed
+					.setTitle('❌ Parlay Busted')
+					.setColor('#ff6961')
+					.addFields({
+						name: '💸 Lost',
+						value: MoneyFormatter.toUSD(data.stake),
+						inline: true,
+					})
+				break
+			case 'push_refunded':
+				baseEmbed
+					.setTitle('🔄 Parlay Refunded')
+					.setColor('#ffa500')
+					.addFields({
+						name: '💵 Refunded Amount',
+						value: MoneyFormatter.toUSD(
+							data.refund_amount ??
+								data.actual_payout ??
+								data.stake,
+						),
+						inline: true,
+					})
+					.addFields({
+						name: 'ℹ️ Reason',
+						value: 'All eligible legs pushed or were voided. Your stake has been refunded.',
+						inline: false,
+					})
+				break
+		}
+
+		const groups = this.buildParlayLegFieldGroups(data)
+		if (groups.length === 0) return [baseEmbed]
+		return groups.map((fields, index) => {
+			const embed =
+				index === 0
+					? baseEmbed
+					: new EmbedBuilder()
+							.setTitle('🧾 Parlay Legs (continued)')
+							.setTimestamp()
+							.setFooter({
+								text: `Pluto | Parlay ID: ${data.parlay_id}`,
+							})
+			embed.addFields(...fields)
+			return embed
+		})
+	}
+
+	private buildParlayLegFieldGroups(
+		data: ParlayResultNotification,
+	): Array<Array<{ name: string; value: string; inline: false }>> {
+		const maxFieldLength = 800
+		const maxFieldsPerEmbed = 20
+		const maxLegCharactersPerEmbed = 4500
+		const groups: Array<
+			Array<{ name: string; value: string; inline: false }>
+		> = []
+		let currentGroup: Array<{
+			name: string
+			value: string
+			inline: false
+		}> = []
+		let currentLines: string[] = []
+		let currentFieldLength = 0
+		let currentGroupLength = 0
+
+		const flushField = () => {
+			if (currentLines.length === 0) return
+			currentGroup.push({
+				name:
+					currentGroup.length === 0
+						? '🧾 Legs'
+						: `🧾 Legs (${currentGroup.length + 1})`,
+				value: currentLines.join('\n'),
+				inline: false,
+			})
+			currentLines = []
+			currentFieldLength = 0
+		}
+		const flushGroup = () => {
+			flushField()
+			if (currentGroup.length === 0) return
+			groups.push(currentGroup)
+			currentGroup = []
+			currentGroupLength = 0
+		}
+
+		for (const leg of data.legs) {
+			const selection = leg.selection_display
+			const shortenedSelection =
+				selection.length > 350
+					? `${selection.slice(0, 349)}…`
+					: selection
+			const line = `${this.parlayLegGlyph(leg.result)} ${shortenedSelection} (${this.formatAmericanOdds(leg.odds_american)})`
+			if (
+				currentLines.length > 0 &&
+				currentFieldLength + line.length + 1 > maxFieldLength
+			) {
+				flushField()
+			}
+			if (
+				currentGroup.length >= maxFieldsPerEmbed ||
+				(currentGroupLength > 0 &&
+					currentGroupLength + line.length + 1 >
+						maxLegCharactersPerEmbed)
+			) {
+				flushGroup()
+			}
+			currentLines.push(line)
+			currentFieldLength += line.length + 1
+			currentGroupLength += line.length + 1
+		}
+		flushGroup()
+
+		return groups
+	}
+
+	private parlayLegGlyph(
+		result: ParlayResultNotification['legs'][number]['result'],
+	): string {
+		switch (result) {
+			case 'won':
+				return '✅'
+			case 'lost':
+				return '❌'
+			case 'pending':
+				return '⏳'
+			case 'push':
+			case 'void':
+				return '➖'
+		}
+	}
+
+	private formatAmericanOdds(odds: number): string {
+		return odds > 0 ? `+${odds}` : `${odds}`
+	}
+
+	private async sendParlayEmbeds(
+		userId: string,
+		data: ParlayResultNotification,
+		embeds: EmbedBuilder[],
+	): Promise<void> {
+		const client = container.client
+
+		if (!client) {
+			logger.error({
+				method: this.sendParlayEmbeds.name,
+				event: 'parlay.notification.delivery_failed',
+				message: 'Discord client not available for parlay notification',
+				critical: true,
+				kind: data.kind,
+				parlay_id: data.parlay_id,
+				user_id: userId,
+			})
+			return
+		}
+
+		try {
+			const user = await client.users.fetch(userId)
+			for (const embed of embeds) {
+				await user.send({ embeds: [embed] })
+			}
+		} catch (error) {
+			logger.error({
+				method: this.sendParlayEmbeds.name,
+				event: 'parlay.notification.delivery_failed',
+				message: 'Unable to send parlay result Discord DM',
+				critical: true,
+				kind: data.kind,
+				parlay_id: data.parlay_id,
+				user_id: userId,
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			})
 		}
 	}
 

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -28,12 +28,15 @@ export default class NotificationService {
 		// Process winners (only if not null and has items)
 		if (hasWinners) {
 			for (const winner of data.winners!) {
-				if (!winner.result.oldBalance || !winner.result.newBalance) {
-					logger.error({
+				if (
+					winner.result.oldBalance === undefined ||
+					winner.result.newBalance === undefined
+				) {
+					logger.warn({
 						method: this.processBetResults.name,
-						message: `Missing balance data for user ${winner.userId}`,
+						event: 'notification_balance_unavailable',
+						message: `Missing balance data for user ${winner.userId}; sending notification without balance delta`,
 					})
-					continue
 				}
 
 				const formattedAmounts = await MoneyFormatter.formatAmounts({
@@ -51,12 +54,14 @@ export default class NotificationService {
 					displayBetAmount,
 					displayPayout,
 					displayProfit,
-					displayNewBalance: MoneyFormatter.toUSD(
-						winner.result.newBalance,
-					),
-					displayOldBalance: MoneyFormatter.toUSD(
-						winner.result.oldBalance,
-					),
+					displayNewBalance:
+						winner.result.newBalance === undefined
+							? 'Unavailable'
+							: MoneyFormatter.toUSD(winner.result.newBalance),
+					displayOldBalance:
+						winner.result.oldBalance === undefined
+							? 'Unavailable'
+							: MoneyFormatter.toUSD(winner.result.oldBalance),
 				}
 				const displayWinner: DisplayBetNotificationWon = {
 					...winner,

--- a/src/utils/api/routes/notifications/parlay-notification-contract.ts
+++ b/src/utils/api/routes/notifications/parlay-notification-contract.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+
+/**
+ * Temporary compatibility contract for TF-967.
+ *
+ * @pluto-khronos/types@3.4.3 does not export the C5 parlay notification
+ * schema yet. Keep this shape aligned with TF-949's
+ * `parlayResultNotificationSchema`; replace this module import with the
+ * published package export when the paired Khronos release lands.
+ */
+export const parlayResultNotificationSchema = z
+	.object({
+		kind: z.enum(['won', 'lost', 'push_refunded', 'busted']),
+		parlay_id: z.string().uuid(),
+		user_id: z.string().min(1),
+		guild_id: z.string().min(1).optional(),
+		stake: z.number().finite().nonnegative(),
+		combined_odds_american: z.number().int(),
+		payout: z.number().finite().nonnegative().optional(),
+		actual_payout: z.number().finite().nonnegative().nullable(),
+		refund_amount: z.number().finite().nonnegative().optional(),
+		old_balance: z.number().finite().optional(),
+		new_balance: z.number().finite().optional(),
+		legs: z
+			.array(
+				z.object({
+					id: z.string().min(1),
+					event_id: z.string().min(1),
+					outcome_uuid: z.string().min(1),
+					selection_display: z.string().min(1),
+					market_key: z.string().min(1),
+					odds_american: z.number().int(),
+					point: z.number().finite().nullable(),
+					commence_time: z.coerce.date(),
+					result: z.enum(['pending', 'won', 'lost', 'push', 'void']),
+					home_team: z.string().min(1).optional(),
+					away_team: z.string().min(1).optional(),
+				}),
+			)
+			.min(1),
+	})
+	.superRefine((payload, context) => {
+		if (
+			payload.kind === 'won' &&
+			payload.actual_payout === null &&
+			payload.payout === undefined
+		) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['payout'],
+				message: 'won notifications require payout or actual_payout',
+			})
+		}
+	})
+
+export type ParlayResultNotification = z.infer<
+	typeof parlayResultNotificationSchema
+>

--- a/src/utils/api/routes/notifications/parlay-notification-utils.ts
+++ b/src/utils/api/routes/notifications/parlay-notification-utils.ts
@@ -1,0 +1,24 @@
+import { logger } from '../../../logging/WinstonLogger.js'
+import {
+	type ParlayResultNotification,
+	parlayResultNotificationSchema,
+} from './parlay-notification-contract.js'
+
+/** Parse and strictly validate the Khronos parlay result notification. */
+export function validateParlayResultNotification(
+	payload: unknown,
+): ParlayResultNotification | null {
+	const result = parlayResultNotificationSchema.safeParse(payload)
+
+	if (!result.success) {
+		logger.warn({
+			method: 'validateParlayResultNotification',
+			event: 'parlay.notification.validation_failed',
+			message: 'Invalid parlay result notification payload',
+			errors: result.error.issues,
+		})
+		return null
+	}
+
+	return result.data
+}

--- a/src/utils/api/routes/props/__tests__/props-router.test.ts
+++ b/src/utils/api/routes/props/__tests__/props-router.test.ts
@@ -1,0 +1,152 @@
+import { createServer, type Server } from 'node:http'
+import Koa from 'koa'
+import bodyParser from 'koa-bodyparser'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+const postPropsToChannel = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+vi.mock('../../../../props/PropPostingHandler.js', () => {
+	function MockPropPostingHandler(this: {
+		postPropsToChannel: typeof postPropsToChannel
+	}) {
+		this.postPropsToChannel = postPropsToChannel
+	}
+
+	return { PropPostingHandler: MockPropPostingHandler }
+})
+
+import PropsRouter from '../props-router.js'
+
+const validPayload = {
+	props: [
+		{
+			event_id: 'event-1',
+			commence_time: '2026-07-11T00:00:00Z',
+			home_team: 'Home',
+			away_team: 'Away',
+			sport_title: 'NBA',
+			market_key: 'player_points',
+			bookmaker_key: 'draftkings',
+			description: 'Player',
+			point: 20.5,
+			over: {
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+				outcome_name: 'Over',
+				price: -110,
+			},
+			under: {
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+				outcome_name: 'Under',
+				price: -110,
+			},
+		},
+	],
+	guilds: [{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' }],
+}
+
+describe('POST /props/daily', () => {
+	let server: Server | undefined
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		postPropsToChannel.mockResolvedValue({
+			posted: 1,
+			filtered: 0,
+			failed: 0,
+			total: 1,
+		})
+	})
+
+	afterEach(async () => {
+		if (server?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()))
+			})
+		}
+	})
+
+	async function request(payload: unknown) {
+		const app = new Koa()
+		app.use(bodyParser())
+		app.use(PropsRouter.routes())
+		server = createServer(app.callback())
+
+		await new Promise<void>((resolve) => {
+			server.listen(0, '127.0.0.1', () => resolve())
+		})
+		const address = server.address()
+		if (!address || typeof address === 'string') {
+			throw new Error('Test server did not expose a TCP address')
+		}
+
+		return fetch(`http://127.0.0.1:${address.port}/props/daily`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(payload),
+		})
+	}
+
+	it('passes validated compact props to the posting handler', async () => {
+		const response = await request(validPayload)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			success: true,
+			results: [{ posted: 1, filtered: 0, failed: 0, total: 1 }],
+		})
+		expect(postPropsToChannel).toHaveBeenCalledWith(
+			'guild-1',
+			validPayload.props,
+			'nba',
+			'channel-1',
+		)
+	})
+
+	it('rejects unsupported guild sports with 422', async () => {
+		const response = await request({
+			...validPayload,
+			guilds: [
+				{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'mlb' },
+			],
+		})
+
+		expect(response.status).toBe(422)
+		expect(postPropsToChannel).not.toHaveBeenCalled()
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'push_payload_rejected',
+				schema: 'dailyPropsPayload',
+			}),
+		)
+	})
+
+	it('returns a retryable failure when a guild cannot receive props', async () => {
+		postPropsToChannel.mockResolvedValue({
+			posted: 0,
+			filtered: 0,
+			failed: 1,
+			total: 1,
+		})
+
+		const response = await request(validPayload)
+
+		expect(response.status).toBe(500)
+		expect(await response.json()).toEqual({
+			success: false,
+			error: 'Failed to deliver one or more daily props.',
+			results: [{ posted: 0, filtered: 0, failed: 1, total: 1 }],
+		})
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'props_daily_delivery_failed',
+				failed: 1,
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/props/__tests__/props-router.test.ts
+++ b/src/utils/api/routes/props/__tests__/props-router.test.ts
@@ -1,0 +1,161 @@
+import { createServer, type Server } from 'node:http'
+import Koa from 'koa'
+import bodyParser from 'koa-bodyparser'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+const postPropsToChannel = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+vi.mock('../../../../props/PropPostingHandler.js', () => {
+	function MockPropPostingHandler(this: {
+		postPropsToChannel: typeof postPropsToChannel
+	}) {
+		this.postPropsToChannel = postPropsToChannel
+	}
+
+	return { PropPostingHandler: MockPropPostingHandler }
+})
+
+import PropsRouter from '../props-router.js'
+
+const validPayload = {
+	props: [
+		{
+			event_id: 'event-1',
+			commence_time: '2026-07-11T00:00:00Z',
+			home_team: 'Home',
+			away_team: 'Away',
+			sport_title: 'NBA',
+			market_key: 'player_points',
+			bookmaker_key: 'draftkings',
+			description: 'Player',
+			point: 20.5,
+			over: {
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+				outcome_name: 'Over',
+				price: -110,
+			},
+			under: {
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+				outcome_name: 'Under',
+				price: -110,
+			},
+		},
+	],
+	guilds: [{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' }],
+}
+
+const refs = [
+	{
+		outcome_uuid: validPayload.props[0].over.outcome_uuid,
+		guild_id: 'guild-1',
+		channel_id: 'channel-1',
+		message_id: 'message-1',
+	},
+	{
+		outcome_uuid: validPayload.props[0].under.outcome_uuid,
+		guild_id: 'guild-1',
+		channel_id: 'channel-1',
+		message_id: 'message-1',
+	},
+]
+
+describe('POST /props/daily', () => {
+	let server: Server | undefined
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		postPropsToChannel.mockResolvedValue({
+			posted: 1,
+			filtered: 0,
+			failed: 0,
+			total: 1,
+			results: refs,
+			failures: [],
+		})
+	})
+
+	afterEach(async () => {
+		if (server?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				server?.close((error) => (error ? reject(error) : resolve()))
+			})
+		}
+	})
+
+	async function request(payload: unknown) {
+		const app = new Koa()
+		app.use(bodyParser())
+		app.use(PropsRouter.routes())
+		server = createServer(app.callback())
+
+		await new Promise<void>((resolve) => {
+			server?.listen(0, '127.0.0.1', () => resolve())
+		})
+		const address = server.address()
+		if (!address || typeof address === 'string') {
+			throw new Error('Test server did not expose a TCP address')
+		}
+
+		return fetch(`http://127.0.0.1:${address.port}/props/daily`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(payload),
+		})
+	}
+
+	it('returns one ledger reference for every posted outcome', async () => {
+		const response = await request(validPayload)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual(refs)
+		expect(postPropsToChannel).toHaveBeenCalledWith(
+			'guild-1',
+			validPayload.props,
+			'nba',
+			'channel-1',
+		)
+	})
+
+	it('rejects malformed payloads with structured 422 errors', async () => {
+		const response = await request({ props: [] })
+
+		expect(response.status).toBe(422)
+		const body = await response.json()
+		expect(body).toMatchObject({
+			success: false,
+			error: 'Invalid props payload. Failed Zod validation.',
+		})
+		expect(body.issues).toEqual(expect.any(Array))
+		expect(postPropsToChannel).not.toHaveBeenCalled()
+	})
+
+	it('returns successful refs with 207 when a guild has partial failures', async () => {
+		postPropsToChannel.mockResolvedValue({
+			posted: 1,
+			filtered: 0,
+			failed: 1,
+			total: 2,
+			results: refs,
+			failures: [
+				{
+					guild_id: 'guild-1',
+					channel_id: 'channel-1',
+					outcome_uuids: ['550e8400-e29b-41d4-a716-446655440002'],
+					error: 'Discord unavailable',
+				},
+			],
+		})
+
+		const response = await request(validPayload)
+
+		expect(response.status).toBe(207)
+		expect(response.headers.get('x-props-failed')).toBe('1')
+		expect(await response.json()).toEqual(refs)
+	})
+})

--- a/src/utils/api/routes/props/__tests__/props-validation.test.ts
+++ b/src/utils/api/routes/props/__tests__/props-validation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+
+import { validateDailyPropsPayload } from '../../notifications/notification-utils.js'
+
+describe('daily props validation', () => {
+	it('returns an empty valid batch without treating it as malformed', () => {
+		expect(validateDailyPropsPayload({ props: [], guilds: [] })).toEqual({
+			props: [],
+			guilds: [],
+		})
+	})
+})

--- a/src/utils/api/routes/props/props-router.ts
+++ b/src/utils/api/routes/props/props-router.ts
@@ -1,16 +1,112 @@
 import Router from '@koa/router'
-import { PropsController } from '../../controllers/props.controller.js'
-import type { ReqBodyPropsEmbedsData } from './props-route.interface.js'
+import { logger } from '../../../logging/WinstonLogger.js'
+import { PropPostingHandler } from '../../../props/PropPostingHandler.js'
+import { dailyPropsPayloadSchema } from '../shared-payload-schemas.js'
 
 const PropsRouter = new Router()
-const propsController = new PropsController()
+const propPostingHandler = new PropPostingHandler()
+
+const supportedSports = new Set(['nba', 'nfl'])
 
 PropsRouter.post('/props/daily', async (ctx) => {
-	ctx.status = 200
-	ctx.body = { message: 'Received req to process props for embed generation' }
-	await propsController.processPropsForPredictionEmbeds(
-		ctx.request.body as ReqBodyPropsEmbedsData,
+	const parsedPayload = dailyPropsPayloadSchema.safeParse(
+		ctx.request.body ?? {},
 	)
+	if (!parsedPayload.success) {
+		logger.warn({
+			method: 'PropsRouter',
+			event: 'push_payload_rejected',
+			schema: 'dailyPropsPayload',
+			issues: parsedPayload.error.issues,
+		})
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid props payload. Failed Zod validation.',
+			issues: parsedPayload.error.issues,
+		}
+		return
+	}
+
+	const unsupportedSport = parsedPayload.data.guilds.find(
+		(guild) => !supportedSports.has(guild.sport.toLowerCase()),
+	)
+	if (unsupportedSport) {
+		logger.warn({
+			method: 'PropsRouter',
+			event: 'push_payload_rejected',
+			schema: 'dailyPropsPayload',
+			issues: [
+				{
+					path: ['guilds', 'sport'],
+					message: `Unsupported sport: ${unsupportedSport.sport}`,
+				},
+			],
+		})
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid props payload. Unsupported sport.',
+		}
+		return
+	}
+
+	try {
+		const postingResults = await Promise.all(
+			parsedPayload.data.guilds.map((guild) =>
+				propPostingHandler.postPropsToChannel(
+					guild.guild_id,
+					parsedPayload.data.props,
+					guild.sport.toLowerCase() as 'nba' | 'nfl',
+					guild.channel_id,
+				),
+			),
+		)
+		const references = postingResults.flatMap((result) => result.results)
+		const failures = postingResults.flatMap((result) => result.failures)
+
+		if (failures.length > 0) {
+			logger.warn({
+				method: 'PropsRouter',
+				event: 'props_daily_partial_delivery',
+				posted_count: references.length,
+				failed_count: failures.length,
+				failures,
+			})
+			ctx.set('X-Props-Failed', String(failures.length))
+
+			if (references.length === 0) {
+				ctx.status = 500
+				ctx.body = {
+					success: false,
+					error: 'Failed to deliver daily props.',
+					posted: references,
+					failures,
+				}
+				return
+			}
+
+			// 207 keeps successful message refs parseable by Khronos while
+			// exposing retryable failures through the status/header and logs.
+			ctx.status = 207
+			ctx.body = references
+			return
+		}
+
+		ctx.status = 200
+		ctx.body = references
+	} catch (error) {
+		logger.error({
+			method: 'PropsRouter',
+			event: 'props_daily_processing_failed',
+			error: error instanceof Error ? error.message : String(error),
+		})
+		ctx.status = 500
+		ctx.body = {
+			success: false,
+			error: 'Failed to process daily props.',
+		}
+	}
 })
 
 PropsRouter.post('/props/stats/post-start', async (ctx) => {

--- a/src/utils/api/routes/props/props-router.ts
+++ b/src/utils/api/routes/props/props-router.ts
@@ -1,16 +1,95 @@
 import Router from '@koa/router'
-import { PropsController } from '../../controllers/props.controller.js'
-import type { ReqBodyPropsEmbedsData } from './props-route.interface.js'
+import { logger } from '../../../logging/WinstonLogger.js'
+import { PropPostingHandler } from '../../../props/PropPostingHandler.js'
+import { validateDailyPropsPayload } from '../notifications/notification-utils.js'
 
 const PropsRouter = new Router()
-const propsController = new PropsController()
+const propPostingHandler = new PropPostingHandler()
+
+const supportedSports = new Set(['nba', 'nfl'])
 
 PropsRouter.post('/props/daily', async (ctx) => {
-	ctx.status = 200
-	ctx.body = { message: 'Received req to process props for embed generation' }
-	await propsController.processPropsForPredictionEmbeds(
-		ctx.request.body as ReqBodyPropsEmbedsData,
+	const validatedPayload = validateDailyPropsPayload(ctx.request.body || {})
+	if (!validatedPayload) {
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid props payload. Failed Zod validation.',
+		}
+		return
+	}
+
+	const unsupportedSport = validatedPayload.guilds.find(
+		(guild) => !supportedSports.has(guild.sport.toLowerCase()),
 	)
+	if (unsupportedSport) {
+		logger.warn({
+			method: 'PropsRouter',
+			event: 'push_payload_rejected',
+			schema: 'dailyPropsPayload',
+			issues: [
+				{
+					path: ['guilds', 'sport'],
+					message: `Unsupported sport: ${unsupportedSport.sport}`,
+				},
+			],
+		})
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid props payload. Unsupported sport.',
+		}
+		return
+	}
+
+	try {
+		const results = await Promise.all(
+			validatedPayload.guilds.map((guild) =>
+				propPostingHandler.postPropsToChannel(
+					guild.guild_id,
+					validatedPayload.props,
+					guild.sport.toLowerCase() as 'nba' | 'nfl',
+					guild.channel_id,
+				),
+			),
+		)
+		const failed = results.reduce(
+			(total, result) => total + result.failed,
+			0,
+		)
+		if (failed > 0) {
+			logger.error({
+				method: 'PropsRouter',
+				event: 'props_daily_delivery_failed',
+				failed,
+				results,
+			})
+			ctx.status = 500
+			ctx.body = {
+				success: false,
+				error: 'Failed to deliver one or more daily props.',
+				results,
+			}
+			return
+		}
+
+		ctx.status = 200
+		ctx.body = {
+			success: true,
+			results,
+		}
+	} catch (error) {
+		logger.error({
+			method: 'PropsRouter',
+			event: 'props_daily_processing_failed',
+			error: error instanceof Error ? error.message : String(error),
+		})
+		ctx.status = 500
+		ctx.body = {
+			success: false,
+			error: 'Failed to process daily props.',
+		}
+	}
 })
 
 PropsRouter.post('/props/stats/post-start', async (ctx) => {

--- a/src/utils/api/routes/shared-payload-schemas.ts
+++ b/src/utils/api/routes/shared-payload-schemas.ts
@@ -71,7 +71,7 @@ const sharedPayloadExports = KhronosTypes as unknown as SharedPayloadExports
 function isUsableSchema<T>(
 	schema: z.ZodType<T> | undefined,
 ): schema is z.ZodType<T> {
-	return schema?._def?.type !== 'never'
+	return schema !== undefined && schema._def?.type !== 'never'
 }
 
 /**

--- a/src/utils/api/routes/shared-payload-schemas.ts
+++ b/src/utils/api/routes/shared-payload-schemas.ts
@@ -1,0 +1,92 @@
+import * as KhronosTypes from '@pluto-khronos/types'
+import { z } from 'zod'
+
+const dailyPropOutcomeSchema = z.object({
+	outcome_uuid: z.string().uuid(),
+	outcome_name: z.string().min(1),
+	price: z.number().int(),
+})
+
+const fallbackDailyPropsPayloadSchema = z.object({
+	props: z.array(
+		z.object({
+			event_id: z.string().min(1),
+			commence_time: z.string().min(1),
+			home_team: z.string().min(1),
+			away_team: z.string().min(1),
+			sport_title: z.string().min(1),
+			market_key: z.string().min(1),
+			bookmaker_key: z.string().min(1),
+			description: z.string().min(1),
+			point: z.number(),
+			over: dailyPropOutcomeSchema,
+			under: dailyPropOutcomeSchema,
+		}),
+	),
+	guilds: z.array(
+		z.object({
+			guild_id: z.string().min(1),
+			channel_id: z.string().min(1),
+			sport: z.string().min(1),
+		}),
+	),
+})
+
+const fallbackPropSettledNotificationSchema = z.object({
+	outcome_uuid: z.string().uuid(),
+	result: z.enum(['won', 'lost', 'push', 'void']),
+	winning_side_display: z.string().optional(),
+	actual_value: z.number().finite().nullable().optional(),
+	market_key: z.string().min(1),
+	description: z.string().min(1),
+	point: z.number().finite().nullable().optional(),
+	tallies: z.object({
+		correct: z.number().int().nonnegative(),
+		incorrect: z.number().int().nonnegative(),
+		total: z.number().int().nonnegative(),
+	}),
+	messages: z
+		.array(
+			z.object({
+				guild_id: z.string().min(1),
+				channel_id: z.string().min(1),
+				message_id: z.string().min(1),
+			}),
+		)
+		.min(1),
+})
+
+export type DailyPropsPayload = z.infer<typeof fallbackDailyPropsPayloadSchema>
+export type PropSettledNotification = z.infer<
+	typeof fallbackPropSettledNotificationSchema
+>
+
+type SharedPayloadExports = {
+	dailyPropsPayloadSchema?: z.ZodType<DailyPropsPayload>
+	propSettledNotificationSchema?: z.ZodType<PropSettledNotification>
+}
+
+const sharedPayloadExports = KhronosTypes as unknown as SharedPayloadExports
+
+function isUsableSchema<T>(
+	schema: z.ZodType<T> | undefined,
+): schema is z.ZodType<T> {
+	return schema?._def?.type !== 'never'
+}
+
+/**
+ * Consume the published Khronos contracts when available while keeping a
+ * strict compatibility bridge for deployments that have not received the
+ * TF-939/TF-952 package release yet.
+ */
+export const dailyPropsPayloadSchema = isUsableSchema(
+	sharedPayloadExports.dailyPropsPayloadSchema,
+)
+	? sharedPayloadExports.dailyPropsPayloadSchema
+	: fallbackDailyPropsPayloadSchema
+
+export const propSettledNotificationSchema = isUsableSchema(
+	sharedPayloadExports.propSettledNotificationSchema,
+)
+	? sharedPayloadExports.propSettledNotificationSchema
+	: fallbackPropSettledNotificationSchema

--- a/src/utils/api/routes/shared-payload-schemas.ts
+++ b/src/utils/api/routes/shared-payload-schemas.ts
@@ -1,0 +1,110 @@
+import * as KhronosTypes from '@pluto-khronos/types'
+import { z } from 'zod'
+
+const notificationEntryBaseSchema = z.object({
+	userId: z.string().min(1),
+	betId: z.number().int().nonnegative(),
+})
+
+const legacyPushSchema = z.object({
+	userid: z.string().min(1),
+	amount: z.number().nonnegative(),
+	betid: z.number().int().nonnegative(),
+	team: z.string().min(1),
+})
+
+const typedPushSchema = notificationEntryBaseSchema.extend({
+	result: z.object({
+		team: z.string().min(1),
+		betAmount: z.number().nonnegative(),
+		refunded: z.number().finite().nonnegative(),
+	}),
+})
+
+const fallbackNotificationBetResultsSchema = z.object({
+	winners: z
+		.array(
+			notificationEntryBaseSchema.extend({
+				result: z.object({
+					team: z.string().min(1),
+					betAmount: z.number().nonnegative(),
+					payout: z.number().finite().nonnegative(),
+					profit: z.number().finite(),
+					newBalance: z.number().finite().optional(),
+					oldBalance: z.number().finite().optional(),
+				}),
+			}),
+		)
+		.nullable(),
+	losers: z
+		.array(
+			notificationEntryBaseSchema.extend({
+				result: z.object({
+					team: z.string().min(1),
+					betAmount: z.number().nonnegative(),
+				}),
+			}),
+		)
+		.nullable(),
+	pushes: z.array(z.union([typedPushSchema, legacyPushSchema])).optional(),
+})
+
+const dailyPropOutcomeSchema = z.object({
+	outcome_uuid: z.string().uuid(),
+	outcome_name: z.string().min(1),
+	price: z.number().int(),
+})
+
+const fallbackDailyPropsPayloadSchema = z.object({
+	props: z.array(
+		z.object({
+			event_id: z.string().min(1),
+			commence_time: z.string().min(1),
+			home_team: z.string().min(1),
+			away_team: z.string().min(1),
+			sport_title: z.string().min(1),
+			market_key: z.string().min(1),
+			bookmaker_key: z.string().min(1),
+			description: z.string().min(1),
+			point: z.number(),
+			over: dailyPropOutcomeSchema,
+			under: dailyPropOutcomeSchema,
+		}),
+	),
+	guilds: z.array(
+		z.object({
+			guild_id: z.string().min(1),
+			channel_id: z.string().min(1),
+			sport: z.string().min(1),
+		}),
+	),
+})
+
+export type NotificationBetResults = z.infer<
+	typeof fallbackNotificationBetResultsSchema
+>
+export type DailyPropsPayload = z.infer<typeof fallbackDailyPropsPayloadSchema>
+
+type SharedPayloadExports = {
+	betNotificationWonSchema?: unknown
+	notificationBetResultsSchema?: z.ZodType<NotificationBetResults>
+	dailyPropsPayloadSchema?: z.ZodType<DailyPropsPayload>
+}
+
+const sharedPayloadExports = KhronosTypes as unknown as SharedPayloadExports
+
+/**
+ * Use the published shared schemas when available. The fallback is a strict
+ * compatibility bridge for deployments whose package bump precedes TF-939's
+ * schema release; it can be removed once all supported versions export the
+ * new contracts.
+ */
+export const notificationBetResultsSchema =
+	(sharedPayloadExports.betNotificationWonSchema
+		? sharedPayloadExports.notificationBetResultsSchema
+		: fallbackNotificationBetResultsSchema) ??
+	fallbackNotificationBetResultsSchema
+
+export const dailyPropsPayloadSchema =
+	sharedPayloadExports.dailyPropsPayloadSchema ??
+	fallbackDailyPropsPayloadSchema

--- a/src/utils/betting/american-odds.ts
+++ b/src/utils/betting/american-odds.ts
@@ -1,0 +1,43 @@
+/**
+ * American odds helpers used while the parlay builder is running locally.
+ *
+ * Khronos remains the source of truth at init/place time. Keeping the
+ * conversion here only lets the card show a useful running estimate before
+ * the server snapshots the leg prices.
+ */
+export function americanToDecimal(american: number): number {
+	if (!Number.isFinite(american) || american === 0) {
+		throw new Error('American odds must be a non-zero finite number')
+	}
+
+	return american > 0 ? 1 + american / 100 : 1 + 100 / Math.abs(american)
+}
+
+export function decimalToAmerican(decimal: number): number {
+	if (!Number.isFinite(decimal) || decimal <= 1) {
+		throw new Error('Decimal odds must be greater than 1')
+	}
+
+	return decimal >= 2
+		? Math.round((decimal - 1) * 100)
+		: Math.round(-100 / (decimal - 1))
+}
+
+export function combineAmericanOdds(legs: number[]): {
+	american: number
+	decimal: number
+} {
+	if (legs.length === 0) {
+		throw new Error('At least one odds leg is required')
+	}
+
+	const decimal = legs.reduce(
+		(combined, leg) => combined * americanToDecimal(leg),
+		1,
+	)
+
+	return {
+		american: decimalToAmerican(decimal),
+		decimal,
+	}
+}

--- a/src/utils/cache/redis-instance.ts
+++ b/src/utils/cache/redis-instance.ts
@@ -11,7 +11,13 @@ class InMemoryRedis {
 	private readonly hashes = new Map<string, Map<string, string>>()
 	private readonly sets = new Map<string, Set<string>>()
 
-	async set(key: string, value: string, ..._rest: unknown[]) {
+	async set(key: string, value: string, ...rest: unknown[]) {
+		if (
+			rest.includes('NX') &&
+			(this.values.has(key) || this.hashes.has(key) || this.sets.has(key))
+		) {
+			return null
+		}
 		this.values.set(key, value)
 		return 'OK'
 	}

--- a/src/utils/commands/prediction-deprecation.ts
+++ b/src/utils/commands/prediction-deprecation.ts
@@ -1,0 +1,25 @@
+import { type ChatInputCommandInteraction, EmbedBuilder } from 'discord.js'
+import embedColors from '../../lib/colorsConfig.js'
+
+/**
+ * Keep legacy prediction commands discoverable while the consolidated command
+ * rolls out. The aliases can be removed after one release cycle.
+ */
+export async function sendPredictionCommandDeprecation(
+	interaction: ChatInputCommandInteraction,
+	replacement: string,
+) {
+	await interaction.deferReply({ ephemeral: true })
+
+	const embed = new EmbedBuilder()
+		.setColor(embedColors.info)
+		.setTitle('Prediction command moved')
+		.setDescription(
+			`This command is kept for one release as an alias. Use **${replacement}** instead.`,
+		)
+		.setFooter({
+			text: 'Legacy aliases will be removed after the migration window.',
+		})
+
+	return interaction.editReply({ embeds: [embed] })
+}

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -8,6 +8,7 @@ import {
 } from 'discord.js'
 import { MarketKeyTranslations } from '../api/common/interfaces/market-translations.js'
 import GuildWrapper from '../api/Khronos/guild/guild-wrapper.js'
+import redisCache from '../cache/redis-instance.js'
 import StringUtils from '../common/string-utils.js'
 import TeamInfo from '../common/TeamInfo.js'
 import { logger } from '../logging/WinstonLogger.js'
@@ -24,6 +25,24 @@ export interface PostingResult {
 	failed: number
 	/** Total props processed */
 	total: number
+	/** One ledger reference for each successfully posted outcome */
+	results: PostedPropReference[]
+	/** Per-pair failures kept explicit for route observability and retries */
+	failures: PostingFailure[]
+}
+
+export interface PostedPropReference {
+	outcome_uuid: string
+	guild_id: string
+	channel_id: string
+	message_id: string
+}
+
+export interface PostingFailure {
+	guild_id: string
+	channel_id?: string
+	outcome_uuids: string[]
+	error: string
 }
 
 /**
@@ -46,6 +65,8 @@ export interface PostingResult {
  * ```
  */
 export class PropPostingHandler {
+	private static readonly DELIVERY_TTL_SECONDS = 7 * 24 * 60 * 60
+	private static readonly DELIVERY_CLAIM_TTL_SECONDS = 5 * 60
 	private guildWrapper: GuildWrapper
 
 	constructor() {
@@ -69,24 +90,69 @@ export class PropPostingHandler {
 		guildId: string,
 		props: ProcessedPropDto[],
 		sport: 'nfl' | 'nba',
+		channelId?: string,
 	): Promise<PostingResult> {
 		const result: PostingResult = {
 			posted: 0,
 			filtered: 0,
 			failed: 0,
 			total: props.length,
+			results: [],
+			failures: [],
 		}
 
 		// 1 Embed:1 Pair
 		for (const prop of props) {
+			const deliveryKey = this.getDeliveryKey(guildId, channelId, prop)
+			const deliveryState = await this.claimDelivery(deliveryKey)
+			if (deliveryState === 'sent' || deliveryState === 'claimed') {
+				result.filtered++
+				continue
+			}
+			if (deliveryState === 'unavailable') {
+				result.failed++
+				result.failures.push({
+					guild_id: guildId,
+					channel_id: channelId,
+					outcome_uuids: [
+						prop.over.outcome_uuid,
+						prop.under.outcome_uuid,
+					],
+					error: 'Delivery idempotency unavailable',
+				})
+				continue
+			}
+
 			try {
 				const embed = await this.createPropEmbed(prop, sport)
 				const buttons = this.createPropButtons(prop)
 
-				await this.guildWrapper.sendToPredictionChannel(guildId, {
+				const messageOptions = {
 					embeds: [embed],
 					components: [buttons],
-				})
+				}
+				const message = channelId
+					? await this.guildWrapper.sendToChannel(
+							channelId,
+							messageOptions,
+						)
+					: await this.guildWrapper.sendToPredictionChannel(
+							guildId,
+							messageOptions,
+						)
+
+				await this.markDelivered(deliveryKey)
+				const postedChannelId = channelId ?? message.channelId
+				result.results.push(
+					...[prop.over.outcome_uuid, prop.under.outcome_uuid].map(
+						(outcome_uuid) => ({
+							outcome_uuid,
+							guild_id: guildId,
+							channel_id: postedChannelId,
+							message_id: message.id,
+						}),
+					),
+				)
 
 				result.posted++
 			} catch (error) {
@@ -99,10 +165,92 @@ export class PropPostingHandler {
 					error,
 				})
 				result.failed++
+				result.failures.push({
+					guild_id: guildId,
+					channel_id: channelId,
+					outcome_uuids: [
+						prop.over.outcome_uuid,
+						prop.under.outcome_uuid,
+					],
+					error:
+						error instanceof Error ? error.message : String(error),
+				})
+				await this.releaseDeliveryClaim(deliveryKey)
 			}
 		}
 
 		return result
+	}
+
+	private getDeliveryKey(
+		guildId: string,
+		channelId: string | undefined,
+		prop: ProcessedPropDto,
+	): string {
+		return [
+			'props:delivery',
+			guildId,
+			channelId ?? 'configured',
+			prop.over.outcome_uuid,
+			prop.under.outcome_uuid,
+		].join(':')
+	}
+
+	private async claimDelivery(
+		deliveryKey: string,
+	): Promise<'available' | 'sent' | 'claimed' | 'unavailable'> {
+		try {
+			const existing = await redisCache.get(deliveryKey)
+			if (existing === 'sent') return 'sent'
+			if (existing === 'processing') return 'claimed'
+
+			const lock = await redisCache.set(
+				deliveryKey,
+				'processing',
+				'EX',
+				PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
+				'NX',
+			)
+			return lock === 'OK' ? 'available' : 'claimed'
+		} catch (error) {
+			logger.warn({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_idempotency_unavailable',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return 'unavailable'
+		}
+	}
+
+	private async markDelivered(deliveryKey: string): Promise<void> {
+		try {
+			await redisCache.setex(
+				deliveryKey,
+				PropPostingHandler.DELIVERY_TTL_SECONDS,
+				'sent',
+			)
+		} catch (error) {
+			logger.error({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_marker_write_failed',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	private async releaseDeliveryClaim(deliveryKey: string): Promise<void> {
+		try {
+			await redisCache.del(deliveryKey)
+		} catch (error) {
+			logger.warn({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_claim_release_failed',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
 	}
 
 	/**

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -45,6 +45,11 @@ export interface PostingFailure {
 	error: string
 }
 
+interface DeliveredMarker {
+	status: 'sent'
+	results: PostedPropReference[]
+}
+
 /**
  * Handler for posting player prop embeds with interactive Over/Under buttons to Discord channels
  *
@@ -66,7 +71,11 @@ export interface PostingFailure {
  */
 export class PropPostingHandler {
 	private static readonly DELIVERY_TTL_SECONDS = 7 * 24 * 60 * 60
-	private static readonly DELIVERY_CLAIM_TTL_SECONDS = 5 * 60
+	// Keep the claim for the full idempotency window. Discord does not provide
+	// a transaction that atomically commits a message and its Redis marker, so
+	// a crash after Discord accepts a send must remain conservatively claimed.
+	private static readonly DELIVERY_CLAIM_TTL_SECONDS =
+		PropPostingHandler.DELIVERY_TTL_SECONDS
 	private guildWrapper: GuildWrapper
 
 	constructor() {
@@ -105,11 +114,31 @@ export class PropPostingHandler {
 		for (const prop of props) {
 			const deliveryKey = this.getDeliveryKey(guildId, channelId, prop)
 			const deliveryState = await this.claimDelivery(deliveryKey)
-			if (deliveryState === 'sent' || deliveryState === 'claimed') {
-				result.filtered++
+			if (deliveryState.status === 'sent') {
+				if (deliveryState.results.length > 0) {
+					result.results.push(...deliveryState.results)
+					result.posted++
+				} else {
+					// Legacy markers predate the durable reference ledger. Keep
+					// their at-most-once behavior while new markers are recoverable.
+					result.filtered++
+				}
 				continue
 			}
-			if (deliveryState === 'unavailable') {
+			if (deliveryState.status === 'claimed') {
+				result.failed++
+				result.failures.push({
+					guild_id: guildId,
+					channel_id: channelId,
+					outcome_uuids: [
+						prop.over.outcome_uuid,
+						prop.under.outcome_uuid,
+					],
+					error: 'Delivery is already being processed; retry later',
+				})
+				continue
+			}
+			if (deliveryState.status === 'unavailable') {
 				result.failed++
 				result.failures.push({
 					guild_id: guildId,
@@ -135,24 +164,25 @@ export class PropPostingHandler {
 					? await this.guildWrapper.sendToChannel(
 							channelId,
 							messageOptions,
+							guildId,
 						)
 					: await this.guildWrapper.sendToPredictionChannel(
 							guildId,
 							messageOptions,
 						)
 
-				await this.markDelivered(deliveryKey)
 				const postedChannelId = channelId ?? message.channelId
-				result.results.push(
-					...[prop.over.outcome_uuid, prop.under.outcome_uuid].map(
-						(outcome_uuid) => ({
-							outcome_uuid,
-							guild_id: guildId,
-							channel_id: postedChannelId,
-							message_id: message.id,
-						}),
-					),
-				)
+				const references = [
+					prop.over.outcome_uuid,
+					prop.under.outcome_uuid,
+				].map((outcome_uuid) => ({
+					outcome_uuid,
+					guild_id: guildId,
+					channel_id: postedChannelId,
+					message_id: message.id,
+				}))
+				await this.markDelivered(deliveryKey, references)
+				result.results.push(...references)
 
 				result.posted++
 			} catch (error) {
@@ -198,11 +228,30 @@ export class PropPostingHandler {
 
 	private async claimDelivery(
 		deliveryKey: string,
-	): Promise<'available' | 'sent' | 'claimed' | 'unavailable'> {
+	): Promise<
+		| { status: 'available' }
+		| { status: 'sent'; results: PostedPropReference[] }
+		| { status: 'claimed' }
+		| { status: 'unavailable' }
+	> {
 		try {
 			const existing = await redisCache.get(deliveryKey)
-			if (existing === 'sent') return 'sent'
-			if (existing === 'processing') return 'claimed'
+			if (existing === 'sent') return { status: 'sent', results: [] }
+			if (existing === 'processing') return { status: 'claimed' }
+			if (existing) {
+				try {
+					const marker = JSON.parse(existing) as DeliveredMarker
+					if (
+						marker.status === 'sent' &&
+						Array.isArray(marker.results)
+					) {
+						return { status: 'sent', results: marker.results }
+					}
+				} catch {
+					// An unknown marker is treated as available for compatibility
+					// with older deployments that stored a plain status value.
+				}
+			}
 
 			const lock = await redisCache.set(
 				deliveryKey,
@@ -211,7 +260,9 @@ export class PropPostingHandler {
 				PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
 				'NX',
 			)
-			return lock === 'OK' ? 'available' : 'claimed'
+			return lock === 'OK'
+				? { status: 'available' }
+				: { status: 'claimed' }
 		} catch (error) {
 			logger.warn({
 				method: 'PropPostingHandler',
@@ -219,16 +270,22 @@ export class PropPostingHandler {
 				deliveryKey,
 				error: error instanceof Error ? error.message : String(error),
 			})
-			return 'unavailable'
+			return { status: 'unavailable' }
 		}
 	}
 
-	private async markDelivered(deliveryKey: string): Promise<void> {
+	private async markDelivered(
+		deliveryKey: string,
+		results: PostedPropReference[],
+	): Promise<void> {
 		try {
 			await redisCache.setex(
 				deliveryKey,
 				PropPostingHandler.DELIVERY_TTL_SECONDS,
-				'sent',
+				JSON.stringify({
+					status: 'sent',
+					results,
+				} satisfies DeliveredMarker),
 			)
 		} catch (error) {
 			logger.error({

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -239,6 +239,13 @@ export class PropPostingHandler {
 			const existing = await redisCache.get(deliveryKey)
 			if (existing === 'sent') return { status: 'sent', results: [] }
 			if (existing === 'processing') return { status: 'claimed' }
+			if (existing === 'retry') {
+				try {
+					await redisCache.del(deliveryKey)
+				} catch {
+					return { status: 'claimed' }
+				}
+			}
 			if (existing) {
 				try {
 					const marker = JSON.parse(existing) as DeliveredMarker
@@ -348,6 +355,21 @@ export class PropPostingHandler {
 							? fallbackError.message
 							: String(fallbackError),
 				})
+				try {
+					// Last-resort retry marker for clients where DEL and SETEX are
+					// unavailable. A recovered client removes it before re-claiming.
+					await redisCache.set(deliveryKey, 'retry')
+				} catch (lastError) {
+					logger.error({
+						method: 'PropPostingHandler',
+						event: 'props_delivery_claim_last_resort_failed',
+						deliveryKey,
+						error:
+							lastError instanceof Error
+								? lastError.message
+								: String(lastError),
+					})
+				}
 			}
 		}
 	}

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -8,6 +8,7 @@ import {
 } from 'discord.js'
 import { MarketKeyTranslations } from '../api/common/interfaces/market-translations.js'
 import GuildWrapper from '../api/Khronos/guild/guild-wrapper.js'
+import redisCache from '../cache/redis-instance.js'
 import StringUtils from '../common/string-utils.js'
 import TeamInfo from '../common/TeamInfo.js'
 import { logger } from '../logging/WinstonLogger.js'
@@ -46,6 +47,9 @@ export interface PostingResult {
  * ```
  */
 export class PropPostingHandler {
+	private static readonly DELIVERY_TTL_SECONDS = 7 * 24 * 60 * 60
+	private static readonly DELIVERY_CLAIM_TTL_SECONDS = 5 * 60
+	private static readonly DELIVERY_RELEASE_RETRY_TTL_SECONDS = 5
 	private guildWrapper: GuildWrapper
 
 	constructor() {
@@ -69,6 +73,7 @@ export class PropPostingHandler {
 		guildId: string,
 		props: ProcessedPropDto[],
 		sport: 'nfl' | 'nba',
+		channelId?: string,
 	): Promise<PostingResult> {
 		const result: PostingResult = {
 			posted: 0,
@@ -79,15 +84,45 @@ export class PropPostingHandler {
 
 		// 1 Embed:1 Pair
 		for (const prop of props) {
+			const deliveryKey = this.getDeliveryKey(guildId, channelId, prop)
+			const deliveryState = await this.claimDelivery(deliveryKey)
+			if (deliveryState === 'sent' || deliveryState === 'claimed') {
+				result.filtered++
+				continue
+			}
+			if (deliveryState === 'unavailable') {
+				result.failed++
+				continue
+			}
+
 			try {
+				// Reserve the durable sent state before Discord delivery. This
+				// closes the crash window between Discord accepting a message and
+				// the marker write; the workflow is intentionally at-most-once.
+				if (!(await this.markDelivered(deliveryKey))) {
+					result.failed++
+					await this.releaseDeliveryClaim(deliveryKey)
+					continue
+				}
 				const embed = await this.createPropEmbed(prop, sport)
 				const buttons = this.createPropButtons(prop)
 
-				await this.guildWrapper.sendToPredictionChannel(guildId, {
+				const messageOptions = {
 					embeds: [embed],
 					components: [buttons],
-				})
-
+				}
+				if (channelId) {
+					await this.guildWrapper.sendToChannel(
+						channelId,
+						messageOptions,
+						guildId,
+					)
+				} else {
+					await this.guildWrapper.sendToPredictionChannel(
+						guildId,
+						messageOptions,
+					)
+				}
 				result.posted++
 			} catch (error) {
 				logger.error('Failed to post prop pair', {
@@ -99,10 +134,137 @@ export class PropPostingHandler {
 					error,
 				})
 				result.failed++
+				await this.releaseDeliveryClaim(deliveryKey)
 			}
 		}
 
 		return result
+	}
+
+	private getDeliveryKey(
+		guildId: string,
+		channelId: string | undefined,
+		prop: ProcessedPropDto,
+	): string {
+		const destination = channelId ?? 'configured'
+		return [
+			'props:delivery',
+			guildId,
+			destination,
+			prop.over.outcome_uuid,
+			prop.under.outcome_uuid,
+		].join(':')
+	}
+
+	private async claimDelivery(
+		deliveryKey: string,
+	): Promise<'available' | 'sent' | 'claimed' | 'unavailable'> {
+		try {
+			const existing = await redisCache.get(deliveryKey)
+			if (existing === 'sent') return 'sent'
+			if (existing === 'processing') return 'claimed'
+			if (existing === 'retry') {
+				try {
+					const redis = redisCache as unknown as {
+						eval?: (
+							script: string,
+							numKeys: number,
+							...args: Array<string | number>
+						) => Promise<unknown>
+					}
+					if (!redis.eval) return 'claimed'
+					const reclaimed = await redis.eval(
+						"if redis.call('get', KEYS[1]) == 'retry' then return redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2]) else return nil end",
+						1,
+						deliveryKey,
+						'processing',
+						PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
+					)
+					return reclaimed === 'OK' ? 'available' : 'claimed'
+				} catch {
+					return 'claimed'
+				}
+			}
+
+			const lock = await redisCache.set(
+				deliveryKey,
+				'processing',
+				'EX',
+				PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
+				'NX',
+			)
+			return lock === 'OK' ? 'available' : 'claimed'
+		} catch (error) {
+			logger.warn({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_idempotency_unavailable',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return 'unavailable'
+		}
+	}
+
+	private async markDelivered(deliveryKey: string): Promise<boolean> {
+		try {
+			await redisCache.setex(
+				deliveryKey,
+				PropPostingHandler.DELIVERY_TTL_SECONDS,
+				'sent',
+			)
+			return true
+		} catch (error) {
+			logger.error({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_marker_write_failed',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return false
+		}
+	}
+
+	private async releaseDeliveryClaim(deliveryKey: string): Promise<void> {
+		try {
+			await redisCache.del(deliveryKey)
+		} catch (error) {
+			logger.warn({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_claim_release_failed',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			try {
+				await redisCache.setex(
+					deliveryKey,
+					PropPostingHandler.DELIVERY_RELEASE_RETRY_TTL_SECONDS,
+					'retry',
+				)
+			} catch (fallbackError) {
+				try {
+					await redisCache.set(deliveryKey, 'retry')
+				} catch (lastError) {
+					logger.error({
+						method: 'PropPostingHandler',
+						event: 'props_delivery_claim_cleanup_failed',
+						deliveryKey,
+						error:
+							lastError instanceof Error
+								? lastError.message
+								: String(lastError),
+					})
+				}
+				logger.warn({
+					method: 'PropPostingHandler',
+					event: 'props_delivery_claim_retry_marker_failed',
+					deliveryKey,
+					error:
+						fallbackError instanceof Error
+							? fallbackError.message
+							: String(fallbackError),
+				})
+			}
+		}
 	}
 
 	/**

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -295,6 +295,28 @@ export class PropPostingHandler {
 				deliveryKey,
 				error: error instanceof Error ? error.message : String(error),
 			})
+			try {
+				// Some Redis-compatible test/degraded clients do not implement
+				// SETEX. A plain SET still records the durable sent ledger and is
+				// preferable to leaving a processing claim that can later replay.
+				await redisCache.set(
+					deliveryKey,
+					JSON.stringify({
+						status: 'sent',
+						results,
+					} satisfies DeliveredMarker),
+				)
+			} catch (fallbackError) {
+				logger.error({
+					method: 'PropPostingHandler',
+					event: 'props_delivery_marker_fallback_failed',
+					deliveryKey,
+					error:
+						fallbackError instanceof Error
+							? fallbackError.message
+							: String(fallbackError),
+				})
+			}
 		}
 	}
 

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -71,6 +71,7 @@ interface DeliveredMarker {
  */
 export class PropPostingHandler {
 	private static readonly DELIVERY_TTL_SECONDS = 7 * 24 * 60 * 60
+	private static readonly DELIVERY_RELEASE_RETRY_TTL_SECONDS = 5
 	// Keep the claim for the full idempotency window. Discord does not provide
 	// a transaction that atomically commits a message and its Redis marker, so
 	// a crash after Discord accepts a send must remain conservatively claimed.
@@ -307,6 +308,25 @@ export class PropPostingHandler {
 				deliveryKey,
 				error: error instanceof Error ? error.message : String(error),
 			})
+			try {
+				// If DEL failed, shorten the failed-send claim so a retry can
+				// recover promptly instead of remaining blocked for seven days.
+				await redisCache.setex(
+					deliveryKey,
+					PropPostingHandler.DELIVERY_RELEASE_RETRY_TTL_SECONDS,
+					'processing',
+				)
+			} catch (fallbackError) {
+				logger.error({
+					method: 'PropPostingHandler',
+					event: 'props_delivery_claim_fallback_failed',
+					deliveryKey,
+					error:
+						fallbackError instanceof Error
+							? fallbackError.message
+							: String(fallbackError),
+				})
+			}
 		}
 	}
 

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -186,9 +186,8 @@ export class PropPostingHandler {
 					deliveryKey,
 					references,
 				)
-				result.results.push(...references)
-
 				if (markerPersisted) {
+					result.results.push(...references)
 					result.posted++
 				} else {
 					result.failed++
@@ -256,10 +255,19 @@ export class PropPostingHandler {
 			if (existing === 'processing') return { status: 'claimed' }
 			if (existing === 'retry') {
 				try {
-					const reclaimed = await redisCache.set(
+					const redis = redisCache as unknown as {
+						eval?: (
+							script: string,
+							numKeys: number,
+							...args: Array<string | number>
+						) => Promise<unknown>
+					}
+					if (!redis.eval) return { status: 'claimed' }
+					const reclaimed = await redis.eval(
+						"if redis.call('get', KEYS[1]) == 'retry' then return redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2]) else return nil end",
+						1,
 						deliveryKey,
 						'processing',
-						'EX',
 						PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
 					)
 					return reclaimed === 'OK'

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -182,10 +182,25 @@ export class PropPostingHandler {
 					channel_id: postedChannelId,
 					message_id: message.id,
 				}))
-				await this.markDelivered(deliveryKey, references)
+				const markerPersisted = await this.markDelivered(
+					deliveryKey,
+					references,
+				)
 				result.results.push(...references)
 
-				result.posted++
+				if (markerPersisted) {
+					result.posted++
+				} else {
+					result.failed++
+					result.failures.push({
+						guild_id: guildId,
+						channel_id: postedChannelId,
+						outcome_uuids: references.map(
+							(reference) => reference.outcome_uuid,
+						),
+						error: 'Discord message posted but durable delivery marker was unavailable',
+					})
+				}
 			} catch (error) {
 				logger.error('Failed to post prop pair', {
 					event_id: prop.event_id,
@@ -241,7 +256,15 @@ export class PropPostingHandler {
 			if (existing === 'processing') return { status: 'claimed' }
 			if (existing === 'retry') {
 				try {
-					await redisCache.del(deliveryKey)
+					const reclaimed = await redisCache.set(
+						deliveryKey,
+						'processing',
+						'EX',
+						PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
+					)
+					return reclaimed === 'OK'
+						? { status: 'available' }
+						: { status: 'claimed' }
 				} catch {
 					return { status: 'claimed' }
 				}
@@ -285,7 +308,7 @@ export class PropPostingHandler {
 	private async markDelivered(
 		deliveryKey: string,
 		results: PostedPropReference[],
-	): Promise<void> {
+	): Promise<boolean> {
 		try {
 			await redisCache.setex(
 				deliveryKey,
@@ -295,6 +318,7 @@ export class PropPostingHandler {
 					results,
 				} satisfies DeliveredMarker),
 			)
+			return true
 		} catch (error) {
 			logger.error({
 				method: 'PropPostingHandler',
@@ -313,6 +337,7 @@ export class PropPostingHandler {
 						results,
 					} satisfies DeliveredMarker),
 				)
+				return true
 			} catch (fallbackError) {
 				logger.error({
 					method: 'PropPostingHandler',
@@ -323,6 +348,7 @@ export class PropPostingHandler {
 							? fallbackError.message
 							: String(fallbackError),
 				})
+				return false
 			}
 		}
 	}

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -211,4 +211,22 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'processing',
 		)
 	})
+
+	it('persists a sent ledger with plain SET when SETEX fails', async () => {
+		mocks.setex.mockRejectedValueOnce(
+			new Error('Redis command unavailable'),
+		)
+
+		await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(mocks.set).toHaveBeenLastCalledWith(
+			'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+			expect.stringContaining('"status":"sent"'),
+		)
+	})
 })

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -1,0 +1,218 @@
+import type { ProcessedPropDto } from '@pluto-khronos/api-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	get: vi.fn(),
+	set: vi.fn(),
+	setex: vi.fn(),
+	del: vi.fn(),
+	eval: vi.fn(),
+	sendToChannel: vi.fn(),
+	sendToPredictionChannel: vi.fn(),
+	getTeamInfo: vi.fn(),
+	logger: { error: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../../api/Khronos/guild/guild-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return {
+			sendToChannel: mocks.sendToChannel,
+			sendToPredictionChannel: mocks.sendToPredictionChannel,
+		}
+	}),
+}))
+
+vi.mock('../../common/TeamInfo.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getTeamInfo: mocks.getTeamInfo }
+	}),
+}))
+
+vi.mock('../../cache/redis-instance.js', () => ({
+	default: {
+		get: mocks.get,
+		set: mocks.set,
+		setex: mocks.setex,
+		del: mocks.del,
+		eval: mocks.eval,
+	},
+}))
+
+vi.mock('../../logging/WinstonLogger.js', () => ({ logger: mocks.logger }))
+
+const { PropPostingHandler } = await import('../PropPostingHandler.js')
+
+const prop = {
+	event_id: 'event-1',
+	commence_time: '2026-07-11T00:00:00Z',
+	home_team: 'Home',
+	away_team: 'Away',
+	sport_title: 'NBA',
+	market_key: 'player_points',
+	bookmaker_key: 'draftkings',
+	description: 'Player',
+	point: 20.5,
+	over: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+		outcome_name: 'Over',
+		price: -110,
+	},
+	under: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+		outcome_name: 'Under',
+		price: -110,
+	},
+} as ProcessedPropDto
+
+describe('PropPostingHandler delivery idempotency', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.get.mockResolvedValue(null)
+		mocks.set.mockResolvedValue('OK')
+		mocks.setex.mockResolvedValue('OK')
+		mocks.eval.mockResolvedValue('OK')
+		mocks.del.mockResolvedValue(1)
+		mocks.sendToChannel.mockResolvedValue(undefined)
+		mocks.getTeamInfo.mockResolvedValue({
+			color: 0x123456,
+			resolvedTeamData: { abbrev: 'HOM' },
+		})
+	})
+
+	it('does not repost a prop already delivered to the same destination', async () => {
+		const handler = new PropPostingHandler()
+
+		const first = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		mocks.get.mockResolvedValue('sent')
+		const second = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(first).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(second).toEqual({ posted: 0, filtered: 1, failed: 0, total: 1 })
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+	})
+
+	it('releases the delivery claim when posting fails so a retry can proceed', async () => {
+		const handler = new PropPostingHandler()
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(mocks.del).toHaveBeenCalledWith(
+			'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+		)
+	})
+
+	it('does not send when a durable delivery claim cannot be created', async () => {
+		const handler = new PropPostingHandler()
+		mocks.set.mockRejectedValueOnce(new Error('Redis unavailable'))
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		mocks.set.mockResolvedValue('OK')
+		const retry = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(retry).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+		expect(mocks.logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'props_delivery_idempotency_unavailable',
+			}),
+		)
+	})
+
+	it('allows an interrupted processing claim to retry after its lease expires', async () => {
+		const handler = new PropPostingHandler()
+		mocks.get.mockResolvedValueOnce('processing')
+
+		const inFlight = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		mocks.get.mockResolvedValueOnce(null)
+		const retry = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(inFlight).toEqual({
+			posted: 0,
+			filtered: 1,
+			failed: 0,
+			total: 1,
+		})
+		expect(retry).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+	})
+
+	it('reclaims a retry marker with an atomic Redis transition', async () => {
+		const handler = new PropPostingHandler()
+		mocks.get.mockResolvedValueOnce('retry')
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(mocks.eval).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('get', KEYS[1]) == 'retry'"),
+			1,
+			expect.stringContaining('props:delivery:guild-1:channel-1'),
+			'processing',
+			300,
+		)
+	})
+
+	it('does not send when the durable sent reservation cannot be persisted', async () => {
+		const handler = new PropPostingHandler()
+		mocks.setex.mockRejectedValue(new Error('Redis unavailable'))
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(mocks.sendToChannel).not.toHaveBeenCalled()
+		expect(mocks.logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'props_delivery_marker_write_failed',
+			}),
+		)
+	})
+})

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -191,4 +191,24 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
 		)
 	})
+
+	it('shortens a failed claim when Redis release fails', async () => {
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
+		mocks.del.mockRejectedValueOnce(new Error('Redis unavailable'))
+
+		await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(mocks.setex).toHaveBeenLastCalledWith(
+			'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+			5,
+			'processing',
+		)
+	})
 })

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -229,4 +229,24 @@ describe('PropPostingHandler message references and idempotency', () => {
 			expect.stringContaining('"status":"sent"'),
 		)
 	})
+
+	it('leaves a retry marker when claim release commands fail', async () => {
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
+		mocks.del.mockRejectedValueOnce(new Error('Redis unavailable'))
+		mocks.setex.mockRejectedValueOnce(new Error('Redis unavailable'))
+
+		await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(mocks.set).toHaveBeenLastCalledWith(
+			'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+			'retry',
+		)
+	})
 })

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -1,0 +1,162 @@
+import type { ProcessedPropDto } from '@pluto-khronos/api-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	get: vi.fn(),
+	set: vi.fn(),
+	setex: vi.fn(),
+	del: vi.fn(),
+	sendToChannel: vi.fn(),
+	sendToPredictionChannel: vi.fn(),
+	getTeamInfo: vi.fn(),
+	logger: { error: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../../api/Khronos/guild/guild-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return {
+			sendToChannel: mocks.sendToChannel,
+			sendToPredictionChannel: mocks.sendToPredictionChannel,
+		}
+	}),
+}))
+
+vi.mock('../../common/TeamInfo.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getTeamInfo: mocks.getTeamInfo }
+	}),
+}))
+
+vi.mock('../../cache/redis-instance.js', () => ({
+	default: {
+		get: mocks.get,
+		set: mocks.set,
+		setex: mocks.setex,
+		del: mocks.del,
+	},
+}))
+
+vi.mock('../../logging/WinstonLogger.js', () => ({ logger: mocks.logger }))
+
+const { PropPostingHandler } = await import('../PropPostingHandler.js')
+
+const prop = {
+	event_id: 'event-1',
+	commence_time: '2026-07-11T00:00:00Z',
+	home_team: 'Home',
+	away_team: 'Away',
+	sport_title: 'NBA',
+	market_key: 'player_points',
+	bookmaker_key: 'draftkings',
+	description: 'Player',
+	point: 20.5,
+	over: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+		outcome_name: 'Over',
+		price: -110,
+	},
+	under: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+		outcome_name: 'Under',
+		price: -110,
+	},
+} as ProcessedPropDto
+
+const sentMessage = { id: 'message-1', channelId: 'channel-1' }
+
+describe('PropPostingHandler message references and idempotency', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.get.mockResolvedValue(null)
+		mocks.set.mockResolvedValue('OK')
+		mocks.setex.mockResolvedValue('OK')
+		mocks.del.mockResolvedValue(1)
+		mocks.sendToChannel.mockResolvedValue(sentMessage)
+		mocks.sendToPredictionChannel.mockResolvedValue(sentMessage)
+		mocks.getTeamInfo.mockResolvedValue({
+			color: 0x123456,
+			resolvedTeamData: { abbrev: 'HOM' },
+		})
+	})
+
+	it('returns both outcome refs for one posted Discord message', async () => {
+		const result = await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toMatchObject({
+			posted: 1,
+			filtered: 0,
+			failed: 0,
+			total: 1,
+		})
+		expect(result.results).toEqual([
+			{
+				outcome_uuid: prop.over.outcome_uuid,
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-1',
+			},
+			{
+				outcome_uuid: prop.under.outcome_uuid,
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-1',
+			},
+		])
+		expect(mocks.sendToChannel).toHaveBeenCalledWith(
+			'channel-1',
+			expect.objectContaining({ embeds: expect.any(Array) }),
+		)
+	})
+
+	it('does not repost a sent pair', async () => {
+		const handler = new PropPostingHandler()
+		await handler.postPropsToChannel('guild-1', [prop], 'nba', 'channel-1')
+		mocks.get.mockResolvedValue('sent')
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result.posted).toBe(0)
+		expect(result.filtered).toBe(1)
+		expect(result.results).toEqual([])
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+	})
+
+	it('keeps partial failures explicit and releases failed claims', async () => {
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
+
+		const result = await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toMatchObject({ posted: 0, filtered: 0, failed: 1 })
+		expect(result.failures).toEqual([
+			expect.objectContaining({
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				outcome_uuids: [
+					prop.over.outcome_uuid,
+					prop.under.outcome_uuid,
+				],
+				error: 'Discord unavailable',
+			}),
+		])
+		expect(mocks.del).toHaveBeenCalledWith(
+			'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+		)
+	})
+})

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -110,6 +110,7 @@ describe('PropPostingHandler message references and idempotency', () => {
 		expect(mocks.sendToChannel).toHaveBeenCalledWith(
 			'channel-1',
 			expect.objectContaining({ embeds: expect.any(Array) }),
+			'guild-1',
 		)
 	})
 
@@ -129,6 +130,37 @@ describe('PropPostingHandler message references and idempotency', () => {
 		expect(result.filtered).toBe(1)
 		expect(result.results).toEqual([])
 		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+	})
+
+	it('recovers durable outcome references for a sent pair', async () => {
+		const references = [
+			{
+				outcome_uuid: prop.over.outcome_uuid,
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-1',
+			},
+			{
+				outcome_uuid: prop.under.outcome_uuid,
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-1',
+			},
+		]
+		mocks.get.mockResolvedValue(
+			JSON.stringify({ status: 'sent', results: references }),
+		)
+
+		const result = await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toMatchObject({ posted: 1, filtered: 0, failed: 0 })
+		expect(result.results).toEqual(references)
+		expect(mocks.sendToChannel).not.toHaveBeenCalled()
 	})
 
 	it('keeps partial failures explicit and releases failed claims', async () => {


### PR DESCRIPTION
## Summary\n- validate /props/daily with shared Khronos payload contract and return one { outcome_uuid, guild_id, channel_id, message_id } reference per posted outcome\n- await destination-aware Discord sends, preserve Redis idempotency with short processing claims and durable sent markers, and expose partial delivery failures\n- update legacy/typed push notification compatibility and add focused route/handler coverage\n\n## Verification\n- pnpm exec vitest run src/utils/props/__tests__/PropPostingHandler.test.ts src/utils/api/routes/props/__tests__/props-router.test.ts (6/6)\n- pnpm test:run (65/65)\n- pnpm typecheck\n- pnpm build (199 files)\n- pnpm exec biome check --no-errors-on-unmatched --files-ignore-unknown=true src\n\nTargets dev/parlays-props; no main/production changes. @greptile review