### PR TITLE
feat(predictions): render streak badges in Discord

### DIFF
--- a/src/commands/predictions/__tests__/predictions.test.ts
+++ b/src/commands/predictions/__tests__/predictions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetLeaderboard = vi.fn()
 const mockGetActivePredictionsForUser = vi.fn()
+const mockGetPredictionStats = vi.fn()
 
 vi.mock(
 	'../../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js',
@@ -22,6 +23,12 @@ vi.mock(
 		}),
 	}),
 )
+
+vi.mock('../../../utils/api/Khronos/stats/stats-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getPredictionStats: mockGetPredictionStats }
+	}),
+}))
 
 vi.mock('../../../utils/api/Khronos/props/props-api-wrapper.js', () => ({
 	default: vi.fn().mockImplementation(function () {
@@ -55,7 +62,7 @@ vi.mock('@sapphire/discord.js-utilities', () => ({
 }))
 
 const { SlashCommandBuilder } = await import('discord.js')
-const { UserCommand } = await import('../predictions.js')
+const { formatStreakBadge, UserCommand } = await import('../predictions.js')
 
 function makeInteraction() {
 	return {
@@ -122,6 +129,9 @@ describe('/predictions', () => {
 					correct_predictions: 9,
 					incorrect_predictions: 3,
 					success_rate: 75,
+					current_streak: 0,
+					best_streak: 0,
+					badge_tier: null,
 				},
 			],
 			total_users: 1,
@@ -158,6 +168,103 @@ describe('/predictions', () => {
 				expect.objectContaining({ name: '⏳ Pending', value: '`2`' }),
 			]),
 		)
+	})
+
+	it('renders current and best streak from the Khronos stats contract', async () => {
+		mockGetLeaderboard.mockResolvedValue({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+					current_streak: 4,
+					best_streak: 7,
+					badge_tier: 3,
+				},
+			],
+			total_users: 1,
+		})
+		mockGetActivePredictionsForUser.mockResolvedValue([])
+		mockGetPredictionStats.mockResolvedValue({
+			user_id: 'user-1',
+			correct_predictions: 9,
+			incorrect_predictions: 3,
+			total_predictions: 12,
+			success_rate: 75,
+			current_streak: 4,
+			best_streak: 7,
+			badge_tier: 3,
+		})
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(mockGetPredictionStats).toHaveBeenCalledWith({
+			userId: 'user-1',
+			guildId: 'guild-1',
+		})
+		const [{ embeds }] = interaction.editReply.mock.calls.find(
+			([payload]) => payload.embeds,
+		) as [{ embeds: Array<{ toJSON: () => unknown }> }]
+		const embed = embeds[0].toJSON() as {
+			fields?: Array<{ name: string; value: string }>
+		}
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🔥 Current Streak',
+					value: '`4`',
+				}),
+				expect.objectContaining({
+					name: '🏆 Best Streak',
+					value: '`7`',
+				}),
+				expect.objectContaining({
+					name: '🏅 Streak Badge',
+					value: '`🔥3`',
+				}),
+			]),
+		)
+	})
+
+	it.each([
+		[0, ''],
+		[2, ''],
+		[3, ' 🔥3'],
+		[5, ' 🔥5'],
+		[10, ' 🔥10'],
+	] as const)('formats streak marker at threshold %i', (streak, expected) => {
+		expect(formatStreakBadge(streak)).toBe(expected)
+	})
+
+	it('renders a fire marker in leaderboard rows at the reported tier', async () => {
+		const createLeaderboardEmbed = (
+			command as unknown as {
+				createLeaderboardEmbed: (
+					entries: unknown[],
+					page: number,
+				) => Promise<{ toJSON: () => { description?: string } }>
+			}
+		).createLeaderboardEmbed.bind(command)
+		const embed = await createLeaderboardEmbed(
+			[
+				{
+					position: 1,
+					userId: 'user-1',
+					score: 88,
+					correctPredictions: 10,
+					incorrectPredictions: 2,
+					currentStreak: 5,
+					bestStreak: 6,
+					badgeTier: 5,
+				},
+			],
+			1,
+		)
+
+		expect(embed.toJSON().description).toContain('user-1 🔥5')
 	})
 
 	it('returns friendly empty copy when server stats and pending data are empty', async () => {

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -1,7 +1,4 @@
-import type {
-	AllUserPredictionsDto,
-	SimpleLeaderboardResponseDto,
-} from '@pluto-khronos/api-client'
+import type { AllUserPredictionsDto } from '@pluto-khronos/api-client'
 import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
 import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
@@ -16,13 +13,23 @@ import _ from 'lodash'
 import { teamResolver } from 'resolve-team'
 import embedColors from '../../lib/colorsConfig.js'
 import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
-import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
+import LeaderboardWrapper, {
+	type LeaderboardResponseWithStreaks,
+} from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
 import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
 import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
+import StatsWrapper, {
+	type PredictionStats,
+} from '../../utils/api/Khronos/stats/stats-wrapper.js'
 import ClientTools from '../../utils/bot_res/ClientTools.js'
 import { DateManager } from '../../utils/common/DateManager.js'
 import TeamInfo from '../../utils/common/TeamInfo.js'
 import Pagination from '../../utils/embeds/pagination.js'
+import {
+	formatBadge,
+	formatStreakLine,
+	type StreakBadgeTier,
+} from '../../utils/predictions/streak-display.js'
 
 /**
  * Reserved command id for the consolidated group. Legacy aliases retain their
@@ -30,6 +37,27 @@ import Pagination from '../../utils/embeds/pagination.js'
  * the migration window.
  */
 const PREDICTIONS_COMMAND_ID_HINTS = ['1298280482123026537']
+
+/** Resolve display badge from the current streak when older API payloads omit it. */
+export function resolveStreakBadgeTier(
+	currentStreak: number,
+	reportedTier: StreakBadgeTier = null,
+): StreakBadgeTier {
+	if (reportedTier !== null) return reportedTier
+	if (currentStreak >= 10) return 10
+	if (currentStreak >= 5) return 5
+	if (currentStreak >= 3) return 3
+	return null
+}
+
+/** Keep leaderboard marker copy consistent across pages and future clients. */
+export function formatStreakBadge(
+	currentStreak: number,
+	reportedTier: StreakBadgeTier = null,
+): string {
+	const tier = resolveStreakBadgeTier(currentStreak, reportedTier)
+	return formatBadge(tier)
+}
 
 @ApplyOptions<Subcommand.Options>({
 	name: 'predictions',
@@ -204,6 +232,20 @@ export class UserCommand extends Subcommand {
 					userId: interaction.user.id,
 				}),
 			])
+			let predictionStats: PredictionStats | null = null
+			try {
+				predictionStats = await new StatsWrapper().getPredictionStats({
+					userId: interaction.user.id,
+					guildId,
+				})
+			} catch (error) {
+				// Keep stats usable while a mixed-version Khronos deployment rolls
+				// out, without presenting stale leaderboard streaks as personal stats.
+				this.container.logger.warn(
+					'Prediction streak stats unavailable; using leaderboard fallback.',
+					error,
+				)
+			}
 			const pending = allPending.filter(
 				(prediction) => prediction.guild_id === guildId,
 			)
@@ -221,10 +263,18 @@ export class UserCommand extends Subcommand {
 			const correctPredictions = entry?.correct_predictions ?? 0
 			const incorrectPredictions = entry?.incorrect_predictions ?? 0
 			const winRate = entry?.success_rate ?? 0
+			const currentStreak = predictionStats?.current_streak ?? 0
+			const bestStreak = predictionStats?.best_streak ?? 0
+			const badgeTier = resolveStreakBadgeTier(
+				currentStreak,
+				predictionStats?.badge_tier ?? null,
+			)
 			const embed = new EmbedBuilder()
 				.setTitle('📊 Prediction Statistics')
 				.setColor(embedColors.PlutoBlue)
-				.setDescription(`Server stats for ${interaction.user.username}`)
+				.setDescription(
+					`Server stats for ${interaction.user.username}\n\n${formatStreakLine(currentStreak, bestStreak)}`,
+				)
 				.addFields(
 					{
 						name: 'Total Predictions',
@@ -252,9 +302,27 @@ export class UserCommand extends Subcommand {
 						value: `\`${pending.length}\``,
 						inline: true,
 					},
+					{
+						name: '🔥 Current Streak',
+						value: `\`${currentStreak}\``,
+						inline: true,
+					},
+					{
+						name: '🏆 Best Streak',
+						value: `\`${bestStreak}\``,
+						inline: true,
+					},
+					{
+						name: '🏅 Streak Badge',
+						value:
+							badgeTier === null
+								? '`None yet`'
+								: `\`🔥${badgeTier}\``,
+						inline: true,
+					},
 				)
 				.setFooter({
-					text: 'Streaks will appear here after the engagement rollout.',
+					text: "Use /predictions leaderboard to compare your streak • voids/pushes don't break streaks.",
 				})
 				.setTimestamp()
 
@@ -362,7 +430,7 @@ export class UserCommand extends Subcommand {
 	}
 
 	private parseLeaderboardData(
-		leaderboard: SimpleLeaderboardResponseDto,
+		leaderboard: LeaderboardResponseWithStreaks,
 	): ParsedLeaderboardEntry[] {
 		return leaderboard.entries.map((entry, index) => ({
 			userId: entry.user_id,
@@ -373,6 +441,9 @@ export class UserCommand extends Subcommand {
 					LEADERBOARD_SCORING.INCORRECT_PENALTY,
 			correctPredictions: entry.correct_predictions,
 			incorrectPredictions: entry.incorrect_predictions,
+			currentStreak: entry.current_streak,
+			bestStreak: entry.best_streak,
+			badgeTier: entry.badge_tier,
 		}))
 	}
 
@@ -389,7 +460,11 @@ export class UserCommand extends Subcommand {
 				const username = member?.username ?? entry.userId
 				const total =
 					entry.correctPredictions + entry.incorrectPredictions
-				return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
+				const streakBadge = formatStreakBadge(
+					entry.currentStreak,
+					entry.badgeTier,
+				)
+				return `${entry.position}. ${username}${streakBadge} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
 			}),
 		)
 
@@ -398,7 +473,7 @@ export class UserCommand extends Subcommand {
 			.setColor(embedColors.PlutoBlue)
 			.setDescription(description.join('\n'))
 			.setFooter({
-				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length}`,
+				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length} | 🔥3/5/10 = streak badge`,
 			})
 	}
 
@@ -478,4 +553,7 @@ interface ParsedLeaderboardEntry {
 	score: number
 	correctPredictions: number
 	incorrectPredictions: number
+	currentStreak: number
+	bestStreak: number
+	badgeTier: StreakBadgeTier
 }

--- a/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.ts
+++ b/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.ts
@@ -3,7 +3,26 @@ import {
 	LeaderboardApi,
 	type LeaderboardControllerGetLeaderboardV1Request,
 } from '@pluto-khronos/api-client'
+import type { StreakBadgeTier } from '../../../predictions/streak-display.js'
 import { type IKH_API_CONFIG, KH_API_CONFIG } from '../KhronosInstances.js'
+
+export type { StreakBadgeTier }
+
+export interface LeaderboardEntryWithStreaks {
+	user_id: string
+	total_predictions: number
+	correct_predictions: number
+	incorrect_predictions: number
+	success_rate: number
+	current_streak: number
+	best_streak: number
+	badge_tier: StreakBadgeTier
+}
+
+export interface LeaderboardResponseWithStreaks {
+	entries: LeaderboardEntryWithStreaks[]
+	total_users: number
+}
 
 export default class LeaderboardWrapper {
 	private leaderboardsApi: LeaderboardApi
@@ -20,9 +39,39 @@ export default class LeaderboardWrapper {
 	 */
 	async getLeaderboard(
 		params: LeaderboardControllerGetLeaderboardV1Request,
-	): Promise<SimpleLeaderboardResponseDto> {
-		return await this.leaderboardsApi.leaderboardControllerGetLeaderboardV1(
-			params,
-		)
+	): Promise<LeaderboardResponseWithStreaks> {
+		const response =
+			(await this.leaderboardsApi.leaderboardControllerGetLeaderboardV1(
+				params,
+			)) as SimpleLeaderboardResponseDto & {
+				entries: Array<
+					SimpleLeaderboardResponseDto['entries'][number] &
+						Partial<
+							Pick<
+								LeaderboardEntryWithStreaks,
+								'current_streak' | 'best_streak' | 'badge_tier'
+							>
+						>
+				>
+			}
+		const entries = response.entries as Array<
+			SimpleLeaderboardResponseDto['entries'][number] &
+				Partial<
+					Pick<
+						LeaderboardEntryWithStreaks,
+						'current_streak' | 'best_streak' | 'badge_tier'
+					>
+				>
+		>
+
+		return {
+			...response,
+			entries: entries.map((entry) => ({
+				...entry,
+				current_streak: entry.current_streak ?? 0,
+				best_streak: entry.best_streak ?? 0,
+				badge_tier: entry.badge_tier ?? null,
+			})),
+		}
 	}
 }

--- a/src/utils/api/Khronos/stats/stats-wrapper.ts
+++ b/src/utils/api/Khronos/stats/stats-wrapper.ts
@@ -5,7 +5,82 @@ import {
 } from '@pluto-khronos/api-client'
 import { KH_API_CONFIG } from '../KhronosInstances.js'
 
-export default class StatsWraps {
+export interface PredictionStats {
+	user_id: string
+	correct_predictions: number
+	incorrect_predictions: number
+	total_predictions: number
+	success_rate: number
+	current_streak: number
+	best_streak: number
+	badge_tier: 3 | 5 | 10 | null
+}
+
+export interface PredictionStatsRequest {
+	userId: string
+	guildId: string
+}
+
+/**
+ * The generated client predates the F3 stats operation. Keep the temporary
+ * transport shim here until the next Khronos package release adds it.
+ */
+export function parsePredictionStats(payload: unknown): PredictionStats {
+	if (!payload || typeof payload !== 'object') {
+		throw new Error('Khronos returned an invalid prediction stats payload')
+	}
+
+	const value = payload as Record<string, unknown>
+	const numericFields = [
+		'correct_predictions',
+		'incorrect_predictions',
+		'total_predictions',
+		'success_rate',
+		'current_streak',
+		'best_streak',
+	] as const
+	if (
+		typeof value.user_id !== 'string' ||
+		numericFields.some(
+			(field) =>
+				typeof value[field] !== 'number' ||
+				!Number.isFinite(value[field]),
+		)
+	) {
+		throw new Error('Khronos returned an invalid prediction stats payload')
+	}
+
+	const badgeTier = value.badge_tier as PredictionStats['badge_tier']
+	if (
+		badgeTier !== null &&
+		badgeTier !== 3 &&
+		badgeTier !== 5 &&
+		badgeTier !== 10
+	) {
+		throw new Error(
+			'Khronos returned an invalid prediction stats badge tier',
+		)
+	}
+	const correctPredictions = value.correct_predictions as number
+	const incorrectPredictions = value.incorrect_predictions as number
+	const totalPredictions = value.total_predictions as number
+	const successRate = value.success_rate as number
+	const currentStreak = value.current_streak as number
+	const bestStreak = value.best_streak as number
+
+	return {
+		user_id: value.user_id,
+		correct_predictions: correctPredictions,
+		incorrect_predictions: incorrectPredictions,
+		total_predictions: totalPredictions,
+		success_rate: successRate,
+		current_streak: currentStreak,
+		best_streak: bestStreak,
+		badge_tier: badgeTier,
+	}
+}
+
+export default class StatsWrapper {
 	private readonly statsApi: StatsApi
 
 	constructor() {
@@ -17,5 +92,31 @@ export default class StatsWraps {
 	): Promise<OverallStatsDto> {
 		const response = await this.statsApi.getOverallH2hBettingStats(params)
 		return response
+	}
+
+	async getPredictionStats(
+		params: PredictionStatsRequest,
+	): Promise<PredictionStats> {
+		const path = `/api/khronos/v1/prediction/stats/${encodeURIComponent(params.userId)}`
+		const query = new URLSearchParams({ guild_id: params.guildId })
+		const fetchApi = KH_API_CONFIG.fetchApi ?? fetch
+		const response = await fetchApi(
+			`${KH_API_CONFIG.basePath}${path}?${query.toString()}`,
+			{
+				method: 'GET',
+				headers: {
+					...KH_API_CONFIG.headers,
+					Accept: 'application/json',
+				},
+			},
+		)
+
+		if (!response.ok) {
+			throw new Error(
+				`Khronos prediction stats request failed (${response.status})`,
+			)
+		}
+
+		return parsePredictionStats(await response.json())
 	}
 }

--- a/src/utils/predictions/streak-display.ts
+++ b/src/utils/predictions/streak-display.ts
@@ -1,0 +1,13 @@
+export type StreakBadgeTier = 3 | 5 | 10 | null
+
+/** Format a compact, text-accessible badge marker for leaderboard rows. */
+export function formatBadge(tier: StreakBadgeTier): string {
+	return tier === null ? '' : ` 🔥${tier}`
+}
+
+/** Format the personal streak summary used by prediction stats embeds. */
+export function formatStreakLine(current: number, best: number): string {
+	const currentCopy =
+		current > 0 ? `**${current}**` : '**0** (No active streak)'
+	return `Current Streak: ${currentCopy} · Best: **${best}**`
+}


### PR DESCRIPTION
## Summary
- add typed Khronos prediction-stats compatibility transport for TF-958 fields
- render current/best streak and badge tier in consolidated `/predictions stats`
- add 🔥3/5/10 markers to paginated `/predictions leaderboard` rows
- update footer copy with neutral void/push semantics and add focused formatter/command coverage

## Verification
- `pnpm typecheck`
- `pnpm test:run` (9 files, 70 tests)
- `pnpm build`
- `pnpm exec biome check` (schema-version info only)

Fresh integration branch: based on `origin/dev/parlays-props` at `dfdb0851` after the TF-972/TF-973/TF-974 merge wave. No `main` or production changes.