### PR TITLE
feat(pluto): announce large betting wins (TF-973)

### DIFF
--- a/src/lib/startup/env.ts
+++ b/src/lib/startup/env.ts
@@ -54,6 +54,13 @@ const envSchema = z
 		MOCK_GUILD_BETTING_CHAN_ID: z.string().optional(),
 		DEV_GUILD_GAMES_CATEGORY_ID: z.string().optional(),
 		MOCK_GUILD_SPORT: z.enum(['nba', 'nfl']).default('nba'),
+		ANNOUNCE_PAYOUT_THRESHOLD: z
+			.number()
+			.finite()
+			.nonnegative()
+			.default(100),
+		ANNOUNCE_MAX_PER_HOUR: z.number().int().positive().default(5),
+		BIG_WIN_ANNOUNCEMENTS_ENABLED: z.boolean().default(true),
 	})
 	.superRefine((data, ctx) => {
 		if (data.USE_MOCK_DATA && data.NODE_ENV === 'production') {
@@ -116,6 +123,15 @@ const env = envSchema.parse({
 	MOCK_GUILD_BETTING_CHAN_ID: process.env.MOCK_GUILD_BETTING_CHAN_ID,
 	DEV_GUILD_GAMES_CATEGORY_ID: process.env.DEV_GUILD_GAMES_CATEGORY_ID,
 	MOCK_GUILD_SPORT: process.env.MOCK_GUILD_SPORT || 'nba',
+	ANNOUNCE_PAYOUT_THRESHOLD: Number.parseFloat(
+		process.env.ANNOUNCE_PAYOUT_THRESHOLD || '100',
+	),
+	ANNOUNCE_MAX_PER_HOUR: Number.parseInt(
+		process.env.ANNOUNCE_MAX_PER_HOUR || '5',
+		10,
+	),
+	BIG_WIN_ANNOUNCEMENTS_ENABLED:
+		process.env.BIG_WIN_ANNOUNCEMENTS_ENABLED !== 'false',
 })
 
 // Debug logging for environment validation (redacts sensitive values)
@@ -145,6 +161,9 @@ if (shouldLogDebug) {
 		MOCK_GUILD_BETTING_CHAN_ID: env.MOCK_GUILD_BETTING_CHAN_ID,
 		DEV_GUILD_GAMES_CATEGORY_ID: env.DEV_GUILD_GAMES_CATEGORY_ID,
 		MOCK_GUILD_SPORT: env.MOCK_GUILD_SPORT,
+		ANNOUNCE_PAYOUT_THRESHOLD: env.ANNOUNCE_PAYOUT_THRESHOLD,
+		ANNOUNCE_MAX_PER_HOUR: env.ANNOUNCE_MAX_PER_HOUR,
+		BIG_WIN_ANNOUNCEMENTS_ENABLED: env.BIG_WIN_ANNOUNCEMENTS_ENABLED,
 		// Redacted sensitive fields
 		TOKEN: '[REDACTED]',
 		KH_API_TOKEN: '[REDACTED]',

--- a/src/services/engagement/BigWinAnnouncementService.ts
+++ b/src/services/engagement/BigWinAnnouncementService.ts
@@ -1,0 +1,224 @@
+import { EmbedBuilder, type MessageCreateOptions } from 'discord.js'
+import embedColors from '../../lib/colorsConfig.js'
+import env from '../../lib/startup/env.js'
+import MoneyFormatter from '../../utils/api/common/money-formatting/money-format.js'
+import GuildWrapper from '../../utils/api/Khronos/guild/guild-wrapper.js'
+import redisCache from '../../utils/cache/redis-instance.js'
+import { logger } from '../../utils/logging/WinstonLogger.js'
+
+export const BIG_WIN_ANNOUNCEMENT_MAX_PER_HOUR = 5
+export const BIG_WIN_ANNOUNCEMENT_TTL_SECONDS = 60 * 60
+export const BIG_WIN_ANNOUNCEMENT_DEDUP_TTL_SECONDS = 7 * 24 * 60 * 60
+export const BIG_WIN_DEDUP_KEY_PREFIX = 'pluto:big-win-announcement:sent'
+export const BIG_WIN_RATE_KEY_PREFIX = 'pluto:big-win-announcement:rate'
+
+export interface BigWinAnnouncementRedis {
+	set(
+		key: string,
+		value: string,
+		...args: Array<string | number>
+	): Promise<string | null>
+	incr(key: string): Promise<number>
+	expire(key: string, seconds: number): Promise<number>
+}
+
+export interface BigWinAnnouncementSender {
+	sendToBettingChannel(
+		guildId: string,
+		options: MessageCreateOptions,
+	): Promise<unknown>
+}
+
+export interface BigWinParlayInput {
+	parlayId: string
+	guildId: string
+	userId: string
+	payout: number
+	stake: number
+	combinedOddsAmerican: number
+	legs: number
+}
+
+export interface BigWinSingleBetInput {
+	betId: string | number
+	guildId: string
+	userId: string
+	payout: number
+	betAmount: number
+	team: string
+	oddsAmerican?: number
+}
+
+type AnnouncementKind = 'parlay' | 'bet'
+
+interface AnnouncementInput {
+	kind: AnnouncementKind
+	id: string | number
+	guildId: string
+	userId: string
+	payout: number
+	buildEmbed: () => EmbedBuilder
+}
+
+function getAnnouncementThreshold(): number {
+	const configured = Number(env.ANNOUNCE_PAYOUT_THRESHOLD)
+	return Number.isFinite(configured) && configured >= 0 ? configured : 100
+}
+
+/**
+ * Delivers high-value wins to a guild's betting channel.
+ *
+ * Redis reserves the event before Discord delivery. This makes duplicate
+ * Khronos callbacks safe even when Pluto processes them concurrently. The
+ * per-guild counter is a rolling one-hour window shared by all Pluto replicas.
+ */
+export class BigWinAnnouncementService {
+	constructor(
+		private readonly redis: BigWinAnnouncementRedis = redisCache as unknown as BigWinAnnouncementRedis,
+		private readonly sender: BigWinAnnouncementSender = new GuildWrapper(),
+		private readonly threshold = getAnnouncementThreshold(),
+		private readonly maxPerHour = env.ANNOUNCE_MAX_PER_HOUR ??
+			BIG_WIN_ANNOUNCEMENT_MAX_PER_HOUR,
+		private readonly enabled = env.BIG_WIN_ANNOUNCEMENTS_ENABLED ?? true,
+	) {}
+
+	async announceParlayWin(input: BigWinParlayInput): Promise<boolean> {
+		return this.announce({
+			kind: 'parlay',
+			id: input.parlayId,
+			guildId: input.guildId,
+			userId: input.userId,
+			payout: input.payout,
+			buildEmbed: () =>
+				new EmbedBuilder()
+					.setTitle('💰 Big Parlay Win! 💰')
+					.setDescription(
+						`<@${input.userId}> just hit a huge parlay!`,
+					)
+					.setColor(embedColors.success)
+					.addFields(
+						{
+							name: '🧾 Legs',
+							value: String(input.legs),
+							inline: true,
+						},
+						{
+							name: '📈 Combined Odds',
+							value: this.formatOdds(input.combinedOddsAmerican),
+							inline: true,
+						},
+						{
+							name: '🏆 Payout',
+							value: MoneyFormatter.toUSD(input.payout),
+							inline: false,
+						},
+					)
+					.setFooter({ text: `Parlay ID: ${input.parlayId}` })
+					.setTimestamp(),
+		})
+	}
+
+	async announceSingleBetWin(input: BigWinSingleBetInput): Promise<boolean> {
+		return this.announce({
+			kind: 'bet',
+			id: input.betId,
+			guildId: input.guildId,
+			userId: input.userId,
+			payout: input.payout,
+			buildEmbed: () =>
+				new EmbedBuilder()
+					.setTitle('💰 Big Win! 💰')
+					.setDescription(`<@${input.userId}> just landed a big win!`)
+					.setColor(embedColors.success)
+					.addFields(
+						{
+							name: '🎯 Selection',
+							value: input.team,
+							inline: true,
+						},
+						...(input.oddsAmerican === undefined
+							? []
+							: [
+									{
+										name: '📈 Odds',
+										value: this.formatOdds(
+											input.oddsAmerican,
+										),
+										inline: true,
+									},
+								]),
+						{
+							name: '🏆 Payout',
+							value: MoneyFormatter.toUSD(input.payout),
+							inline: false,
+						},
+					)
+					.setFooter({ text: `Bet ID: ${input.betId}` })
+					.setTimestamp(),
+		})
+	}
+
+	private async announce(input: AnnouncementInput): Promise<boolean> {
+		if (
+			!this.enabled ||
+			!Number.isFinite(input.payout) ||
+			input.payout < this.threshold
+		) {
+			return false
+		}
+
+		const dedupKey = `${BIG_WIN_DEDUP_KEY_PREFIX}:${input.kind}:${input.id}`
+		const rateKey = `${BIG_WIN_RATE_KEY_PREFIX}:${input.guildId}`
+
+		try {
+			const reserved = await this.redis.set(
+				dedupKey,
+				'1',
+				'EX',
+				BIG_WIN_ANNOUNCEMENT_DEDUP_TTL_SECONDS,
+				'NX',
+			)
+			if (reserved !== 'OK') return false
+
+			const count = await this.redis.incr(rateKey)
+			if (count === 1) {
+				await this.redis.expire(
+					rateKey,
+					BIG_WIN_ANNOUNCEMENT_TTL_SECONDS,
+				)
+			}
+			if (count > this.maxPerHour) {
+				logger.info({
+					event: 'big_win.announcement_rate_limited',
+					guild_id: input.guildId,
+					kind: input.kind,
+					id: input.id,
+					count,
+					max_per_hour: this.maxPerHour,
+				})
+				return false
+			}
+
+			await this.sender.sendToBettingChannel(input.guildId, {
+				embeds: [input.buildEmbed()],
+			})
+			return true
+		} catch (error) {
+			logger.error({
+				event: 'big_win.announcement_failed',
+				guild_id: input.guildId,
+				kind: input.kind,
+				id: input.id,
+				payout: input.payout,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return false
+		}
+	}
+
+	private formatOdds(odds: number): string {
+		return odds > 0 ? `+${odds}` : String(odds)
+	}
+}
+
+export default BigWinAnnouncementService

--- a/src/services/engagement/BigWinAnnouncementService.ts
+++ b/src/services/engagement/BigWinAnnouncementService.ts
@@ -19,7 +19,9 @@ export interface BigWinAnnouncementRedis {
 		...args: Array<string | number>
 	): Promise<string | null>
 	incr(key: string): Promise<number>
+	decr(key: string): Promise<number>
 	expire(key: string, seconds: number): Promise<number>
+	del(key: string): Promise<number>
 }
 
 export interface BigWinAnnouncementSender {
@@ -169,6 +171,7 @@ export class BigWinAnnouncementService {
 
 		const dedupKey = `${BIG_WIN_DEDUP_KEY_PREFIX}:${input.kind}:${input.id}`
 		const rateKey = `${BIG_WIN_RATE_KEY_PREFIX}:${input.guildId}`
+		let rateCounted = false
 
 		try {
 			const reserved = await this.redis.set(
@@ -181,13 +184,29 @@ export class BigWinAnnouncementService {
 			if (reserved !== 'OK') return false
 
 			const count = await this.redis.incr(rateKey)
+			rateCounted = true
 			if (count === 1) {
-				await this.redis.expire(
-					rateKey,
-					BIG_WIN_ANNOUNCEMENT_TTL_SECONDS,
-				)
+				try {
+					await this.redis.expire(
+						rateKey,
+						BIG_WIN_ANNOUNCEMENT_TTL_SECONDS,
+					)
+				} catch (error) {
+					await this.compensateRateCounter(rateKey)
+					await this.releaseReservation(dedupKey)
+					logger.error({
+						event: 'big_win.announcement_rate_expiry_failed',
+						guild_id: input.guildId,
+						error:
+							error instanceof Error
+								? error.message
+								: String(error),
+					})
+					return false
+				}
 			}
 			if (count > this.maxPerHour) {
+				await this.releaseReservation(dedupKey)
 				logger.info({
 					event: 'big_win.announcement_rate_limited',
 					guild_id: input.guildId,
@@ -204,6 +223,10 @@ export class BigWinAnnouncementService {
 			})
 			return true
 		} catch (error) {
+			await this.releaseReservation(dedupKey)
+			if (rateCounted) {
+				await this.compensateRateCounter(rateKey)
+			}
 			logger.error({
 				event: 'big_win.announcement_failed',
 				guild_id: input.guildId,
@@ -213,6 +236,38 @@ export class BigWinAnnouncementService {
 				error: error instanceof Error ? error.message : String(error),
 			})
 			return false
+		}
+	}
+
+	private async releaseReservation(dedupKey: string): Promise<void> {
+		try {
+			await this.redis.del(dedupKey)
+		} catch (error) {
+			logger.warn({
+				event: 'big_win.announcement_reservation_cleanup_failed',
+				dedup_key: dedupKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	private async compensateRateCounter(rateKey: string): Promise<void> {
+		try {
+			const remaining = await this.redis.decr(rateKey)
+			if (remaining <= 0) {
+				await this.redis.del(rateKey)
+			} else {
+				await this.redis.expire(
+					rateKey,
+					BIG_WIN_ANNOUNCEMENT_TTL_SECONDS,
+				)
+			}
+		} catch (error) {
+			logger.warn({
+				event: 'big_win.announcement_rate_cleanup_failed',
+				rate_key: rateKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
 		}
 	}
 

--- a/src/services/engagement/__tests__/BigWinAnnouncementService.test.ts
+++ b/src/services/engagement/__tests__/BigWinAnnouncementService.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	redis: {
+		set: vi.fn(),
+		incr: vi.fn(),
+		expire: vi.fn(),
+	},
+	sendToBettingChannel: vi.fn(),
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	},
+}))
+
+vi.mock('../../../utils/cache/redis-instance.js', () => ({
+	default: mocks.redis,
+}))
+
+vi.mock('../../../lib/startup/env.js', () => ({
+	default: { ANNOUNCE_PAYOUT_THRESHOLD: 100 },
+}))
+
+vi.mock('../../../utils/logging/WinstonLogger.js', () => ({
+	logger: mocks.logger,
+}))
+
+vi.mock('../../../utils/api/Khronos/guild/guild-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { sendToBettingChannel: mocks.sendToBettingChannel }
+	}),
+}))
+
+import { BigWinAnnouncementService } from '../BigWinAnnouncementService.js'
+
+const parlay = {
+	parlayId: 'parlay-1',
+	guildId: 'guild-1',
+	userId: 'user-1',
+	payout: 100,
+	stake: 10,
+	combinedOddsAmerican: 900,
+	legs: 3,
+}
+
+describe('BigWinAnnouncementService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.redis.set.mockResolvedValue('OK')
+		mocks.redis.incr.mockResolvedValue(1)
+		mocks.redis.expire.mockResolvedValue(1)
+		mocks.sendToBettingChannel.mockResolvedValue({})
+	})
+
+	it('does not announce below threshold and announces at the boundary', async () => {
+		const service = new BigWinAnnouncementService(
+			mocks.redis,
+			{ sendToBettingChannel: mocks.sendToBettingChannel },
+			100,
+		)
+
+		await expect(
+			service.announceParlayWin({ ...parlay, payout: 99.99 }),
+		).resolves.toBe(false)
+		expect(mocks.redis.set).not.toHaveBeenCalled()
+
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(true)
+		expect(mocks.sendToBettingChannel).toHaveBeenCalledOnce()
+		const [, options] = mocks.sendToBettingChannel.mock.calls[0]
+		const embed = options.embeds[0].toJSON()
+		expect(embed.title).toBe('💰 Big Parlay Win! 💰')
+		expect(embed.description).toContain('<@user-1>')
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: '🧾 Legs', value: '3' }),
+				expect.objectContaining({
+					name: '🏆 Payout',
+					value: '$100.00',
+				}),
+			]),
+		)
+	})
+
+	it('uses Redis deduplication to send each parlay only once', async () => {
+		const service = new BigWinAnnouncementService(mocks.redis, {
+			sendToBettingChannel: mocks.sendToBettingChannel,
+		})
+
+		await service.announceParlayWin(parlay)
+		mocks.redis.set.mockResolvedValueOnce(null)
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(false)
+
+		expect(mocks.sendToBettingChannel).toHaveBeenCalledOnce()
+		expect(mocks.redis.set).toHaveBeenNthCalledWith(
+			2,
+			'pluto:big-win-announcement:sent:parlay:parlay-1',
+			'1',
+			'EX',
+			7 * 24 * 60 * 60,
+			'NX',
+		)
+	})
+
+	it('enforces the per-guild hourly rate limit across announcement kinds', async () => {
+		mocks.redis.incr.mockResolvedValue(2)
+		const service = new BigWinAnnouncementService(
+			mocks.redis,
+			{ sendToBettingChannel: mocks.sendToBettingChannel },
+			100,
+			1,
+		)
+
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(false)
+		expect(mocks.sendToBettingChannel).not.toHaveBeenCalled()
+		expect(mocks.logger.info).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'big_win.announcement_rate_limited',
+				guild_id: 'guild-1',
+			}),
+		)
+	})
+
+	it('formats large single-bet wins for the betting channel', async () => {
+		const service = new BigWinAnnouncementService(mocks.redis, {
+			sendToBettingChannel: mocks.sendToBettingChannel,
+		})
+
+		await expect(
+			service.announceSingleBetWin({
+				betId: 42,
+				guildId: 'guild-1',
+				userId: 'user-1',
+				payout: 250,
+				betAmount: 25,
+				team: 'Lakers',
+				oddsAmerican: 900,
+			}),
+		).resolves.toBe(true)
+
+		const [, options] = mocks.sendToBettingChannel.mock.calls[0]
+		const embed = options.embeds[0].toJSON()
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🎯 Selection',
+					value: 'Lakers',
+				}),
+				expect.objectContaining({ name: '📈 Odds', value: '+900' }),
+				expect.objectContaining({
+					name: '🏆 Payout',
+					value: '$250.00',
+				}),
+			]),
+		)
+	})
+})

--- a/src/services/engagement/__tests__/BigWinAnnouncementService.test.ts
+++ b/src/services/engagement/__tests__/BigWinAnnouncementService.test.ts
@@ -4,7 +4,9 @@ const mocks = vi.hoisted(() => ({
 	redis: {
 		set: vi.fn(),
 		incr: vi.fn(),
+		decr: vi.fn(),
 		expire: vi.fn(),
+		del: vi.fn(),
 	},
 	sendToBettingChannel: vi.fn(),
 	logger: {
@@ -49,7 +51,9 @@ describe('BigWinAnnouncementService', () => {
 		vi.clearAllMocks()
 		mocks.redis.set.mockResolvedValue('OK')
 		mocks.redis.incr.mockResolvedValue(1)
+		mocks.redis.decr.mockResolvedValue(0)
 		mocks.redis.expire.mockResolvedValue(1)
+		mocks.redis.del.mockResolvedValue(1)
 		mocks.sendToBettingChannel.mockResolvedValue({})
 	})
 
@@ -152,6 +156,38 @@ describe('BigWinAnnouncementService', () => {
 					value: '$250.00',
 				}),
 			]),
+		)
+	})
+
+	it('releases reservations and rate capacity when delivery fails', async () => {
+		mocks.sendToBettingChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
+		const service = new BigWinAnnouncementService(mocks.redis, {
+			sendToBettingChannel: mocks.sendToBettingChannel,
+		})
+
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(false)
+		expect(mocks.redis.del).toHaveBeenCalledWith(
+			'pluto:big-win-announcement:sent:parlay:parlay-1',
+		)
+		expect(mocks.redis.decr).toHaveBeenCalledWith(
+			'pluto:big-win-announcement:rate:guild-1',
+		)
+	})
+
+	it('does not reserve a failed rate window when expiry fails', async () => {
+		mocks.redis.expire.mockRejectedValueOnce(new Error('Redis unavailable'))
+		const service = new BigWinAnnouncementService(mocks.redis, {
+			sendToBettingChannel: mocks.sendToBettingChannel,
+		})
+
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(false)
+		expect(mocks.redis.del).toHaveBeenCalledWith(
+			'pluto:big-win-announcement:sent:parlay:parlay-1',
+		)
+		expect(mocks.redis.decr).toHaveBeenCalledWith(
+			'pluto:big-win-announcement:rate:guild-1',
 		)
 	})
 })

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
@@ -164,4 +164,26 @@ describe('NotificationService.processParlayResult', () => {
 			expect(field.value.length).toBeLessThanOrEqual(1024)
 		}
 	})
+
+	it('forwards winning parlays with guild context to big-win announcements', async () => {
+		const announceParlayWin = vi.fn().mockResolvedValue(true)
+		const bigWinService = { announceParlayWin }
+		const payload = {
+			...makePayload('won'),
+			guild_id: 'guild-1',
+		}
+
+		await new NotificationService(
+			bigWinService as never,
+		).processParlayResult(payload)
+
+		expect(announceParlayWin).toHaveBeenCalledWith(
+			expect.objectContaining({
+				parlayId: payload.parlay_id,
+				guildId: 'guild-1',
+				payout: 47.7,
+				legs: 2,
+			}),
+		)
+	})
 })

--- a/src/utils/api/routes/notifications/notification-utils.ts
+++ b/src/utils/api/routes/notifications/notification-utils.ts
@@ -21,16 +21,28 @@ export function validateNotifyBetUsers(
 	}
 
 	return {
-		winners: (result.data.winners ?? []).map((winner) => ({
-			...winner,
-			guildId: winner.guildId ?? winner.guild_id,
-			result: { ...winner.result, outcome: 'won' as const },
-		})),
-		losers: (result.data.losers ?? []).map((loser) => ({
-			...loser,
-			guildId: loser.guildId ?? loser.guild_id,
-			result: { ...loser.result, outcome: 'lost' as const },
-		})),
+		winners: (result.data.winners ?? []).map((winner) => {
+			const withGuild = winner as typeof winner & {
+				guildId?: string
+				guild_id?: string
+			}
+			return {
+				...winner,
+				guildId: withGuild.guildId ?? withGuild.guild_id,
+				result: { ...winner.result, outcome: 'won' as const },
+			}
+		}),
+		losers: (result.data.losers ?? []).map((loser) => {
+			const withGuild = loser as typeof loser & {
+				guildId?: string
+				guild_id?: string
+			}
+			return {
+				...loser,
+				guildId: withGuild.guildId ?? withGuild.guild_id,
+				result: { ...loser.result, outcome: 'lost' as const },
+			}
+		}),
 		pushes: (result.data.pushes ?? []).map((push) => {
 			if ('userid' in push) {
 				return {

--- a/src/utils/api/routes/notifications/notification-utils.ts
+++ b/src/utils/api/routes/notifications/notification-utils.ts
@@ -23,10 +23,12 @@ export function validateNotifyBetUsers(
 	return {
 		winners: (result.data.winners ?? []).map((winner) => ({
 			...winner,
+			guildId: winner.guildId ?? winner.guild_id,
 			result: { ...winner.result, outcome: 'won' as const },
 		})),
 		losers: (result.data.losers ?? []).map((loser) => ({
 			...loser,
+			guildId: loser.guildId ?? loser.guild_id,
 			result: { ...loser.result, outcome: 'lost' as const },
 		})),
 		pushes: (result.data.pushes ?? []).map((push) => {

--- a/src/utils/api/routes/notifications/notifications.interface.ts
+++ b/src/utils/api/routes/notifications/notifications.interface.ts
@@ -29,6 +29,8 @@ export interface ResultPush {
 export interface BetNotificationBase {
 	userId: string
 	betId: number
+	/** Optional until Khronos includes guild context in bet-result callbacks. */
+	guildId?: string
 }
 
 export interface BetNotificationWon extends BetNotificationBase {

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -1,9 +1,15 @@
 // Import interfaces and potentially the Discord client type
 import { container } from '@sapphire/framework'
 import { EmbedBuilder } from 'discord.js'
+import type {
+	BigWinAnnouncementService,
+	BigWinParlayInput,
+	BigWinSingleBetInput,
+} from '../../../../services/engagement/BigWinAnnouncementService.js'
 import { logger } from '../../../logging/WinstonLogger.js'
 import MoneyFormatter from '../../common/money-formatting/money-format.js'
 import type {
+	BetNotificationWon,
 	DisplayBetNotification,
 	DisplayBetNotificationLost,
 	DisplayBetNotificationPush,
@@ -16,6 +22,12 @@ import type {
 import type { ParlayResultNotification } from './parlay-notification-contract.js'
 
 export default class NotificationService {
+	private bigWinAnnouncementService?: BigWinAnnouncementService
+
+	constructor(bigWinAnnouncementService?: BigWinAnnouncementService) {
+		this.bigWinAnnouncementService = bigWinAnnouncementService
+	}
+
 	async processBetResults(data: NotifyBetUsers): Promise<void> {
 		const hasWinners = data.winners && data.winners.length > 0
 		const hasLosers = data.losers && data.losers.length > 0
@@ -71,6 +83,7 @@ export default class NotificationService {
 
 				// Use displayWinner for user notifications
 				await this.notifyUser(displayWinner)
+				await this.announceSingleBetWin(winner)
 			}
 		}
 
@@ -124,6 +137,55 @@ export default class NotificationService {
 	async processParlayResult(data: ParlayResultNotification): Promise<void> {
 		const embeds = this.buildParlayEmbeds(data)
 		await this.sendParlayEmbeds(data.user_id, data, embeds)
+		await this.announceParlayWin(data)
+	}
+
+	private async announceParlayWin(
+		data: ParlayResultNotification,
+	): Promise<void> {
+		if (data.kind !== 'won' || !data.guild_id) return
+
+		const payout = data.actual_payout ?? data.payout
+		if (payout === undefined) return
+
+		const input: BigWinParlayInput = {
+			parlayId: data.parlay_id,
+			guildId: data.guild_id,
+			userId: data.user_id,
+			payout,
+			stake: data.stake,
+			combinedOddsAmerican: data.combined_odds_american,
+			legs: data.legs.length,
+		}
+		const service = await this.getBigWinAnnouncementService()
+		await service.announceParlayWin(input)
+	}
+
+	private async announceSingleBetWin(
+		winner: BetNotificationWon,
+	): Promise<void> {
+		if (!winner.guildId) return
+
+		const input: BigWinSingleBetInput = {
+			betId: winner.betId,
+			guildId: winner.guildId,
+			userId: winner.userId,
+			payout: winner.result.payout,
+			betAmount: winner.result.betAmount,
+			team: winner.result.team,
+		}
+		const service = await this.getBigWinAnnouncementService()
+		await service.announceSingleBetWin(input)
+	}
+
+	private async getBigWinAnnouncementService(): Promise<BigWinAnnouncementService> {
+		if (!this.bigWinAnnouncementService) {
+			const module = await import(
+				'../../../../services/engagement/BigWinAnnouncementService.js'
+			)
+			this.bigWinAnnouncementService = new module.default()
+		}
+		return this.bigWinAnnouncementService
 	}
 
 	private buildParlayEmbeds(data: ParlayResultNotification): EmbedBuilder[] {

--- a/src/utils/api/routes/shared-payload-schemas.ts
+++ b/src/utils/api/routes/shared-payload-schemas.ts
@@ -4,6 +4,9 @@ import { z } from 'zod'
 const notificationEntryBaseSchema = z.object({
 	userId: z.string().min(1),
 	betId: z.number().int().nonnegative(),
+	/** Optional until Khronos includes guild context on bet-result callbacks. */
+	guildId: z.string().min(1).optional(),
+	guild_id: z.string().min(1).optional(),
 })
 
 const legacyPushSchema = z.object({

--- a/src/utils/cache/redis-instance.ts
+++ b/src/utils/cache/redis-instance.ts
@@ -57,6 +57,12 @@ class InMemoryRedis {
 		return next
 	}
 
+	async decr(key: string) {
+		const next = Number(this.values.get(key) ?? 0) - 1
+		this.values.set(key, String(next))
+		return next
+	}
+
 	async expire(_key: string, _seconds: number) {
 		// Stub for testing: always returns 1, does not actually expire keys
 		return 1


### PR DESCRIPTION
## Summary
- add configurable `ANNOUNCE_PAYOUT_THRESHOLD` (default 100), `ANNOUNCE_MAX_PER_HOUR` (default 5), and `BIG_WIN_ANNOUNCEMENTS_ENABLED`
- add Redis-backed `BigWinAnnouncementService` with 7-day per-bet/parlay deduplication and one-hour per-guild rate limiting
- publish celebratory betting-channel embeds for threshold-crossing parlays and guild-aware single-bet result callbacks
- hook parlay wins and optional `guild_id`/`guildId` single-bet winners without changing existing DM delivery

## Dependency and scope
- Stacked on open TF-967 / PR #567 (`feat/betting-ws/TF-967`) because parlay result delivery is not yet on `dev/parlays-props`.
- Khronos's current single-bet result contract does not include guild context. Pluto maps optional `guild_id`/`guildId` when supplied and skips public single-bet announcement safely when absent; no unsafe guild inference is attempted.
- Targets `dev/parlays-props`; no `main` or production changes.

## Verification
- `pnpm test:run` (12 files, 74 tests)
- `pnpm typecheck`
- `pnpm build`
- Biome pre-commit check

Linear: TF-973