### PR TITLE
feat(engagement): weekly recap digest cron (TF-974)

### DIFF
--- a/src/lib/startup/env.ts
+++ b/src/lib/startup/env.ts
@@ -61,6 +61,10 @@ const envSchema = z
 			.default(100),
 		ANNOUNCE_MAX_PER_HOUR: z.number().int().positive().default(5),
 		BIG_WIN_ANNOUNCEMENTS_ENABLED: z.boolean().default(true),
+		RECAP_CRON: z.string().default('0 9 * * 1'),
+		RECAP_CHANNEL_ID: z.string().optional(),
+		RECAP_ENABLED: z.boolean().default(true),
+		RECAP_GUILD_IDS: z.string().default(''),
 	})
 	.superRefine((data, ctx) => {
 		if (data.USE_MOCK_DATA && data.NODE_ENV === 'production') {
@@ -132,6 +136,10 @@ const env = envSchema.parse({
 	),
 	BIG_WIN_ANNOUNCEMENTS_ENABLED:
 		process.env.BIG_WIN_ANNOUNCEMENTS_ENABLED !== 'false',
+	RECAP_CRON: process.env.RECAP_CRON,
+	RECAP_CHANNEL_ID: process.env.RECAP_CHANNEL_ID,
+	RECAP_ENABLED: process.env.RECAP_ENABLED !== 'false',
+	RECAP_GUILD_IDS: process.env.RECAP_GUILD_IDS || process.env.GUILD_ID || '',
 })
 
 // Debug logging for environment validation (redacts sensitive values)
@@ -164,6 +172,10 @@ if (shouldLogDebug) {
 		ANNOUNCE_PAYOUT_THRESHOLD: env.ANNOUNCE_PAYOUT_THRESHOLD,
 		ANNOUNCE_MAX_PER_HOUR: env.ANNOUNCE_MAX_PER_HOUR,
 		BIG_WIN_ANNOUNCEMENTS_ENABLED: env.BIG_WIN_ANNOUNCEMENTS_ENABLED,
+		RECAP_CRON: env.RECAP_CRON,
+		RECAP_CHANNEL_ID: env.RECAP_CHANNEL_ID,
+		RECAP_ENABLED: env.RECAP_ENABLED,
+		RECAP_GUILD_IDS: env.RECAP_GUILD_IDS,
 		// Redacted sensitive fields
 		TOKEN: '[REDACTED]',
 		KH_API_TOKEN: '[REDACTED]',

--- a/src/utils/api/Khronos/recap/recap-wrapper.ts
+++ b/src/utils/api/Khronos/recap/recap-wrapper.ts
@@ -1,0 +1,107 @@
+import * as KhronosApiClient from '@pluto-khronos/api-client'
+import pTimeout from 'p-timeout'
+import { KH_API_CONFIG } from '../KhronosInstances.js'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+/**
+ * Weekly recap contract exposed by Khronos TF-957.
+ *
+ * Kept local until the generated client release containing RecapApi is
+ * published. The runtime constructor is resolved from that generated client
+ * so this module does not introduce a hand-written HTTP implementation.
+ */
+export interface WeeklyRecapResponse {
+	window: {
+		start_date: string
+		end_date: string
+		week_number?: number
+		season_year?: number
+	}
+	total_predictions: number
+	correct_predictions: number
+	incorrect_predictions: number
+	accuracy: number
+	accuracy_delta: number
+	top_predictors: Array<{
+		user_id: string
+		correct_predictions: number
+		incorrect_predictions: number
+		success_rate: number
+		display_name?: string
+	}>
+	biggest_single_win: {
+		user_id: string
+		payout: number
+		bet_id?: number
+		parlay_id?: string
+	} | null
+	biggest_parlay_win: {
+		user_id: string
+		payout: number
+		bet_id?: number
+		parlay_id?: string
+	} | null
+}
+
+export interface WeeklyRecapRequest {
+	guildId: string
+	weekOffset?: number
+}
+
+export interface RecapApiClient {
+	getWeeklyRecap(
+		guildId: string,
+		weekOffset?: number,
+	): Promise<WeeklyRecapResponse>
+}
+
+interface GeneratedRecapApiClient {
+	getWeeklyRecap(request: WeeklyRecapRequest): Promise<WeeklyRecapResponse>
+}
+
+type RecapApiConstructor = new (
+	config: typeof KH_API_CONFIG,
+) => GeneratedRecapApiClient
+
+const GeneratedRecapApi = (
+	KhronosApiClient as unknown as { RecapApi?: RecapApiConstructor }
+).RecapApi
+
+/**
+ * Generated-client wrapper for Khronos weekly recap data.
+ */
+export default class RecapWrapper implements RecapApiClient {
+	private readonly recapApi: GeneratedRecapApiClient
+
+	constructor(recapApi?: RecapApiClient) {
+		if (recapApi) {
+			this.recapApi = {
+				getWeeklyRecap: (request) =>
+					recapApi.getWeeklyRecap(
+						request.guildId,
+						request.weekOffset,
+					),
+			}
+			return
+		}
+
+		if (!GeneratedRecapApi) {
+			throw new Error(
+				'Khronos RecapApi is unavailable; update @pluto-khronos/api-client to the TF-957 release before enabling weekly recaps',
+			)
+		}
+
+		this.recapApi = new GeneratedRecapApi(KH_API_CONFIG)
+	}
+
+	async getWeeklyRecap(
+		guildId: string,
+		weekOffset = -1,
+	): Promise<WeeklyRecapResponse> {
+		return await pTimeout(
+			this.recapApi.getWeeklyRecap({ guildId, weekOffset }),
+			{ milliseconds: DEFAULT_TIMEOUT_MS },
+		)
+	}
+}

--- a/src/utils/cache/cache-manager.ts
+++ b/src/utils/cache/cache-manager.ts
@@ -23,6 +23,21 @@ export class CacheManager {
 		return true
 	}
 
+	/** Atomically claims a key when it is absent, with a bounded TTL. */
+	async setIfAbsent(key: string, data: unknown, TTL?: number) {
+		if (!key) {
+			throw new Error('No key was provided to save into cache')
+		}
+		const result = await this.cache.set(
+			key,
+			JSON.stringify(data),
+			'EX',
+			TTL || 1800,
+			'NX',
+		)
+		return result === 'OK'
+	}
+
 	async get(key: string) {
 		if (!key) {
 			throw new Error('No key was provided to save into cache')

--- a/src/utils/cron/RecapCronScheduler.ts
+++ b/src/utils/cron/RecapCronScheduler.ts
@@ -172,7 +172,7 @@ export class RecapCronScheduler {
 		if (this.lastRunMinute === minuteKey) return false
 
 		this.lastRunMinute = minuteKey
-		await this.recapService.runWeeklyRecap(now)
+		await this.recapService.runWeeklyRecap(now, allowCatchUp)
 		return true
 	}
 

--- a/src/utils/cron/RecapCronScheduler.ts
+++ b/src/utils/cron/RecapCronScheduler.ts
@@ -1,0 +1,140 @@
+import { logger } from '../logging/WinstonLogger.js'
+import type { RecapCronService } from './RecapCronService.js'
+
+const POLL_INTERVAL_MS = 30_000
+
+/**
+ * Minimal UTC cron matcher for the five-field expression used by RECAP_CRON.
+ * Supports literals, comma lists, ranges, and wildcard step values.
+ */
+export function matchesCronExpression(expression: string, date: Date): boolean {
+	const fields = expression.trim().split(/\s+/)
+	if (fields.length !== 5) return false
+
+	const [minute, hour, dayOfMonth, month, dayOfWeek] = fields
+	return (
+		matchesCronField(minute, date.getUTCMinutes(), 0, 59) &&
+		matchesCronField(hour, date.getUTCHours(), 0, 23) &&
+		matchesCronField(dayOfMonth, date.getUTCDate(), 1, 31) &&
+		matchesCronField(month, date.getUTCMonth() + 1, 1, 12) &&
+		matchesCronField(dayOfWeek, date.getUTCDay(), 0, 6)
+	)
+}
+
+function matchesCronField(
+	field: string,
+	value: number,
+	minimum: number,
+	maximum: number,
+): boolean {
+	return field.split(',').some((part) => {
+		const [rangePart, stepPart] = part.split('/')
+		const step = stepPart ? Number.parseInt(stepPart, 10) : 1
+		if (!Number.isInteger(step) || step < 1) return false
+
+		const range = rangePart === '*' ? `${minimum}-${maximum}` : rangePart
+		const [startText, endText] = range.includes('-')
+			? range.split('-')
+			: [range, range]
+		const start = Number.parseInt(startText, 10)
+		const end = Number.parseInt(endText, 10)
+		if (
+			!Number.isInteger(start) ||
+			!Number.isInteger(end) ||
+			start < minimum ||
+			end > maximum ||
+			start > end
+		) {
+			return false
+		}
+
+		return value >= start && value <= end && (value - start) % step === 0
+	})
+}
+
+/**
+ * Polls the configured UTC cron expression and runs one recap per matching
+ * minute. In-memory minute tracking handles the duplicate ticks caused by the
+ * 30-second poll interval; Redis deduplication handles process restarts.
+ */
+export class RecapCronScheduler {
+	private interval: NodeJS.Timeout | null = null
+	private lastRunMinute: string | null = null
+
+	constructor(
+		private readonly recapService: Pick<RecapCronService, 'runWeeklyRecap'>,
+		private readonly expression: string,
+		private readonly pollIntervalMs = POLL_INTERVAL_MS,
+	) {}
+
+	start(): void {
+		if (this.interval) return
+		this.tick(new Date(), true).catch((error) => {
+			logger.error({
+				message: 'Weekly recap scheduler startup tick failed',
+				metadata: {
+					error:
+						error instanceof Error ? error.message : String(error),
+				},
+			})
+		})
+		this.interval = setInterval(() => {
+			this.tick().catch((error) => {
+				logger.error({
+					message: 'Weekly recap scheduler tick failed',
+					metadata: {
+						error:
+							error instanceof Error
+								? error.message
+								: String(error),
+					},
+				})
+			})
+		}, this.pollIntervalMs)
+	}
+
+	async tick(now = new Date(), allowCatchUp = false): Promise<boolean> {
+		if (
+			!matchesCronExpression(this.expression, now) &&
+			!(allowCatchUp && isCronDueToday(this.expression, now))
+		) {
+			return false
+		}
+		const minuteKey = now.toISOString().slice(0, 16)
+		if (this.lastRunMinute === minuteKey) return false
+
+		this.lastRunMinute = minuteKey
+		await this.recapService.runWeeklyRecap(now)
+		return true
+	}
+
+	stop(): void {
+		if (!this.interval) return
+		clearInterval(this.interval)
+		this.interval = null
+	}
+
+	getStatus(): boolean {
+		return this.interval !== null
+	}
+}
+
+/**
+ * Treat a bot restart later on the scheduled UTC day as a missed-run catch-up.
+ * This keeps the default Monday digest reliable without posting on other days.
+ */
+function isCronDueToday(expression: string, now: Date): boolean {
+	const minute = now.getUTCMinutes()
+	const hour = now.getUTCHours()
+	for (let candidate = 0; candidate <= hour * 60 + minute; candidate++) {
+		const candidateDate = new Date(now)
+		candidateDate.setUTCHours(
+			Math.floor(candidate / 60),
+			candidate % 60,
+			0,
+			0,
+		)
+		if (matchesCronExpression(expression, candidateDate)) return true
+	}
+	return false
+}

--- a/src/utils/cron/RecapCronScheduler.ts
+++ b/src/utils/cron/RecapCronScheduler.ts
@@ -21,6 +21,64 @@ export function matchesCronExpression(expression: string, date: Date): boolean {
 	)
 }
 
+export function isValidCronExpression(expression: string): boolean {
+	const fields = expression.trim().split(/\s+/)
+	if (fields.length !== 5) return false
+	return fields.every((field, index) =>
+		isValidCronField(
+			field,
+			index === 0
+				? 0
+				: index === 1
+					? 0
+					: index === 2
+						? 1
+						: index === 3
+							? 1
+							: 0,
+			index === 0
+				? 59
+				: index === 1
+					? 23
+					: index === 2
+						? 31
+						: index === 3
+							? 12
+							: 6,
+		),
+	)
+}
+
+function isValidCronField(
+	field: string,
+	minimum: number,
+	maximum: number,
+): boolean {
+	return field.split(',').every((part) => {
+		const [rangePart, stepPart] = part.split('/')
+		const step = stepPart ? Number.parseInt(stepPart, 10) : 1
+		if (
+			!Number.isInteger(step) ||
+			step < 1 ||
+			(stepPart && !/^\d+$/.test(stepPart))
+		)
+			return false
+		if (rangePart === '*') return true
+		const [startText, endText] = rangePart.includes('-')
+			? rangePart.split('-')
+			: [rangePart, rangePart]
+		const start = Number.parseInt(startText, 10)
+		const end = Number.parseInt(endText, 10)
+		return (
+			Number.isInteger(start) &&
+			Number.isInteger(end) &&
+			start >= minimum &&
+			end <= maximum &&
+			start <= end
+		)
+	})
+}
+
 function matchesCronField(
 	field: string,
 	value: number,
@@ -60,15 +118,24 @@ function matchesCronField(
 export class RecapCronScheduler {
 	private interval: NodeJS.Timeout | null = null
 	private lastRunMinute: string | null = null
+	private readonly validExpression: boolean
 
 	constructor(
 		private readonly recapService: Pick<RecapCronService, 'runWeeklyRecap'>,
 		private readonly expression: string,
 		private readonly pollIntervalMs = POLL_INTERVAL_MS,
-	) {}
+	) {
+		this.validExpression = isValidCronExpression(expression)
+		if (!this.validExpression) {
+			logger.error({
+				message: 'Weekly recap scheduler disabled: invalid RECAP_CRON',
+				metadata: { expression },
+			})
+		}
+	}
 
 	start(): void {
-		if (this.interval) return
+		if (this.interval || !this.validExpression) return
 		this.tick(new Date(), true).catch((error) => {
 			logger.error({
 				message: 'Weekly recap scheduler startup tick failed',
@@ -94,6 +161,7 @@ export class RecapCronScheduler {
 	}
 
 	async tick(now = new Date(), allowCatchUp = false): Promise<boolean> {
+		if (!this.validExpression) return false
 		if (
 			!matchesCronExpression(this.expression, now) &&
 			!(allowCatchUp && isCronDueToday(this.expression, now))

--- a/src/utils/cron/RecapCronService.ts
+++ b/src/utils/cron/RecapCronService.ts
@@ -8,6 +8,7 @@ import { buildWeeklyRecapEmbeds } from '../embeds/weekly-recap.embed.js'
 import { logger } from '../logging/WinstonLogger.js'
 
 const RECAP_DEDUP_TTL_SECONDS = 8 * 24 * 60 * 60
+const RECAP_CLAIM_TTL_SECONDS = 5 * 60
 
 export interface RecapChannelResolver {
 	getBettingChannel(guildId: string): Promise<TextChannel>
@@ -201,14 +202,14 @@ export class RecapCronService {
 			return await this.cache.setIfAbsent(
 				key,
 				{ status: 'processing' },
-				RECAP_DEDUP_TTL_SECONDS,
+				RECAP_CLAIM_TTL_SECONDS,
 			)
 		}
 		if (await this.cache.get(key)) return false
 		await this.cache.set(
 			key,
 			{ status: 'processing' },
-			RECAP_DEDUP_TTL_SECONDS,
+			RECAP_CLAIM_TTL_SECONDS,
 		)
 		return true
 	}

--- a/src/utils/cron/RecapCronService.ts
+++ b/src/utils/cron/RecapCronService.ts
@@ -1,0 +1,170 @@
+import { container } from '@sapphire/framework'
+import { getISOWeek, getISOWeekYear } from 'date-fns'
+import { ChannelType, type TextChannel } from 'discord.js'
+import type RecapWrapper from '../api/Khronos/recap/recap-wrapper.js'
+import type { WeeklyRecapResponse } from '../api/Khronos/recap/recap-wrapper.js'
+import type { CacheManager } from '../cache/cache-manager.js'
+import { buildWeeklyRecapEmbeds } from '../embeds/weekly-recap.embed.js'
+import { logger } from '../logging/WinstonLogger.js'
+
+const RECAP_DEDUP_TTL_SECONDS = 8 * 24 * 60 * 60
+
+export interface RecapChannelResolver {
+	getBettingChannel(guildId: string): Promise<TextChannel>
+}
+
+export interface RecapCronOptions {
+	guildIds: string[]
+	enabled?: boolean
+	channelId?: string
+	weekOffset?: number
+}
+
+export interface RecapRunResult {
+	posted: number
+	skipped: number
+	failed: number
+}
+
+function resolveWeekIdentity(
+	data: WeeklyRecapResponse,
+	now: Date,
+): { seasonYear: number; weekNumber: number } {
+	const startDate = new Date(data.window.start_date)
+	const fallbackDate = Number.isNaN(startDate.valueOf()) ? now : startDate
+	return {
+		seasonYear: data.window.season_year ?? getISOWeekYear(fallbackDate),
+		weekNumber: data.window.week_number ?? getISOWeek(fallbackDate),
+	}
+}
+
+function dedupKey(
+	guildId: string,
+	data: WeeklyRecapResponse,
+	now: Date,
+): string {
+	const { seasonYear, weekNumber } = resolveWeekIdentity(data, now)
+	return `recap:posted:${guildId}:${seasonYear}:${weekNumber}`
+}
+
+/**
+ * Pulls a weekly recap from Khronos and delivers one digest per configured
+ * guild. The service owns idempotency and failure isolation; the scheduler
+ * only decides when this method runs.
+ */
+export class RecapCronService {
+	private readonly recapApi: Pick<RecapWrapper, 'getWeeklyRecap'>
+	private readonly cache: Pick<CacheManager, 'get' | 'set'>
+	private readonly channelResolver: RecapChannelResolver
+	private readonly options: Required<
+		Pick<RecapCronOptions, 'guildIds' | 'enabled' | 'weekOffset'>
+	> &
+		Pick<RecapCronOptions, 'channelId'>
+
+	constructor(
+		recapApi: Pick<RecapWrapper, 'getWeeklyRecap'>,
+		cache: Pick<CacheManager, 'get' | 'set'>,
+		channelResolver: RecapChannelResolver,
+		options: RecapCronOptions,
+	) {
+		this.recapApi = recapApi
+		this.cache = cache
+		this.channelResolver = channelResolver
+		this.options = {
+			guildIds: options.guildIds.filter(Boolean),
+			enabled: options.enabled ?? true,
+			channelId: options.channelId,
+			weekOffset: options.weekOffset ?? -1,
+		}
+	}
+
+	async runWeeklyRecap(now = new Date()): Promise<RecapRunResult> {
+		const result: RecapRunResult = { posted: 0, skipped: 0, failed: 0 }
+
+		if (!this.options.enabled) {
+			await logger.info({
+				message: 'weekly_recap_skipped',
+				metadata: { reason: 'disabled' },
+			})
+			return result
+		}
+
+		for (const guildId of this.options.guildIds) {
+			try {
+				const recap = await this.recapApi.getWeeklyRecap(
+					guildId,
+					this.options.weekOffset,
+				)
+				const key = dedupKey(guildId, recap, now)
+
+				if (await this.cache.get(key)) {
+					result.skipped++
+					await logger.info({
+						message: 'weekly_recap_skipped',
+						metadata: { reason: 'dedup', guild_id: guildId, key },
+					})
+					continue
+				}
+
+				const channel = await this.getRecapChannel(guildId)
+				await channel.send({ embeds: buildWeeklyRecapEmbeds(recap) })
+				await this.cache.set(key, true, RECAP_DEDUP_TTL_SECONDS)
+				result.posted++
+
+				await logger.info({
+					message: 'weekly_recap_posted',
+					metadata: {
+						guild_id: guildId,
+						week_number: recap.window.week_number,
+						channel_id: channel.id,
+					},
+				})
+			} catch (error) {
+				result.failed++
+				await logger.error({
+					message: 'weekly_recap_skipped',
+					metadata: {
+						reason: 'error',
+						guild_id: guildId,
+						status: this.getErrorStatus(error),
+						error:
+							error instanceof Error
+								? error.message
+								: String(error),
+					},
+				})
+			}
+		}
+
+		return result
+	}
+
+	private async getRecapChannel(guildId: string): Promise<TextChannel> {
+		if (!this.options.channelId) {
+			return await this.channelResolver.getBettingChannel(guildId)
+		}
+
+		const channel = await container.client.channels.fetch(
+			this.options.channelId,
+		)
+		if (!channel || channel.type !== ChannelType.GuildText) {
+			throw new Error(
+				`Recap channel ${this.options.channelId} is missing or not a text channel`,
+			)
+		}
+		if (channel.guild.id !== guildId) {
+			throw new Error(
+				`Recap channel ${this.options.channelId} does not belong to guild ${guildId}`,
+			)
+		}
+		return channel
+	}
+
+	private getErrorStatus(error: unknown): number | undefined {
+		if (!error || typeof error !== 'object') return undefined
+		const response = (error as { response?: { status?: unknown } }).response
+		return typeof response?.status === 'number'
+			? response.status
+			: undefined
+	}
+}

--- a/src/utils/cron/RecapCronService.ts
+++ b/src/utils/cron/RecapCronService.ts
@@ -86,7 +86,10 @@ export class RecapCronService {
 		}
 	}
 
-	async runWeeklyRecap(now = new Date()): Promise<RecapRunResult> {
+	async runWeeklyRecap(
+		now = new Date(),
+		allowProcessingReclaim = false,
+	): Promise<RecapRunResult> {
 		const result: RecapRunResult = { posted: 0, skipped: 0, failed: 0 }
 
 		if (!this.options.enabled) {
@@ -105,7 +108,10 @@ export class RecapCronService {
 				)
 				const key = dedupKey(guildId, recap, now)
 
-				const claimed = await this.claimDelivery(key)
+				const claimed = await this.claimDelivery(
+					key,
+					allowProcessingReclaim,
+				)
 				if (!claimed) {
 					result.skipped++
 					await logger.info({
@@ -139,6 +145,28 @@ export class RecapCronService {
 									: String(error),
 						},
 					})
+					try {
+						// Keep a durable sent marker lease when the first marker write
+						// fails. This closes the post-send crash/retry window without
+						// ever treating a failed Discord send as delivered.
+						await this.cache.set(
+							key,
+							{ status: 'sent' },
+							RECAP_DEDUP_TTL_SECONDS,
+						)
+					} catch (fallbackError) {
+						await logger.error({
+							message: 'weekly_recap_dedup_fallback_failed',
+							metadata: {
+								guild_id: guildId,
+								key,
+								error:
+									fallbackError instanceof Error
+										? fallbackError.message
+										: String(fallbackError),
+							},
+						})
+					}
 				}
 				result.posted++
 
@@ -197,7 +225,22 @@ export class RecapCronService {
 		return channel
 	}
 
-	private async claimDelivery(key: string): Promise<boolean> {
+	private async claimDelivery(
+		key: string,
+		allowProcessingReclaim: boolean,
+	): Promise<boolean> {
+		if (allowProcessingReclaim) {
+			const existing = await this.cache.get(key)
+			const isProcessing =
+				typeof existing === 'object' &&
+				existing !== null &&
+				(existing as { status?: unknown }).status === 'processing'
+			if (isProcessing) {
+				if (!this.cache.del) return false
+				await this.cache.del(key)
+			}
+		}
+
 		if (this.cache.setIfAbsent) {
 			return await this.cache.setIfAbsent(
 				key,

--- a/src/utils/cron/RecapCronService.ts
+++ b/src/utils/cron/RecapCronService.ts
@@ -20,6 +20,13 @@ export interface RecapCronOptions {
 	weekOffset?: number
 }
 
+interface RecapCache {
+	get(key: string): Promise<unknown>
+	set(key: string, value: unknown, ttl?: number): Promise<unknown>
+	setIfAbsent?(key: string, value: unknown, ttl?: number): Promise<boolean>
+	del?(key: string): Promise<unknown>
+}
+
 export interface RecapRunResult {
 	posted: number
 	skipped: number
@@ -54,7 +61,7 @@ function dedupKey(
  */
 export class RecapCronService {
 	private readonly recapApi: Pick<RecapWrapper, 'getWeeklyRecap'>
-	private readonly cache: Pick<CacheManager, 'get' | 'set'>
+	private readonly cache: RecapCache
 	private readonly channelResolver: RecapChannelResolver
 	private readonly options: Required<
 		Pick<RecapCronOptions, 'guildIds' | 'enabled' | 'weekOffset'>
@@ -97,7 +104,8 @@ export class RecapCronService {
 				)
 				const key = dedupKey(guildId, recap, now)
 
-				if (await this.cache.get(key)) {
+				const claimed = await this.claimDelivery(key)
+				if (!claimed) {
 					result.skipped++
 					await logger.info({
 						message: 'weekly_recap_skipped',
@@ -107,8 +115,29 @@ export class RecapCronService {
 				}
 
 				const channel = await this.getRecapChannel(guildId)
-				await channel.send({ embeds: buildWeeklyRecapEmbeds(recap) })
-				await this.cache.set(key, true, RECAP_DEDUP_TTL_SECONDS)
+				try {
+					await channel.send({
+						embeds: buildWeeklyRecapEmbeds(recap),
+					})
+				} catch (error) {
+					await this.releaseDeliveryClaim(key)
+					throw error
+				}
+				try {
+					await this.cache.set(key, true, RECAP_DEDUP_TTL_SECONDS)
+				} catch (error) {
+					await logger.warn({
+						message: 'weekly_recap_dedup_persist_failed',
+						metadata: {
+							guild_id: guildId,
+							key,
+							error:
+								error instanceof Error
+									? error.message
+									: String(error),
+						},
+					})
+				}
 				result.posted++
 
 				await logger.info({
@@ -153,11 +182,49 @@ export class RecapCronService {
 			)
 		}
 		if (channel.guild.id !== guildId) {
-			throw new Error(
-				`Recap channel ${this.options.channelId} does not belong to guild ${guildId}`,
-			)
+			await logger.warn({
+				message: 'weekly_recap_channel_override_mismatch',
+				metadata: {
+					guild_id: guildId,
+					channel_id: this.options.channelId,
+					channel_guild_id: channel.guild.id,
+				},
+			})
+			return await this.channelResolver.getBettingChannel(guildId)
 		}
 		return channel
+	}
+
+	private async claimDelivery(key: string): Promise<boolean> {
+		if (this.cache.setIfAbsent) {
+			return await this.cache.setIfAbsent(
+				key,
+				{ status: 'processing' },
+				RECAP_DEDUP_TTL_SECONDS,
+			)
+		}
+		if (await this.cache.get(key)) return false
+		await this.cache.set(
+			key,
+			{ status: 'processing' },
+			RECAP_DEDUP_TTL_SECONDS,
+		)
+		return true
+	}
+
+	private async releaseDeliveryClaim(key: string): Promise<void> {
+		try {
+			if (this.cache.del) await this.cache.del(key)
+		} catch (error) {
+			await logger.warn({
+				message: 'weekly_recap_claim_release_failed',
+				metadata: {
+					key,
+					error:
+						error instanceof Error ? error.message : String(error),
+				},
+			})
+		}
 	}
 
 	private getErrorStatus(error: unknown): number | undefined {

--- a/src/utils/cron/RecapCronService.ts
+++ b/src/utils/cron/RecapCronService.ts
@@ -114,8 +114,9 @@ export class RecapCronService {
 					continue
 				}
 
-				const channel = await this.getRecapChannel(guildId)
+				let channel: TextChannel
 				try {
+					channel = await this.getRecapChannel(guildId)
 					await channel.send({
 						embeds: buildWeeklyRecapEmbeds(recap),
 					})

--- a/src/utils/cron/__tests__/RecapCronScheduler.test.ts
+++ b/src/utils/cron/__tests__/RecapCronScheduler.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../logging/WinstonLogger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+import {
+	matchesCronExpression,
+	RecapCronScheduler,
+} from '../RecapCronScheduler.js'
+
+describe('matchesCronExpression', () => {
+	it('matches the Monday 09:00 UTC default', () => {
+		expect(
+			matchesCronExpression(
+				'0 9 * * 1',
+				new Date('2026-07-13T09:00:00.000Z'),
+			),
+		).toBe(true)
+		expect(
+			matchesCronExpression(
+				'0 9 * * 1',
+				new Date('2026-07-13T09:01:00.000Z'),
+			),
+		).toBe(false)
+	})
+})
+
+describe('RecapCronScheduler', () => {
+	it('runs once for a matching minute despite duplicate polls', async () => {
+		const runWeeklyRecap = vi.fn(async () => ({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		}))
+		const scheduler = new RecapCronScheduler(
+			{ runWeeklyRecap },
+			'0 9 * * 1',
+		)
+		const now = new Date('2026-07-13T09:00:15.000Z')
+
+		expect(await scheduler.tick(now)).toBe(true)
+		expect(await scheduler.tick(new Date('2026-07-13T09:00:45.000Z'))).toBe(
+			false,
+		)
+		expect(runWeeklyRecap).toHaveBeenCalledTimes(1)
+	})
+
+	it('catches up when the bot starts after the scheduled minute', async () => {
+		const runWeeklyRecap = vi.fn(async () => ({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		}))
+		const scheduler = new RecapCronScheduler(
+			{ runWeeklyRecap },
+			'0 9 * * 1',
+		)
+
+		expect(
+			await scheduler.tick(new Date('2026-07-13T10:15:00.000Z'), true),
+		).toBe(true)
+		expect(runWeeklyRecap).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/utils/cron/__tests__/RecapCronScheduler.test.ts
+++ b/src/utils/cron/__tests__/RecapCronScheduler.test.ts
@@ -66,5 +66,9 @@ describe('RecapCronScheduler', () => {
 			await scheduler.tick(new Date('2026-07-13T10:15:00.000Z'), true),
 		).toBe(true)
 		expect(runWeeklyRecap).toHaveBeenCalledTimes(1)
+		expect(runWeeklyRecap).toHaveBeenCalledWith(
+			new Date('2026-07-13T10:15:00.000Z'),
+			true,
+		)
 	})
 })

--- a/src/utils/cron/__tests__/RecapCronService.test.ts
+++ b/src/utils/cron/__tests__/RecapCronService.test.ts
@@ -38,6 +38,10 @@ function makeHarness() {
 			values.set(key, value)
 			return true
 		}),
+		del: vi.fn(async (key: string) => {
+			values.delete(key)
+			return 1
+		}),
 	}
 	const channel = {
 		id: 'recap-channel',
@@ -118,5 +122,58 @@ describe('RecapCronService', () => {
 			failed: 0,
 		})
 		expect(harness.recapApi.getWeeklyRecap).not.toHaveBeenCalled()
+	})
+
+	it('retains a sent marker lease when the first dedup write fails', async () => {
+		const harness = makeHarness()
+		harness.cache.set
+			.mockResolvedValueOnce(true)
+			.mockRejectedValueOnce(new Error('Redis write failed'))
+			.mockResolvedValueOnce(true)
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1'] },
+		)
+
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		})
+		expect(harness.cache.set).toHaveBeenLastCalledWith(
+			'recap:posted:guild-1:2026:19',
+			{ status: 'sent' },
+			691200,
+		)
+	})
+
+	it('reclaims a processing marker during startup catch-up', async () => {
+		const harness = makeHarness()
+		await harness.cache.set('recap:posted:guild-1:2026:19', {
+			status: 'processing',
+		})
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1'] },
+		)
+
+		expect(
+			await service.runWeeklyRecap(
+				new Date('2026-07-13T10:15:00.000Z'),
+				true,
+			),
+		).toEqual({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		})
+		expect(harness.cache.del).toHaveBeenCalledWith(
+			'recap:posted:guild-1:2026:19',
+		)
+		expect(harness.channel.send).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/utils/cron/__tests__/RecapCronService.test.ts
+++ b/src/utils/cron/__tests__/RecapCronService.test.ts
@@ -1,0 +1,122 @@
+import type { TextChannel } from 'discord.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../logging/WinstonLogger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+import type { WeeklyRecapResponse } from '../../api/Khronos/recap/recap-wrapper.js'
+import { RecapCronService } from '../RecapCronService.js'
+
+const recap: WeeklyRecapResponse = {
+	window: {
+		start_date: '2026-07-06T00:00:00.000Z',
+		end_date: '2026-07-12T23:59:59.999Z',
+		week_number: 19,
+		season_year: 2026,
+	},
+	total_predictions: 1,
+	correct_predictions: 1,
+	incorrect_predictions: 0,
+	accuracy: 100,
+	accuracy_delta: 10,
+	top_predictors: [],
+	biggest_single_win: null,
+	biggest_parlay_win: null,
+}
+
+function makeHarness() {
+	const values = new Map<string, unknown>()
+	const cache = {
+		get: vi.fn(async (key: string) => values.get(key) ?? false),
+		set: vi.fn(async (key: string, value: unknown) => {
+			values.set(key, value)
+			return true
+		}),
+	}
+	const channel = {
+		id: 'recap-channel',
+		send: vi.fn(async () => ({ id: 'message-1' })),
+	} as unknown as TextChannel
+	const channelResolver = {
+		getBettingChannel: vi.fn(async () => channel),
+	}
+	const recapApi = {
+		getWeeklyRecap: vi.fn(async () => recap),
+	}
+
+	return { cache, channel, channelResolver, recapApi }
+}
+
+describe('RecapCronService', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('posts once and skips the same guild/week after a restart', async () => {
+		const harness = makeHarness()
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1'] },
+		)
+
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		})
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 0,
+			skipped: 1,
+			failed: 0,
+		})
+		expect(harness.channel.send).toHaveBeenCalledTimes(1)
+		expect(harness.cache.set).toHaveBeenCalledWith(
+			'recap:posted:guild-1:2026:19',
+			true,
+			691200,
+		)
+	})
+
+	it('isolates Khronos or Discord failures per guild', async () => {
+		const harness = makeHarness()
+		harness.recapApi.getWeeklyRecap
+			.mockRejectedValueOnce(new Error('Khronos 503'))
+			.mockResolvedValueOnce(recap)
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1', 'guild-2'] },
+		)
+
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 1,
+			skipped: 0,
+			failed: 1,
+		})
+		expect(harness.channel.send).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not call Khronos when disabled', async () => {
+		const harness = makeHarness()
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1'], enabled: false },
+		)
+
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 0,
+			skipped: 0,
+			failed: 0,
+		})
+		expect(harness.recapApi.getWeeklyRecap).not.toHaveBeenCalled()
+	})
+})

--- a/src/utils/cron/index.ts
+++ b/src/utils/cron/index.ts
@@ -2,14 +2,19 @@
 // Cron Job Initialization - Export and initialize cron services
 // ============================================================================
 
+import env from '../../lib/startup/env.js'
+import GuildWrapper from '../api/Khronos/guild/guild-wrapper.js'
 import PredictionApiWrapper from '../api/Khronos/prediction/predictionApiWrapper.js'
 import PropsApiWrapper from '../api/Khronos/props/props-api-wrapper.js'
+import RecapWrapper from '../api/Khronos/recap/recap-wrapper.js'
 import { Cache } from '../cache/cache-manager.js'
 import { logger } from '../logging/WinstonLogger.js'
 import { ActivePropsService } from '../props/ActivePropsService.js'
 import { PropsCacheService } from '../props/PropCacheService.js'
 import { PropsCronScheduler } from './PropsCronScheduler.js'
 import { PropsCronService } from './PropsCronService.js'
+import { RecapCronScheduler } from './RecapCronScheduler.js'
+import { RecapCronService } from './RecapCronService.js'
 
 /**
  * Initialize and start the props cron scheduler
@@ -68,12 +73,83 @@ export function setPropsCronScheduler(scheduler: PropsCronScheduler): void {
 	propsCronScheduler = scheduler
 }
 
+/**
+ * Initialize the weekly recap digest. Recap remains opt-out by default but
+ * only starts when at least one guild is configured and Khronos has shipped
+ * the generated RecapApi client.
+ */
+export async function initializeRecapCron(): Promise<RecapCronScheduler | null> {
+	const guildIds = (env.RECAP_GUILD_IDS || process.env.GUILD_ID || '')
+		.split(',')
+		.map((guildId) => guildId.trim())
+		.filter(Boolean)
+
+	if (
+		env.USE_MOCK_DATA ||
+		env.RECAP_ENABLED === false ||
+		guildIds.length === 0
+	) {
+		await logger.info({
+			message: 'weekly_recap_skipped',
+			metadata: {
+				reason: env.USE_MOCK_DATA
+					? 'mock_data'
+					: env.RECAP_ENABLED === false
+						? 'disabled'
+						: 'no_guilds_configured',
+			},
+		})
+		return null
+	}
+
+	try {
+		const service = new RecapCronService(
+			new RecapWrapper(),
+			Cache(),
+			new GuildWrapper(),
+			{
+				guildIds,
+				enabled: env.RECAP_ENABLED,
+				channelId: env.RECAP_CHANNEL_ID,
+				weekOffset: -1,
+			},
+		)
+		const scheduler = new RecapCronScheduler(service, env.RECAP_CRON)
+		scheduler.start()
+		await logger.info({
+			message: 'Weekly recap scheduler initialized and started',
+			metadata: {
+				guild_count: guildIds.length,
+				expression: env.RECAP_CRON,
+			},
+		})
+		return scheduler
+	} catch (error) {
+		await logger.error({
+			message: 'weekly_recap_skipped',
+			metadata: {
+				reason: 'client_unavailable',
+				error: error instanceof Error ? error.message : String(error),
+			},
+		})
+		return null
+	}
+}
+
+let recapCronScheduler: RecapCronScheduler | null = null
+
+export function getRecapCronScheduler(): RecapCronScheduler | null {
+	return recapCronScheduler
+}
+
 // Auto-initialize when module is imported (after cache is ready)
 // We use a slight delay to ensure all dependencies are loaded
 setTimeout(async () => {
 	try {
 		const scheduler = await initializePropsCron()
 		setPropsCronScheduler(scheduler)
+		const recapScheduler = await initializeRecapCron()
+		recapCronScheduler = recapScheduler
 	} catch (error) {
 		await logger.error({
 			message: 'Failed to initialize props cron scheduler',

--- a/src/utils/embeds/__tests__/weekly-recap.embed.test.ts
+++ b/src/utils/embeds/__tests__/weekly-recap.embed.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+	buildWeeklyRecapEmbeds,
+	formatRecapUser,
+} from '../weekly-recap.embed.js'
+
+const recap = {
+	window: {
+		start_date: '2026-07-06T00:00:00.000Z',
+		end_date: '2026-07-12T23:59:59.999Z',
+		week_number: 19,
+		season_year: 2026,
+	},
+	total_predictions: 12,
+	correct_predictions: 9,
+	incorrect_predictions: 3,
+	accuracy: 75,
+	accuracy_delta: 12.5,
+	top_predictors: [
+		{
+			user_id: '123456789012345678',
+			correct_predictions: 8,
+			incorrect_predictions: 1,
+			success_rate: 88.888,
+			display_name: 'Top predictor',
+		},
+	],
+	biggest_single_win: {
+		user_id: '123456789012345678',
+		payout: 125.5,
+	},
+	biggest_parlay_win: null,
+}
+
+describe('buildWeeklyRecapEmbeds', () => {
+	it('renders week metadata, predictor standings, highlights, and totals', () => {
+		const [embed] = buildWeeklyRecapEmbeds(recap)
+		const json = embed.toJSON()
+
+		expect(json.title).toBe('📊 Week 19 Recap')
+		expect(json.description).toContain('Jul 6')
+		expect(json.fields?.map((field) => field.name)).toEqual([
+			'Top predictors',
+			'Highlights',
+			'Totals',
+		])
+		expect(json.fields?.[0]?.value).toContain('Top predictor')
+		expect(json.fields?.[1]?.value).toContain('125.50')
+		expect(json.fields?.[2]?.value).toContain('75.0%')
+	})
+
+	it('renders a friendly quiet-week state', () => {
+		const [embed] = buildWeeklyRecapEmbeds({
+			...recap,
+			total_predictions: 0,
+			correct_predictions: 0,
+			incorrect_predictions: 0,
+			accuracy: 0,
+			accuracy_delta: 0,
+			top_predictors: [],
+			biggest_single_win: null,
+			biggest_parlay_win: null,
+		})
+		const json = embed.toJSON()
+
+		expect(json.fields?.[0]?.value).toContain(
+			'No predictors recorded this week',
+		)
+		expect(json.fields?.[1]?.value).toContain('No wins recorded this week')
+	})
+})
+
+describe('formatRecapUser', () => {
+	it('truncates long display names without dropping the identity fallback', () => {
+		const formatted = formatRecapUser('123', 'a'.repeat(80))
+		expect(formatted).toHaveLength(32)
+		expect(formatted.endsWith('…')).toBe(true)
+	})
+})

--- a/src/utils/embeds/weekly-recap.embed.ts
+++ b/src/utils/embeds/weekly-recap.embed.ts
@@ -1,0 +1,116 @@
+import { EmbedBuilder } from 'discord.js'
+import embedColors from '../../lib/colorsConfig.js'
+import type { WeeklyRecapResponse } from '../api/Khronos/recap/recap-wrapper.js'
+
+const MAX_PREDICTORS = 5
+const MAX_DISPLAY_NAME_LENGTH = 32
+
+export type WeeklyRecapEmbedData = WeeklyRecapResponse
+
+/**
+ * Truncate user-provided display names before inserting them into Discord
+ * embed text. IDs remain available as a mention fallback when no name exists.
+ */
+export function formatRecapUser(userId: string, displayName?: string): string {
+	const candidate = displayName?.trim() || `<@${userId}>`
+	if (candidate.length <= MAX_DISPLAY_NAME_LENGTH) return candidate
+	return `${candidate.slice(0, MAX_DISPLAY_NAME_LENGTH - 1)}…`
+}
+
+function formatPayout(payout: number): string {
+	return Number.isFinite(payout) ? payout.toFixed(2) : '0.00'
+}
+
+function formatDelta(delta: number): string {
+	if (!Number.isFinite(delta) || delta === 0) return '0.0 pp'
+	return `${delta > 0 ? '+' : ''}${delta.toFixed(1)} pp`
+}
+
+function formatDateRange(data: WeeklyRecapEmbedData): string {
+	const start = new Date(data.window.start_date)
+	const end = new Date(data.window.end_date)
+	if (Number.isNaN(start.valueOf()) || Number.isNaN(end.valueOf())) {
+		return 'Sleeper-aligned weekly window'
+	}
+
+	return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })} – ${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })}`
+}
+
+function buildPredictorLines(data: WeeklyRecapEmbedData): string {
+	const predictors = data.top_predictors.slice(0, MAX_PREDICTORS)
+	if (predictors.length === 0) return 'No predictors recorded this week.'
+
+	return predictors
+		.map((predictor, index) => {
+			const total =
+				predictor.correct_predictions + predictor.incorrect_predictions
+			const rate = Number.isFinite(predictor.success_rate)
+				? predictor.success_rate
+				: total > 0
+					? (predictor.correct_predictions / total) * 100
+					: 0
+			return `${index + 1}. ${formatRecapUser(predictor.user_id, predictor.display_name)} — **${predictor.correct_predictions}/${total}** (${rate.toFixed(1)}%)`
+		})
+		.join('\n')
+}
+
+function buildWinLines(data: WeeklyRecapEmbedData): string {
+	const lines: string[] = []
+	if (data.biggest_single_win) {
+		lines.push(
+			`🎯 Single: ${formatRecapUser(data.biggest_single_win.user_id)} — **${formatPayout(data.biggest_single_win.payout)}**`,
+		)
+	}
+	if (data.biggest_parlay_win) {
+		lines.push(
+			`🎲 Parlay: ${formatRecapUser(data.biggest_parlay_win.user_id)} — **${formatPayout(data.biggest_parlay_win.payout)}**`,
+		)
+	}
+	return lines.length > 0
+		? lines.join('\n')
+		: 'No wins recorded this week — next week is yours.'
+}
+
+/**
+ * Build the weekly digest embeds posted by the recap cron.
+ *
+ * The digest intentionally caps predictor rows at five and keeps each section
+ * in a single field, staying below Discord's field and message limits while
+ * preserving the complete aggregate totals from Khronos.
+ */
+export function buildWeeklyRecapEmbeds(
+	data: WeeklyRecapEmbedData,
+): EmbedBuilder[] {
+	const weekLabel = data.window.week_number
+		? `Week ${data.window.week_number}`
+		: 'Weekly Recap'
+	const accuracy = Number.isFinite(data.accuracy) ? data.accuracy : 0
+
+	const embed = new EmbedBuilder()
+		.setTitle(`📊 ${weekLabel} Recap`)
+		.setColor(embedColors.PlutoBlue)
+		.setDescription(
+			`Sleeper-aligned window: **${formatDateRange(data)}**${data.window.season_year ? ` · Season ${data.window.season_year}` : ''}`,
+		)
+		.addFields(
+			{
+				name: 'Top predictors',
+				value: buildPredictorLines(data),
+			},
+			{
+				name: 'Highlights',
+				value: buildWinLines(data),
+			},
+			{
+				name: 'Totals',
+				value: [
+					`Predictions: **${data.total_predictions}**`,
+					`Correct: **${data.correct_predictions}** · Incorrect: **${data.incorrect_predictions}`,
+					`Accuracy: **${accuracy.toFixed(1)}%** (${formatDelta(data.accuracy_delta)})`,
+				].join('\n'),
+			},
+		)
+		.setFooter({ text: 'Khronos weekly recap · Pluto' })
+
+	return [embed]
+}

--- a/src/utils/embeds/weekly-recap.embed.ts
+++ b/src/utils/embeds/weekly-recap.embed.ts
@@ -105,7 +105,7 @@ export function buildWeeklyRecapEmbeds(
 				name: 'Totals',
 				value: [
 					`Predictions: **${data.total_predictions}**`,
-					`Correct: **${data.correct_predictions}** · Incorrect: **${data.incorrect_predictions}`,
+					`Correct: **${data.correct_predictions}** · Incorrect: **${data.incorrect_predictions}**`,
 					`Accuracy: **${accuracy.toFixed(1)}%** (${formatDelta(data.accuracy_delta)})`,
 				].join('\n'),
 			},


### PR DESCRIPTION
## Summary\n- add RECAP_CRON, RECAP_CHANNEL_ID, RECAP_ENABLED, and RECAP_GUILD_IDS controls\n- pull Khronos weekly recap through the generated-client RecapApi contract\n- post bounded weekly recap embeds with quiet-week fallback to configured guild channels\n- deduplicate by guild/season/week in Redis for 8 days and catch up after Monday restarts\n- isolate API/channel failures and emit weekly_recap_posted / weekly_recap_skipped logs\n\n## Verification\n- focused Vitest: 9/9\n- full Vitest: 68/68\n- pnpm typecheck\n- pnpm build\n- targeted and full Biome checks\n- git diff --check\n\n## Dependency\nTF-974 is paired with Khronos TF-957. Runtime uses the generated RecapApi export once the Khronos client release is published; current client absence is handled as a non-fatal client_unavailable skip.\n\nTarget is the integration branch dev/parlays-props; no main/production changes.\n\nLinear: TF-974