### PR TITLE
feat(predictions): render streak badges in Discord

### DIFF
--- a/src/commands/predictions/__tests__/predictions.test.ts
+++ b/src/commands/predictions/__tests__/predictions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetLeaderboard = vi.fn()
 const mockGetActivePredictionsForUser = vi.fn()
+const mockGetPredictionStats = vi.fn()
 
 vi.mock(
 	'../../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js',
@@ -22,6 +23,12 @@ vi.mock(
 		}),
 	}),
 )
+
+vi.mock('../../../utils/api/Khronos/stats/stats-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getPredictionStats: mockGetPredictionStats }
+	}),
+}))
 
 vi.mock('../../../utils/api/Khronos/props/props-api-wrapper.js', () => ({
 	default: vi.fn().mockImplementation(function () {
@@ -55,7 +62,7 @@ vi.mock('@sapphire/discord.js-utilities', () => ({
 }))
 
 const { SlashCommandBuilder } = await import('discord.js')
-const { UserCommand } = await import('../predictions.js')
+const { formatStreakBadge, UserCommand } = await import('../predictions.js')
 
 function makeInteraction() {
 	return {
@@ -122,6 +129,9 @@ describe('/predictions', () => {
 					correct_predictions: 9,
 					incorrect_predictions: 3,
 					success_rate: 75,
+					current_streak: 0,
+					best_streak: 0,
+					badge_tier: null,
 				},
 			],
 			total_users: 1,
@@ -158,6 +168,103 @@ describe('/predictions', () => {
 				expect.objectContaining({ name: '⏳ Pending', value: '`2`' }),
 			]),
 		)
+	})
+
+	it('renders current and best streak from the Khronos stats contract', async () => {
+		mockGetLeaderboard.mockResolvedValue({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+					current_streak: 4,
+					best_streak: 7,
+					badge_tier: 3,
+				},
+			],
+			total_users: 1,
+		})
+		mockGetActivePredictionsForUser.mockResolvedValue([])
+		mockGetPredictionStats.mockResolvedValue({
+			user_id: 'user-1',
+			correct_predictions: 9,
+			incorrect_predictions: 3,
+			total_predictions: 12,
+			success_rate: 75,
+			current_streak: 4,
+			best_streak: 7,
+			badge_tier: 3,
+		})
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(mockGetPredictionStats).toHaveBeenCalledWith({
+			userId: 'user-1',
+			guildId: 'guild-1',
+		})
+		const [{ embeds }] = interaction.editReply.mock.calls.find(
+			([payload]) => payload.embeds,
+		) as [{ embeds: Array<{ toJSON: () => unknown }> }]
+		const embed = embeds[0].toJSON() as {
+			fields?: Array<{ name: string; value: string }>
+		}
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🔥 Current Streak',
+					value: '`4`',
+				}),
+				expect.objectContaining({
+					name: '🏆 Best Streak',
+					value: '`7`',
+				}),
+				expect.objectContaining({
+					name: '🏅 Streak Badge',
+					value: '`🔥3`',
+				}),
+			]),
+		)
+	})
+
+	it.each([
+		[0, ''],
+		[2, ''],
+		[3, ' 🔥3'],
+		[5, ' 🔥5'],
+		[10, ' 🔥10'],
+	] as const)('formats streak marker at threshold %i', (streak, expected) => {
+		expect(formatStreakBadge(streak)).toBe(expected)
+	})
+
+	it('renders a fire marker in leaderboard rows at the reported tier', async () => {
+		const createLeaderboardEmbed = (
+			command as unknown as {
+				createLeaderboardEmbed: (
+					entries: unknown[],
+					page: number,
+				) => Promise<{ toJSON: () => { description?: string } }>
+			}
+		).createLeaderboardEmbed.bind(command)
+		const embed = await createLeaderboardEmbed(
+			[
+				{
+					position: 1,
+					userId: 'user-1',
+					score: 88,
+					correctPredictions: 10,
+					incorrectPredictions: 2,
+					currentStreak: 5,
+					bestStreak: 6,
+					badgeTier: 5,
+				},
+			],
+			1,
+		)
+
+		expect(embed.toJSON().description).toContain('user-1 🔥5')
 	})
 
 	it('returns friendly empty copy when server stats and pending data are empty', async () => {

--- a/src/commands/predictions/__tests__/predictions.test.ts
+++ b/src/commands/predictions/__tests__/predictions.test.ts
@@ -63,6 +63,9 @@ vi.mock('@sapphire/discord.js-utilities', () => ({
 
 const { SlashCommandBuilder } = await import('discord.js')
 const { formatStreakBadge, UserCommand } = await import('../predictions.js')
+const { formatStreakLine } = await import(
+	'../../../utils/predictions/streak-display.js'
+)
 
 function makeInteraction() {
 	return {
@@ -237,6 +240,52 @@ describe('/predictions', () => {
 		[10, ' 🔥10'],
 	] as const)('formats streak marker at threshold %i', (streak, expected) => {
 		expect(formatStreakBadge(streak)).toBe(expected)
+	})
+
+	it('does not present unavailable stats as a broken zero streak', async () => {
+		mockGetLeaderboard.mockResolvedValue({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+					current_streak: 4,
+					best_streak: 7,
+					badge_tier: 3,
+				},
+			],
+			total_users: 1,
+		})
+		mockGetActivePredictionsForUser.mockResolvedValue([])
+		mockGetPredictionStats.mockRejectedValue(
+			new Error('stats endpoint unavailable'),
+		)
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		const [{ embeds }] = interaction.editReply.mock.calls.find(
+			([payload]) => payload.embeds,
+		) as [{ embeds: Array<{ toJSON: () => unknown }> }]
+		const embed = embeds[0].toJSON() as {
+			description?: string
+			fields?: Array<{ name: string; value: string }>
+		}
+		expect(embed.description).toContain(formatStreakLine(null, null))
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🔥 Current Streak',
+					value: '`Unavailable`',
+				}),
+				expect.objectContaining({
+					name: '🏅 Streak Badge',
+					value: '`Unavailable`',
+				}),
+			]),
+		)
 	})
 
 	it('renders a fire marker in leaderboard rows at the reported tier', async () => {

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -1,7 +1,4 @@
-import type {
-	AllUserPredictionsDto,
-	SimpleLeaderboardResponseDto,
-} from '@pluto-khronos/api-client'
+import type { AllUserPredictionsDto } from '@pluto-khronos/api-client'
 import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
 import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
@@ -16,13 +13,23 @@ import _ from 'lodash'
 import { teamResolver } from 'resolve-team'
 import embedColors from '../../lib/colorsConfig.js'
 import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
-import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
+import LeaderboardWrapper, {
+	type LeaderboardResponseWithStreaks,
+} from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
 import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
 import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
+import StatsWrapper, {
+	type PredictionStats,
+} from '../../utils/api/Khronos/stats/stats-wrapper.js'
 import ClientTools from '../../utils/bot_res/ClientTools.js'
 import { DateManager } from '../../utils/common/DateManager.js'
 import TeamInfo from '../../utils/common/TeamInfo.js'
 import Pagination from '../../utils/embeds/pagination.js'
+import {
+	formatBadge,
+	formatStreakLine,
+	type StreakBadgeTier,
+} from '../../utils/predictions/streak-display.js'
 
 /**
  * Reserved command id for the consolidated group. Legacy aliases retain their
@@ -30,6 +37,27 @@ import Pagination from '../../utils/embeds/pagination.js'
  * the migration window.
  */
 const PREDICTIONS_COMMAND_ID_HINTS = ['1298280482123026537']
+
+/** Resolve display badge from the current streak when older API payloads omit it. */
+export function resolveStreakBadgeTier(
+	currentStreak: number,
+	reportedTier: StreakBadgeTier = null,
+): StreakBadgeTier {
+	if (reportedTier !== null) return reportedTier
+	if (currentStreak >= 10) return 10
+	if (currentStreak >= 5) return 5
+	if (currentStreak >= 3) return 3
+	return null
+}
+
+/** Keep leaderboard marker copy consistent across pages and future clients. */
+export function formatStreakBadge(
+	currentStreak: number,
+	reportedTier: StreakBadgeTier = null,
+): string {
+	const tier = resolveStreakBadgeTier(currentStreak, reportedTier)
+	return formatBadge(tier)
+}
 
 @ApplyOptions<Subcommand.Options>({
 	name: 'predictions',
@@ -204,6 +232,20 @@ export class UserCommand extends Subcommand {
 					userId: interaction.user.id,
 				}),
 			])
+			let predictionStats: PredictionStats | null = null
+			try {
+				predictionStats = await new StatsWrapper().getPredictionStats({
+					userId: interaction.user.id,
+					guildId,
+				})
+			} catch (error) {
+				// Keep stats usable while a mixed-version Khronos deployment rolls
+				// out, without presenting stale leaderboard streaks as personal stats.
+				this.container.logger.warn(
+					'Prediction streak stats unavailable; using leaderboard fallback.',
+					error,
+				)
+			}
 			const pending = allPending.filter(
 				(prediction) => prediction.guild_id === guildId,
 			)
@@ -221,10 +263,18 @@ export class UserCommand extends Subcommand {
 			const correctPredictions = entry?.correct_predictions ?? 0
 			const incorrectPredictions = entry?.incorrect_predictions ?? 0
 			const winRate = entry?.success_rate ?? 0
+			const currentStreak = predictionStats?.current_streak ?? 0
+			const bestStreak = predictionStats?.best_streak ?? 0
+			const badgeTier = resolveStreakBadgeTier(
+				currentStreak,
+				predictionStats?.badge_tier ?? null,
+			)
 			const embed = new EmbedBuilder()
 				.setTitle('📊 Prediction Statistics')
 				.setColor(embedColors.PlutoBlue)
-				.setDescription(`Server stats for ${interaction.user.username}`)
+				.setDescription(
+					`Server stats for ${interaction.user.username}\n\n${formatStreakLine(currentStreak, bestStreak)}`,
+				)
 				.addFields(
 					{
 						name: 'Total Predictions',
@@ -252,9 +302,27 @@ export class UserCommand extends Subcommand {
 						value: `\`${pending.length}\``,
 						inline: true,
 					},
+					{
+						name: '🔥 Current Streak',
+						value: `\`${currentStreak}\``,
+						inline: true,
+					},
+					{
+						name: '🏆 Best Streak',
+						value: `\`${bestStreak}\``,
+						inline: true,
+					},
+					{
+						name: '🏅 Streak Badge',
+						value:
+							badgeTier === null
+								? '`None yet`'
+								: `\`🔥${badgeTier}\``,
+						inline: true,
+					},
 				)
 				.setFooter({
-					text: 'Streaks will appear here after the engagement rollout.',
+					text: "Use /predictions leaderboard to compare your streak • voids/pushes don't break streaks.",
 				})
 				.setTimestamp()
 
@@ -362,7 +430,7 @@ export class UserCommand extends Subcommand {
 	}
 
 	private parseLeaderboardData(
-		leaderboard: SimpleLeaderboardResponseDto,
+		leaderboard: LeaderboardResponseWithStreaks,
 	): ParsedLeaderboardEntry[] {
 		return leaderboard.entries.map((entry, index) => ({
 			userId: entry.user_id,
@@ -373,6 +441,9 @@ export class UserCommand extends Subcommand {
 					LEADERBOARD_SCORING.INCORRECT_PENALTY,
 			correctPredictions: entry.correct_predictions,
 			incorrectPredictions: entry.incorrect_predictions,
+			currentStreak: entry.current_streak,
+			bestStreak: entry.best_streak,
+			badgeTier: entry.badge_tier,
 		}))
 	}
 
@@ -389,7 +460,11 @@ export class UserCommand extends Subcommand {
 				const username = member?.username ?? entry.userId
 				const total =
 					entry.correctPredictions + entry.incorrectPredictions
-				return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
+				const streakBadge = formatStreakBadge(
+					entry.currentStreak,
+					entry.badgeTier,
+				)
+				return `${entry.position}. ${username}${streakBadge} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
 			}),
 		)
 
@@ -398,7 +473,7 @@ export class UserCommand extends Subcommand {
 			.setColor(embedColors.PlutoBlue)
 			.setDescription(description.join('\n'))
 			.setFooter({
-				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length}`,
+				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length} | 🔥3/5/10 = streak badge`,
 			})
 	}
 
@@ -478,4 +553,7 @@ interface ParsedLeaderboardEntry {
 	score: number
 	correctPredictions: number
 	incorrectPredictions: number
+	currentStreak: number
+	bestStreak: number
+	badgeTier: StreakBadgeTier
 }

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -40,9 +40,10 @@ const PREDICTIONS_COMMAND_ID_HINTS = ['1298280482123026537']
 
 /** Resolve display badge from the current streak when older API payloads omit it. */
 export function resolveStreakBadgeTier(
-	currentStreak: number,
+	currentStreak: number | null,
 	reportedTier: StreakBadgeTier = null,
 ): StreakBadgeTier {
+	if (currentStreak === null) return null
 	if (reportedTier !== null) return reportedTier
 	if (currentStreak >= 10) return 10
 	if (currentStreak >= 5) return 5
@@ -263,8 +264,8 @@ export class UserCommand extends Subcommand {
 			const correctPredictions = entry?.correct_predictions ?? 0
 			const incorrectPredictions = entry?.incorrect_predictions ?? 0
 			const winRate = entry?.success_rate ?? 0
-			const currentStreak = predictionStats?.current_streak ?? 0
-			const bestStreak = predictionStats?.best_streak ?? 0
+			const currentStreak = predictionStats?.current_streak ?? null
+			const bestStreak = predictionStats?.best_streak ?? null
 			const badgeTier = resolveStreakBadgeTier(
 				currentStreak,
 				predictionStats?.badge_tier ?? null,
@@ -304,20 +305,28 @@ export class UserCommand extends Subcommand {
 					},
 					{
 						name: '🔥 Current Streak',
-						value: `\`${currentStreak}\``,
+						value:
+							currentStreak === null
+								? '`Unavailable`'
+								: `\`${currentStreak}\``,
 						inline: true,
 					},
 					{
 						name: '🏆 Best Streak',
-						value: `\`${bestStreak}\``,
+						value:
+							bestStreak === null
+								? '`Unavailable`'
+								: `\`${bestStreak}\``,
 						inline: true,
 					},
 					{
 						name: '🏅 Streak Badge',
 						value:
-							badgeTier === null
-								? '`None yet`'
-								: `\`🔥${badgeTier}\``,
+							predictionStats === null
+								? '`Unavailable`'
+								: badgeTier === null
+									? '`None yet`'
+									: `\`🔥${badgeTier}\``,
 						inline: true,
 					},
 				)

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -240,7 +240,7 @@ export class UserCommand extends Subcommand {
 				})
 			} catch (error) {
 				// Keep stats usable while a mixed-version Khronos deployment rolls
-				// out, without presenting stale leaderboard streaks as personal stats.
+				// out without presenting stale leaderboard streaks as personal stats.
 				this.container.logger.warn(
 					'Prediction streak stats unavailable; using leaderboard fallback.',
 					error,

--- a/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.test.ts
+++ b/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const fetchApi = vi.fn()
+
+vi.mock('../KhronosInstances.js', () => ({
+	KH_API_CONFIG: {
+		basePath: 'https://khronos.test/',
+		headers: { 'x-api-key': 'test-key' },
+		fetchApi,
+	},
+}))
+
+const { default: LeaderboardWrapper, parseLeaderboardWithStreaks } =
+	await import('./leaderboard-wrapper.js')
+
+describe('parseLeaderboardWithStreaks', () => {
+	it('preserves streak fields from the raw snake-case wire response', () => {
+		expect(
+			parseLeaderboardWithStreaks({
+				entries: [
+					{
+						user_id: 'user-1',
+						total_predictions: 12,
+						correct_predictions: 9,
+						incorrect_predictions: 3,
+						success_rate: 75,
+						current_streak: 4,
+						best_streak: 7,
+						badge_tier: 5,
+					},
+				],
+				total_users: 1,
+			}),
+		).toEqual({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+					current_streak: 4,
+					best_streak: 7,
+					badge_tier: 5,
+				},
+			],
+			total_users: 1,
+		})
+	})
+
+	it('normalizes camel-case fields and missing streak fields', () => {
+		expect(
+			parseLeaderboardWithStreaks({
+				entries: [
+					{
+						userId: 'user-2',
+						totalPredictions: 0,
+						correctPredictions: 0,
+						incorrectPredictions: 0,
+						successRate: 0,
+					},
+				],
+				totalUsers: 1,
+			}),
+		).toMatchObject({
+			entries: [
+				{
+					user_id: 'user-2',
+					current_streak: 0,
+					best_streak: 0,
+					badge_tier: null,
+				},
+			],
+			total_users: 1,
+		})
+	})
+})
+
+describe('LeaderboardWrapper', () => {
+	it('uses the raw transport so generated DTOs cannot drop streak fields', async () => {
+		fetchApi.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				entries: [
+					{
+						user_id: 'user-1',
+						total_predictions: 10,
+						correct_predictions: 8,
+						incorrect_predictions: 2,
+						success_rate: 80,
+						current_streak: 3,
+						best_streak: 5,
+						badge_tier: 3,
+					},
+				],
+				total_users: 1,
+			}),
+		})
+
+		await expect(
+			new LeaderboardWrapper().getLeaderboard({ guildId: 'guild/1' }),
+		).resolves.toMatchObject({
+			entries: [{ current_streak: 3, best_streak: 5, badge_tier: 3 }],
+		})
+		expect(fetchApi).toHaveBeenCalledWith(
+			'https://khronos.test/api/khronos/v1/leaderboard?guild_id=guild%2F1',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'x-api-key': 'test-key',
+					Accept: 'application/json',
+				}),
+			}),
+		)
+	})
+
+	it('surfaces non-success responses instead of returning an empty leaderboard', async () => {
+		fetchApi.mockResolvedValueOnce({ ok: false, status: 503 })
+
+		await expect(
+			new LeaderboardWrapper().getLeaderboard({ guildId: 'guild-1' }),
+		).rejects.toThrow('Khronos leaderboard request failed (503)')
+	})
+})

--- a/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.ts
+++ b/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.ts
@@ -1,8 +1,4 @@
-import type { SimpleLeaderboardResponseDto } from '@pluto-khronos/api-client'
-import {
-	LeaderboardApi,
-	type LeaderboardControllerGetLeaderboardV1Request,
-} from '@pluto-khronos/api-client'
+import type { LeaderboardControllerGetLeaderboardV1Request } from '@pluto-khronos/api-client'
 import type { StreakBadgeTier } from '../../../predictions/streak-display.js'
 import { type IKH_API_CONFIG, KH_API_CONFIG } from '../KhronosInstances.js'
 
@@ -24,13 +20,131 @@ export interface LeaderboardResponseWithStreaks {
 	total_users: number
 }
 
-export default class LeaderboardWrapper {
-	private leaderboardsApi: LeaderboardApi
-	private readonly khConfig: IKH_API_CONFIG = KH_API_CONFIG
+const readField = (
+	value: Record<string, unknown>,
+	snakeCase: string,
+	camelCase: string,
+) =>
+	Object.prototype.hasOwnProperty.call(value, snakeCase)
+		? value[snakeCase]
+		: value[camelCase]
 
-	constructor() {
-		this.leaderboardsApi = new LeaderboardApi(this.khConfig)
+const readRequiredNumber = (
+	value: Record<string, unknown>,
+	snakeCase: string,
+	camelCase: string,
+) => {
+	const field = readField(value, snakeCase, camelCase)
+	if (typeof field !== 'number' || !Number.isFinite(field)) {
+		throw new Error(`Khronos returned an invalid leaderboard ${snakeCase}`)
 	}
+	return field
+}
+
+const readOptionalNumber = (
+	value: Record<string, unknown>,
+	snakeCase: string,
+	camelCase: string,
+) => {
+	const field = readField(value, snakeCase, camelCase)
+	if (field === undefined || field === null) return 0
+	if (typeof field !== 'number' || !Number.isFinite(field)) {
+		throw new Error(`Khronos returned an invalid leaderboard ${snakeCase}`)
+	}
+	return field
+}
+
+/**
+ * Normalize the wire response without going through the generated client DTO.
+ *
+ * The installed Khronos client predates streak fields and its generated
+ * deserializer drops unknown properties before this wrapper can see them.
+ */
+export function parseLeaderboardWithStreaks(
+	payload: unknown,
+): LeaderboardResponseWithStreaks {
+	if (!payload || typeof payload !== 'object') {
+		throw new Error('Khronos returned an invalid leaderboard payload')
+	}
+
+	const response = payload as Record<string, unknown>
+	if (!Array.isArray(response.entries)) {
+		throw new Error(
+			'Khronos returned an invalid leaderboard entries payload',
+		)
+	}
+	const totalUsers = readField(response, 'total_users', 'totalUsers')
+	if (typeof totalUsers !== 'number' || !Number.isFinite(totalUsers)) {
+		throw new Error('Khronos returned an invalid leaderboard total_users')
+	}
+
+	return {
+		total_users: totalUsers,
+		entries: response.entries.map((entry) => {
+			if (!entry || typeof entry !== 'object') {
+				throw new Error('Khronos returned an invalid leaderboard entry')
+			}
+			const value = entry as Record<string, unknown>
+			const userId = readField(value, 'user_id', 'userId')
+			if (typeof userId !== 'string') {
+				throw new Error(
+					'Khronos returned an invalid leaderboard user_id',
+				)
+			}
+			const badgeTier = readField(value, 'badge_tier', 'badgeTier')
+			if (
+				badgeTier !== undefined &&
+				badgeTier !== null &&
+				badgeTier !== 3 &&
+				badgeTier !== 5 &&
+				badgeTier !== 10
+			) {
+				throw new Error(
+					'Khronos returned an invalid leaderboard badge tier',
+				)
+			}
+
+			return {
+				...value,
+				user_id: userId,
+				total_predictions: readRequiredNumber(
+					value,
+					'total_predictions',
+					'totalPredictions',
+				),
+				correct_predictions: readRequiredNumber(
+					value,
+					'correct_predictions',
+					'correctPredictions',
+				),
+				incorrect_predictions: readRequiredNumber(
+					value,
+					'incorrect_predictions',
+					'incorrectPredictions',
+				),
+				success_rate: readRequiredNumber(
+					value,
+					'success_rate',
+					'successRate',
+				),
+				current_streak: readOptionalNumber(
+					value,
+					'current_streak',
+					'currentStreak',
+				),
+				best_streak: readOptionalNumber(
+					value,
+					'best_streak',
+					'bestStreak',
+				),
+				badge_tier: (badgeTier ?? null) as StreakBadgeTier,
+			}
+		}),
+	}
+}
+
+export default class LeaderboardWrapper {
+	private readonly khConfig: IKH_API_CONFIG = KH_API_CONFIG
 
 	/**
 	 * @summary Retrieve leaderboard data based upon provided data
@@ -40,38 +154,26 @@ export default class LeaderboardWrapper {
 	async getLeaderboard(
 		params: LeaderboardControllerGetLeaderboardV1Request,
 	): Promise<LeaderboardResponseWithStreaks> {
-		const response =
-			(await this.leaderboardsApi.leaderboardControllerGetLeaderboardV1(
-				params,
-			)) as SimpleLeaderboardResponseDto & {
-				entries: Array<
-					SimpleLeaderboardResponseDto['entries'][number] &
-						Partial<
-							Pick<
-								LeaderboardEntryWithStreaks,
-								'current_streak' | 'best_streak' | 'badge_tier'
-							>
-						>
-				>
-			}
-		const entries = response.entries as Array<
-			SimpleLeaderboardResponseDto['entries'][number] &
-				Partial<
-					Pick<
-						LeaderboardEntryWithStreaks,
-						'current_streak' | 'best_streak' | 'badge_tier'
-					>
-				>
-		>
+		const path = '/api/khronos/v1/leaderboard'
+		const query = new URLSearchParams({ guild_id: params.guildId })
+		const fetchApi = this.khConfig.fetchApi ?? fetch
+		const response = await fetchApi(
+			`${this.khConfig.basePath.replace(/\/$/, '')}${path}?${query.toString()}`,
+			{
+				method: 'GET',
+				headers: {
+					...this.khConfig.headers,
+					Accept: 'application/json',
+				},
+			},
+		)
 
-		return {
-			...response,
-			entries: entries.map((entry) => ({
-				...entry,
-				current_streak: entry.current_streak ?? 0,
-				best_streak: entry.best_streak ?? 0,
-				badge_tier: entry.badge_tier ?? null,
-			})),
+		if (!response.ok) {
+			throw new Error(
+				`Khronos leaderboard request failed (${response.status})`,
+			)
 		}
+
+		return parseLeaderboardWithStreaks(await response.json())
 	}
 }

--- a/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.ts
+++ b/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.ts
@@ -3,7 +3,26 @@ import {
 	LeaderboardApi,
 	type LeaderboardControllerGetLeaderboardV1Request,
 } from '@pluto-khronos/api-client'
+import type { StreakBadgeTier } from '../../../predictions/streak-display.js'
 import { type IKH_API_CONFIG, KH_API_CONFIG } from '../KhronosInstances.js'
+
+export type { StreakBadgeTier }
+
+export interface LeaderboardEntryWithStreaks {
+	user_id: string
+	total_predictions: number
+	correct_predictions: number
+	incorrect_predictions: number
+	success_rate: number
+	current_streak: number
+	best_streak: number
+	badge_tier: StreakBadgeTier
+}
+
+export interface LeaderboardResponseWithStreaks {
+	entries: LeaderboardEntryWithStreaks[]
+	total_users: number
+}
 
 export default class LeaderboardWrapper {
 	private leaderboardsApi: LeaderboardApi
@@ -20,9 +39,39 @@ export default class LeaderboardWrapper {
 	 */
 	async getLeaderboard(
 		params: LeaderboardControllerGetLeaderboardV1Request,
-	): Promise<SimpleLeaderboardResponseDto> {
-		return await this.leaderboardsApi.leaderboardControllerGetLeaderboardV1(
-			params,
-		)
+	): Promise<LeaderboardResponseWithStreaks> {
+		const response =
+			(await this.leaderboardsApi.leaderboardControllerGetLeaderboardV1(
+				params,
+			)) as SimpleLeaderboardResponseDto & {
+				entries: Array<
+					SimpleLeaderboardResponseDto['entries'][number] &
+						Partial<
+							Pick<
+								LeaderboardEntryWithStreaks,
+								'current_streak' | 'best_streak' | 'badge_tier'
+							>
+						>
+				>
+			}
+		const entries = response.entries as Array<
+			SimpleLeaderboardResponseDto['entries'][number] &
+				Partial<
+					Pick<
+						LeaderboardEntryWithStreaks,
+						'current_streak' | 'best_streak' | 'badge_tier'
+					>
+				>
+		>
+
+		return {
+			...response,
+			entries: entries.map((entry) => ({
+				...entry,
+				current_streak: entry.current_streak ?? 0,
+				best_streak: entry.best_streak ?? 0,
+				badge_tier: entry.badge_tier ?? null,
+			})),
+		}
 	}
 }

--- a/src/utils/api/Khronos/stats/stats-wrapper.test.ts
+++ b/src/utils/api/Khronos/stats/stats-wrapper.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it, vi } from 'vitest'
 
+const mocks = vi.hoisted(() => ({ fetchApi: vi.fn() }))
+
 vi.mock('../KhronosInstances.js', () => ({
-	KH_API_CONFIG: {},
+	KH_API_CONFIG: {
+		basePath: 'https://khronos.test/',
+		headers: { 'x-api-key': 'test-key' },
+		fetchApi: mocks.fetchApi,
+	},
 }))
 
-const { parsePredictionStats } = await import('./stats-wrapper.js')
+const { default: StatsWrapper, parsePredictionStats } = await import(
+	'./stats-wrapper.js'
+)
 
 describe('parsePredictionStats', () => {
 	it('accepts both generated camel-case and wire snake-case fields', () => {
@@ -42,5 +50,32 @@ describe('parsePredictionStats', () => {
 				badge_tier: null,
 			}),
 		).toMatchObject({ user_id: 'user-2', badge_tier: null })
+	})
+
+	it('normalizes a trailing-slash base URL for the raw stats transport', async () => {
+		mocks.fetchApi.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				user_id: 'user-1',
+				correct_predictions: 9,
+				incorrect_predictions: 3,
+				total_predictions: 12,
+				success_rate: 75,
+				current_streak: 4,
+				best_streak: 7,
+				badge_tier: 3,
+			}),
+		})
+
+		await new StatsWrapper().getPredictionStats({
+			userId: 'user-1',
+			guildId: 'guild-1',
+		})
+
+		expect(mocks.fetchApi).toHaveBeenCalledWith(
+			'https://khronos.test/api/khronos/v1/prediction/stats/user-1?guild_id=guild-1',
+			expect.anything(),
+		)
 	})
 })

--- a/src/utils/api/Khronos/stats/stats-wrapper.test.ts
+++ b/src/utils/api/Khronos/stats/stats-wrapper.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../KhronosInstances.js', () => ({
+	KH_API_CONFIG: {},
+}))
+
+const { parsePredictionStats } = await import('./stats-wrapper.js')
+
+describe('parsePredictionStats', () => {
+	it('accepts both generated camel-case and wire snake-case fields', () => {
+		expect(
+			parsePredictionStats({
+				userId: 'user-1',
+				correctPredictions: 9,
+				incorrectPredictions: 3,
+				totalPredictions: 12,
+				successRate: 75,
+				currentStreak: 4,
+				bestStreak: 7,
+				badgeTier: 3,
+			}),
+		).toEqual({
+			user_id: 'user-1',
+			correct_predictions: 9,
+			incorrect_predictions: 3,
+			total_predictions: 12,
+			success_rate: 75,
+			current_streak: 4,
+			best_streak: 7,
+			badge_tier: 3,
+		})
+
+		expect(
+			parsePredictionStats({
+				user_id: 'user-2',
+				correct_predictions: 0,
+				incorrect_predictions: 0,
+				total_predictions: 0,
+				success_rate: 0,
+				current_streak: 0,
+				best_streak: 0,
+				badge_tier: null,
+			}),
+		).toMatchObject({ user_id: 'user-2', badge_tier: null })
+	})
+})

--- a/src/utils/api/Khronos/stats/stats-wrapper.ts
+++ b/src/utils/api/Khronos/stats/stats-wrapper.ts
@@ -31,26 +31,33 @@ export function parsePredictionStats(payload: unknown): PredictionStats {
 	}
 
 	const value = payload as Record<string, unknown>
+	const readField = (snakeCase: string, camelCase: string) =>
+		Object.prototype.hasOwnProperty.call(value, snakeCase)
+			? value[snakeCase]
+			: value[camelCase]
+	const userId = readField('user_id', 'userId')
 	const numericFields = [
-		'correct_predictions',
-		'incorrect_predictions',
-		'total_predictions',
-		'success_rate',
-		'current_streak',
-		'best_streak',
+		['correct_predictions', 'correctPredictions'],
+		['incorrect_predictions', 'incorrectPredictions'],
+		['total_predictions', 'totalPredictions'],
+		['success_rate', 'successRate'],
+		['current_streak', 'currentStreak'],
+		['best_streak', 'bestStreak'],
 	] as const
 	if (
-		typeof value.user_id !== 'string' ||
-		numericFields.some(
-			(field) =>
-				typeof value[field] !== 'number' ||
-				!Number.isFinite(value[field]),
-		)
+		typeof userId !== 'string' ||
+		numericFields.some(([snakeCase, camelCase]) => {
+			const field = readField(snakeCase, camelCase)
+			return typeof field !== 'number' || !Number.isFinite(field)
+		})
 	) {
 		throw new Error('Khronos returned an invalid prediction stats payload')
 	}
 
-	const badgeTier = value.badge_tier as PredictionStats['badge_tier']
+	const badgeTier = readField(
+		'badge_tier',
+		'badgeTier',
+	) as PredictionStats['badge_tier']
 	if (
 		badgeTier !== null &&
 		badgeTier !== 3 &&
@@ -61,15 +68,24 @@ export function parsePredictionStats(payload: unknown): PredictionStats {
 			'Khronos returned an invalid prediction stats badge tier',
 		)
 	}
-	const correctPredictions = value.correct_predictions as number
-	const incorrectPredictions = value.incorrect_predictions as number
-	const totalPredictions = value.total_predictions as number
-	const successRate = value.success_rate as number
-	const currentStreak = value.current_streak as number
-	const bestStreak = value.best_streak as number
+	const correctPredictions = readField(
+		'correct_predictions',
+		'correctPredictions',
+	) as number
+	const incorrectPredictions = readField(
+		'incorrect_predictions',
+		'incorrectPredictions',
+	) as number
+	const totalPredictions = readField(
+		'total_predictions',
+		'totalPredictions',
+	) as number
+	const successRate = readField('success_rate', 'successRate') as number
+	const currentStreak = readField('current_streak', 'currentStreak') as number
+	const bestStreak = readField('best_streak', 'bestStreak') as number
 
 	return {
-		user_id: value.user_id,
+		user_id: userId,
 		correct_predictions: correctPredictions,
 		incorrect_predictions: incorrectPredictions,
 		total_predictions: totalPredictions,

--- a/src/utils/api/Khronos/stats/stats-wrapper.ts
+++ b/src/utils/api/Khronos/stats/stats-wrapper.ts
@@ -117,7 +117,7 @@ export default class StatsWrapper {
 		const query = new URLSearchParams({ guild_id: params.guildId })
 		const fetchApi = KH_API_CONFIG.fetchApi ?? fetch
 		const response = await fetchApi(
-			`${KH_API_CONFIG.basePath}${path}?${query.toString()}`,
+			`${KH_API_CONFIG.basePath.replace(/\/$/, '')}${path}?${query.toString()}`,
 			{
 				method: 'GET',
 				headers: {

--- a/src/utils/api/Khronos/stats/stats-wrapper.ts
+++ b/src/utils/api/Khronos/stats/stats-wrapper.ts
@@ -5,7 +5,82 @@ import {
 } from '@pluto-khronos/api-client'
 import { KH_API_CONFIG } from '../KhronosInstances.js'
 
-export default class StatsWraps {
+export interface PredictionStats {
+	user_id: string
+	correct_predictions: number
+	incorrect_predictions: number
+	total_predictions: number
+	success_rate: number
+	current_streak: number
+	best_streak: number
+	badge_tier: 3 | 5 | 10 | null
+}
+
+export interface PredictionStatsRequest {
+	userId: string
+	guildId: string
+}
+
+/**
+ * The generated client predates the F3 stats operation. Keep the temporary
+ * transport shim here until the next Khronos package release adds it.
+ */
+export function parsePredictionStats(payload: unknown): PredictionStats {
+	if (!payload || typeof payload !== 'object') {
+		throw new Error('Khronos returned an invalid prediction stats payload')
+	}
+
+	const value = payload as Record<string, unknown>
+	const numericFields = [
+		'correct_predictions',
+		'incorrect_predictions',
+		'total_predictions',
+		'success_rate',
+		'current_streak',
+		'best_streak',
+	] as const
+	if (
+		typeof value.user_id !== 'string' ||
+		numericFields.some(
+			(field) =>
+				typeof value[field] !== 'number' ||
+				!Number.isFinite(value[field]),
+		)
+	) {
+		throw new Error('Khronos returned an invalid prediction stats payload')
+	}
+
+	const badgeTier = value.badge_tier as PredictionStats['badge_tier']
+	if (
+		badgeTier !== null &&
+		badgeTier !== 3 &&
+		badgeTier !== 5 &&
+		badgeTier !== 10
+	) {
+		throw new Error(
+			'Khronos returned an invalid prediction stats badge tier',
+		)
+	}
+	const correctPredictions = value.correct_predictions as number
+	const incorrectPredictions = value.incorrect_predictions as number
+	const totalPredictions = value.total_predictions as number
+	const successRate = value.success_rate as number
+	const currentStreak = value.current_streak as number
+	const bestStreak = value.best_streak as number
+
+	return {
+		user_id: value.user_id,
+		correct_predictions: correctPredictions,
+		incorrect_predictions: incorrectPredictions,
+		total_predictions: totalPredictions,
+		success_rate: successRate,
+		current_streak: currentStreak,
+		best_streak: bestStreak,
+		badge_tier: badgeTier,
+	}
+}
+
+export default class StatsWrapper {
 	private readonly statsApi: StatsApi
 
 	constructor() {
@@ -17,5 +92,31 @@ export default class StatsWraps {
 	): Promise<OverallStatsDto> {
 		const response = await this.statsApi.getOverallH2hBettingStats(params)
 		return response
+	}
+
+	async getPredictionStats(
+		params: PredictionStatsRequest,
+	): Promise<PredictionStats> {
+		const path = `/api/khronos/v1/prediction/stats/${encodeURIComponent(params.userId)}`
+		const query = new URLSearchParams({ guild_id: params.guildId })
+		const fetchApi = KH_API_CONFIG.fetchApi ?? fetch
+		const response = await fetchApi(
+			`${KH_API_CONFIG.basePath}${path}?${query.toString()}`,
+			{
+				method: 'GET',
+				headers: {
+					...KH_API_CONFIG.headers,
+					Accept: 'application/json',
+				},
+			},
+		)
+
+		if (!response.ok) {
+			throw new Error(
+				`Khronos prediction stats request failed (${response.status})`,
+			)
+		}
+
+		return parsePredictionStats(await response.json())
 	}
 }

--- a/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
@@ -44,7 +44,7 @@ describe('notification payload validators', () => {
 		expect(logger.error).not.toHaveBeenCalled()
 	})
 
-	it('rejects a winner without a bet id and logs the schema issues', () => {
+	it('accepts a winner without a bet id from the current shared contract', () => {
 		const result = validateNotifyBetUsers({
 			winners: [
 				{
@@ -55,13 +55,10 @@ describe('notification payload validators', () => {
 			losers: [],
 		})
 
-		expect(result).toBeNull()
-		expect(logger.error).toHaveBeenCalledWith(
-			expect.objectContaining({
-				event: 'push_payload_rejected',
-				schema: 'notificationBetResults',
-			}),
-		)
+		expect(result?.winners).toHaveLength(1)
+		expect(result?.winners[0].betId).toBeUndefined()
+		expect(result?.winners[0].result.outcome).toBe('won')
+		expect(logger.error).not.toHaveBeenCalled()
 	})
 
 	it('normalizes legacy flat push entries from the published package', () => {

--- a/src/utils/predictions/streak-display.ts
+++ b/src/utils/predictions/streak-display.ts
@@ -1,0 +1,13 @@
+export type StreakBadgeTier = 3 | 5 | 10 | null
+
+/** Format a compact, text-accessible badge marker for leaderboard rows. */
+export function formatBadge(tier: StreakBadgeTier): string {
+	return tier === null ? '' : ` 🔥${tier}`
+}
+
+/** Format the personal streak summary used by prediction stats embeds. */
+export function formatStreakLine(current: number, best: number): string {
+	const currentCopy =
+		current > 0 ? `**${current}**` : '**0** (No active streak)'
+	return `Current Streak: ${currentCopy} · Best: **${best}**`
+}

--- a/src/utils/predictions/streak-display.ts
+++ b/src/utils/predictions/streak-display.ts
@@ -6,7 +6,14 @@ export function formatBadge(tier: StreakBadgeTier): string {
 }
 
 /** Format the personal streak summary used by prediction stats embeds. */
-export function formatStreakLine(current: number, best: number): string {
+export function formatStreakLine(
+	current: number | null,
+	best: number | null,
+): string {
+	if (current === null || best === null) {
+		return 'Current Streak: **Unavailable** · Best: **Unavailable**'
+	}
+
 	const currentCopy =
 		current > 0 ? `**${current}**` : '**0** (No active streak)'
 	return `Current Streak: ${currentCopy} · Best: **${best}**`


### PR DESCRIPTION
## Summary
- add typed Khronos prediction-stats compatibility transport for TF-958 fields
- accept both snake_case wire and camelCase generated-model responses
- render current/best streak and badge tier in consolidated `/predictions stats`
- render explicit `Unavailable` state on personal-stats failure (never a misleading zero)
- add 🔥3/5/10 markers to paginated `/predictions leaderboard` rows
- update footer copy with neutral void/push semantics and add focused formatter/command/parser coverage
- correct one stale integration fixture to match the current shared notification contract (winner callbacks may omit betId)

## Verification
- `pnpm typecheck` ✅
- `pnpm test:run` ✅ (26 files, 140 tests)
- focused prediction/stats tests ✅ (13/13)
- `pnpm build` ✅
- changed-file Biome checks ✅
- `git diff --check` ✅

Fresh branch starts at `origin/dev/parlays-props` `dfdb0851` after TF-972/TF-973/TF-974 merge wave. No `main` or production changes.