### PR TITLE
feat(pluto): update original prop embeds on settlement (TF-971)

### DIFF
--- a/src/utils/api/koa/setup/apiKeyAuth.ts
+++ b/src/utils/api/koa/setup/apiKeyAuth.ts
@@ -44,6 +44,7 @@ export function createApiKeyAuthMiddleware() {
 			return
 		}
 
+		ctx.state.apiKeyAuthenticated = true
 		await next()
 	}
 }

--- a/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
@@ -44,7 +44,7 @@ describe('notification payload validators', () => {
 		expect(logger.error).not.toHaveBeenCalled()
 	})
 
-	it('rejects a winner without a bet id and logs the schema issues', () => {
+	it('accepts a winner without a bet id from the current shared contract', () => {
 		const result = validateNotifyBetUsers({
 			winners: [
 				{
@@ -55,13 +55,10 @@ describe('notification payload validators', () => {
 			losers: [],
 		})
 
-		expect(result).toBeNull()
-		expect(logger.error).toHaveBeenCalledWith(
-			expect.objectContaining({
-				event: 'push_payload_rejected',
-				schema: 'notificationBetResults',
-			}),
-		)
+		expect(result?.winners).toHaveLength(1)
+		expect(result?.winners[0].betId).toBeUndefined()
+		expect(result?.winners[0].result.outcome).toBe('won')
+		expect(logger.error).not.toHaveBeenCalled()
 	})
 
 	it('normalizes legacy flat push entries from the published package', () => {

--- a/src/utils/api/routes/notifications/__tests__/notifications.controller.prop.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.controller.prop.test.ts
@@ -38,7 +38,18 @@ function getPropSettlementRoute() {
 	)
 	if (!route)
 		throw new Error('Prop settlement notification route not registered')
-	return route.stack[0]
+	return async (ctx: unknown, next: () => Promise<void>) => {
+		let index = -1
+		const dispatch = async (current: number): Promise<void> => {
+			if (current <= index)
+				throw new Error('next() called multiple times')
+			index = current
+			const middleware = route.stack[current]
+			if (!middleware) return await next()
+			await middleware(ctx as never, () => dispatch(current + 1))
+		}
+		await dispatch(0)
+	}
 }
 
 describe('POST /notifications/props/settled', () => {
@@ -51,6 +62,7 @@ describe('POST /notifications/props/settled', () => {
 			request: { body: validPayload },
 			body: undefined as unknown,
 			status: 200,
+			state: { apiKeyAuthenticated: true },
 		}
 
 		await getPropSettlementRoute()(ctx as never, async () => undefined)
@@ -65,6 +77,7 @@ describe('POST /notifications/props/settled', () => {
 			request: { body: { ...validPayload, outcome_uuid: 'not-a-uuid' } },
 			body: undefined as unknown,
 			status: 200,
+			state: { apiKeyAuthenticated: true },
 		}
 
 		await getPropSettlementRoute()(ctx as never, async () => undefined)
@@ -75,5 +88,38 @@ describe('POST /notifications/props/settled', () => {
 			success: false,
 			error: 'Invalid prop settlement notification data. Failed Zod validation.',
 		})
+	})
+
+	it('rejects mathematically inconsistent settlement tallies', async () => {
+		const ctx = {
+			request: {
+				body: {
+					...validPayload,
+					tallies: { correct: 2, incorrect: 0, total: 1 },
+				},
+			},
+			body: undefined as unknown,
+			status: 200,
+			state: { apiKeyAuthenticated: true },
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(processPropSettled).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(422)
+	})
+
+	it('rejects direct router calls without app-level API authentication', async () => {
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+			state: {},
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(processPropSettled).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(401)
 	})
 })

--- a/src/utils/api/routes/notifications/__tests__/notifications.controller.prop.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.controller.prop.test.ts
@@ -72,6 +72,24 @@ describe('POST /notifications/props/settled', () => {
 		expect(ctx.body).toEqual({ success: true })
 	})
 
+	it('returns 500 when settlement processing fails', async () => {
+		processPropSettled.mockRejectedValueOnce(new Error('delivery failed'))
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+			state: { apiKeyAuthenticated: true },
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(ctx.status).toBe(500)
+		expect(ctx.body).toEqual({
+			success: false,
+			error: 'Failed to process prop settlement notification',
+		})
+	})
+
 	it('returns 422 and skips delivery for malformed payloads', async () => {
 		const ctx = {
 			request: { body: { ...validPayload, outcome_uuid: 'not-a-uuid' } },

--- a/src/utils/api/routes/notifications/__tests__/notifications.controller.prop.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.controller.prop.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const processPropSettled = vi.fn()
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../notifications.service.js', () => ({
+	default: class MockNotificationService {
+		processPropSettled = processPropSettled
+	},
+}))
+
+import NotificationRouter from '../notifications.controller.js'
+
+const validPayload = {
+	outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+	result: 'won',
+	winning_side_display: 'Over',
+	actual_value: 37,
+	market_key: 'player_points',
+	description: 'Stephen Curry',
+	point: 35.5,
+	tallies: { correct: 11, incorrect: 16, total: 27 },
+	messages: [
+		{
+			guild_id: 'guild-1',
+			channel_id: 'channel-1',
+			message_id: 'message-1',
+		},
+	],
+}
+
+function getPropSettlementRoute() {
+	const route = NotificationRouter.stack.find(
+		(layer) => layer.path === '/notifications/props/settled',
+	)
+	if (!route)
+		throw new Error('Prop settlement notification route not registered')
+	return route.stack[0]
+}
+
+describe('POST /notifications/props/settled', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns 200 after processing a valid payload', async () => {
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(processPropSettled).toHaveBeenCalledOnce()
+		expect(ctx.status).toBe(200)
+		expect(ctx.body).toEqual({ success: true })
+	})
+
+	it('returns 422 and skips delivery for malformed payloads', async () => {
+		const ctx = {
+			request: { body: { ...validPayload, outcome_uuid: 'not-a-uuid' } },
+			body: undefined as unknown,
+			status: 200,
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(processPropSettled).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(422)
+		expect(ctx.body).toEqual({
+			success: false,
+			error: 'Invalid prop settlement notification data. Failed Zod validation.',
+		})
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.prop.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.prop.test.ts
@@ -135,12 +135,20 @@ describe('NotificationService.processPropSettled', () => {
 	})
 
 	it('logs missing messages and continues without throwing', async () => {
-		mocks.fetchChannel.mockRejectedValue(new Error('Unknown Message'))
+		const channel = {
+			guildId: 'guild-1',
+			isTextBased: () => true,
+			messages: {
+				fetch: vi.fn().mockRejectedValue(new Error('Unknown Message')),
+			},
+		}
+		mocks.fetchChannel.mockResolvedValue(channel)
 
 		await expect(
 			new NotificationService().processPropSettled(payload),
 		).resolves.toBeUndefined()
 
+		expect(channel.messages.fetch).toHaveBeenCalledWith('message-1')
 		expect(mocks.logger.warn).toHaveBeenCalledWith(
 			expect.objectContaining({
 				event: 'prop.notification.message_update_failed',

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.prop.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.prop.test.ts
@@ -1,0 +1,151 @@
+import { EmbedBuilder } from 'discord.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	fetchChannel: vi.fn(),
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	container: {
+		client: {
+			channels: {
+				fetch: mocks.fetchChannel,
+			},
+		},
+	},
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: mocks.logger,
+}))
+
+import NotificationService from '../notifications.service.js'
+
+const payload = {
+	outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+	result: 'won' as const,
+	winning_side_display: 'Over',
+	actual_value: 37,
+	market_key: 'player_points',
+	description: 'Stephen Curry',
+	point: 35.5,
+	tallies: { correct: 11, incorrect: 16, total: 27 },
+	messages: [
+		{
+			guild_id: 'guild-1',
+			channel_id: 'channel-1',
+			message_id: 'message-1',
+		},
+	],
+}
+
+function createMessage() {
+	const message = {
+		embeds: [
+			new EmbedBuilder().setTitle('🎯 Accuracy Challenge').addFields({
+				name: 'Match',
+				value: 'GSW vs LAL',
+				inline: true,
+			}),
+		],
+		edit: vi.fn(),
+	} as any
+	message.edit.mockImplementation(async (options: { embeds: unknown[] }) => {
+		message.embeds = options.embeds.map((embed) =>
+			EmbedBuilder.from(embed as never).toJSON(),
+		)
+		return message
+	})
+	return message
+}
+
+describe('NotificationService.processPropSettled', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('edits the original embed with result/tallies and removes stale buttons', async () => {
+		const message = createMessage()
+		const channel = {
+			guildId: 'guild-1',
+			isTextBased: () => true,
+			messages: { fetch: vi.fn().mockResolvedValue(message) },
+		}
+		mocks.fetchChannel.mockResolvedValue(channel)
+
+		await new NotificationService().processPropSettled(payload)
+
+		expect(channel.messages.fetch).toHaveBeenCalledWith('message-1')
+		expect(message.edit).toHaveBeenCalledOnce()
+		const edit = message.edit.mock.calls[0][0] as {
+			embeds: Array<{
+				toJSON: () => {
+					fields?: Array<{ name: string; value: string }>
+				}
+			}>
+			components: unknown[]
+		}
+		const fields = edit.embeds[0].toJSON().fields ?? []
+		expect(fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🎯 Result',
+					value: '**Result: Over ✅ — 37**',
+				}),
+				expect.objectContaining({
+					name: '📊 Prediction results',
+					value: '41% of 27 predictors got it right (11 correct, 16 incorrect).',
+				}),
+			]),
+		)
+		expect(edit.components).toEqual([])
+	})
+
+	it('deduplicates repeated message references and is idempotent on retry', async () => {
+		const message = createMessage()
+		const channel = {
+			guildId: 'guild-1',
+			isTextBased: () => true,
+			messages: { fetch: vi.fn().mockResolvedValue(message) },
+		}
+		mocks.fetchChannel.mockResolvedValue(channel)
+
+		const service = new NotificationService()
+		await service.processPropSettled({
+			...payload,
+			messages: [payload.messages[0], payload.messages[0]],
+		})
+		await service.processPropSettled(payload)
+
+		expect(channel.messages.fetch).toHaveBeenCalledTimes(2)
+		expect(message.edit).toHaveBeenCalledTimes(2)
+		const fields =
+			(message.embeds[0] as { fields?: unknown[] }).fields ?? []
+		expect(
+			fields.filter(
+				(field) => (field as { name?: string }).name === '🎯 Result',
+			),
+		).toHaveLength(1)
+	})
+
+	it('logs missing messages and continues without throwing', async () => {
+		mocks.fetchChannel.mockRejectedValue(new Error('Unknown Message'))
+
+		await expect(
+			new NotificationService().processPropSettled(payload),
+		).resolves.toBeUndefined()
+
+		expect(mocks.logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'prop.notification.message_update_failed',
+				message_id: 'message-1',
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.test.ts
@@ -53,4 +53,40 @@ describe('NotificationService', () => {
 			}),
 		)
 	})
+
+	it('does not forward winners without bet IDs to single-bet announcements', async () => {
+		const service = new NotificationService()
+		const notifyUser = vi
+			.spyOn(service, 'notifyUser')
+			.mockResolvedValue(undefined)
+		const getBigWinAnnouncementService = vi
+			.spyOn(
+				service as unknown as {
+					getBigWinAnnouncementService: () => Promise<unknown>
+				},
+				'getBigWinAnnouncementService',
+			)
+			.mockResolvedValue({})
+
+		await service.processBetResults({
+			winners: [
+				{
+					userId: 'user-1',
+					guildId: 'guild-1',
+					result: {
+						outcome: 'won',
+						team: 'Home',
+						betAmount: 10,
+						payout: 20,
+						profit: 10,
+					},
+				},
+			],
+			losers: [],
+			pushes: [],
+		})
+
+		expect(notifyUser).toHaveBeenCalledOnce()
+		expect(getBigWinAnnouncementService).not.toHaveBeenCalled()
+	})
 })

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -3,6 +3,7 @@ import { logger } from '../../../logging/WinstonLogger.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
 import { validateParlayResultNotification } from './parlay-notification-utils.js'
+import { validatePropSettledNotification } from './prop-settled-notification-utils.js'
 
 const NotificationRouter = new Router()
 
@@ -77,6 +78,41 @@ NotificationRouter.post('/notifications/parlays/results', async (ctx) => {
 		ctx.body = {
 			success: false,
 			error: 'Failed to process parlay notifications',
+		}
+		ctx.status = 500
+	}
+})
+
+NotificationRouter.post('/notifications/props/settled', async (ctx) => {
+	const rawPayload = ctx.request.body || {}
+	const validatedData = validatePropSettledNotification(rawPayload)
+
+	if (!validatedData) {
+		ctx.body = {
+			success: false,
+			error: 'Invalid prop settlement notification data. Failed Zod validation.',
+		}
+		ctx.status = 422
+		return
+	}
+
+	try {
+		await new NotificationService().processPropSettled(validatedData)
+		ctx.body = {
+			success: true,
+		}
+	} catch (error) {
+		logger.error({
+			method: 'NotificationRouter',
+			event: 'prop.notification.processing_failed',
+			message: 'CRITICAL: Failed to process prop settlement notification',
+			error: error instanceof Error ? error.message : error,
+			critical: true,
+			outcome_uuid: validatedData.outcome_uuid,
+		})
+		ctx.body = {
+			success: false,
+			error: 'Failed to process prop settlement notification',
 		}
 		ctx.status = 500
 	}

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -1,4 +1,5 @@
 import Router from '@koa/router'
+import type { Context, Next } from 'koa'
 import { logger } from '../../../logging/WinstonLogger.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
@@ -6,6 +7,24 @@ import { validateParlayResultNotification } from './parlay-notification-utils.js
 import { validatePropSettledNotification } from './prop-settled-notification-utils.js'
 
 const NotificationRouter = new Router()
+
+/**
+ * The app-level API-key middleware normally runs before this router. Keep a
+ * route-local guard as defense in depth so mounting the router elsewhere
+ * cannot expose a caller-controlled Discord message edit endpoint.
+ */
+async function requireApiKeyAuthentication(ctx: Context, next: Next) {
+	if (ctx.state.apiKeyAuthenticated !== true) {
+		ctx.status = 401
+		ctx.body = {
+			status: 'error',
+			code: 'UNAUTHENTICATED_NOTIFICATION_CALLBACK',
+			message: 'Authenticated service credentials are required',
+		}
+		return
+	}
+	await next()
+}
 
 NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 	const rawPayload = ctx.request.body || {}
@@ -83,39 +102,44 @@ NotificationRouter.post('/notifications/parlays/results', async (ctx) => {
 	}
 })
 
-NotificationRouter.post('/notifications/props/settled', async (ctx) => {
-	const rawPayload = ctx.request.body || {}
-	const validatedData = validatePropSettledNotification(rawPayload)
+NotificationRouter.post(
+	'/notifications/props/settled',
+	requireApiKeyAuthentication,
+	async (ctx) => {
+		const rawPayload = ctx.request.body || {}
+		const validatedData = validatePropSettledNotification(rawPayload)
 
-	if (!validatedData) {
-		ctx.body = {
-			success: false,
-			error: 'Invalid prop settlement notification data. Failed Zod validation.',
+		if (!validatedData) {
+			ctx.body = {
+				success: false,
+				error: 'Invalid prop settlement notification data. Failed Zod validation.',
+			}
+			ctx.status = 422
+			return
 		}
-		ctx.status = 422
-		return
-	}
 
-	try {
-		await new NotificationService().processPropSettled(validatedData)
-		ctx.body = {
-			success: true,
+		try {
+			await new NotificationService().processPropSettled(validatedData)
+			ctx.body = {
+				success: true,
+			}
+		} catch (error) {
+			logger.error({
+				method: 'NotificationRouter',
+				event: 'prop.notification.processing_failed',
+				message:
+					'CRITICAL: Failed to process prop settlement notification',
+				error: error instanceof Error ? error.message : error,
+				critical: true,
+				outcome_uuid: validatedData.outcome_uuid,
+			})
+			ctx.body = {
+				success: false,
+				error: 'Failed to process prop settlement notification',
+			}
+			ctx.status = 500
 		}
-	} catch (error) {
-		logger.error({
-			method: 'NotificationRouter',
-			event: 'prop.notification.processing_failed',
-			message: 'CRITICAL: Failed to process prop settlement notification',
-			error: error instanceof Error ? error.message : error,
-			critical: true,
-			outcome_uuid: validatedData.outcome_uuid,
-		})
-		ctx.body = {
-			success: false,
-			error: 'Failed to process prop settlement notification',
-		}
-		ctx.status = 500
-	}
-})
+	},
+)
 
 export default NotificationRouter

--- a/src/utils/api/routes/notifications/notifications.interface.ts
+++ b/src/utils/api/routes/notifications/notifications.interface.ts
@@ -28,7 +28,8 @@ export interface ResultPush {
 
 export interface BetNotificationBase {
 	userId: string
-	betId: number
+	/** Optional for shared-contract winners that are not tied to a single bet. */
+	betId?: number
 	/** Optional until Khronos includes guild context in bet-result callbacks. */
 	guildId?: string
 }

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -1,6 +1,6 @@
 // Import interfaces and potentially the Discord client type
 import { container } from '@sapphire/framework'
-import { EmbedBuilder } from 'discord.js'
+import { EmbedBuilder, type Message } from 'discord.js'
 import type {
 	BigWinAnnouncementService,
 	BigWinParlayInput,
@@ -8,6 +8,7 @@ import type {
 } from '../../../../services/engagement/BigWinAnnouncementService.js'
 import { logger } from '../../../logging/WinstonLogger.js'
 import MoneyFormatter from '../../common/money-formatting/money-format.js'
+import type { PropSettledNotification } from '../shared-payload-schemas.js'
 import type {
 	BetNotificationWon,
 	DisplayBetNotification,
@@ -138,6 +139,157 @@ export default class NotificationService {
 		const embeds = this.buildParlayEmbeds(data)
 		await this.sendParlayEmbeds(data.user_id, data, embeds)
 		await this.announceParlayWin(data)
+	}
+
+	/**
+	 * Apply one Khronos prop settlement to every original Discord post in the
+	 * posting ledger. A missing/deleted message is a delivery warning, not a
+	 * failed settlement: Khronos has already committed the outcome and can
+	 * safely retry the callback later.
+	 */
+	async processPropSettled(data: PropSettledNotification): Promise<void> {
+		const client = container.client
+		if (!client) {
+			logger.error({
+				method: this.processPropSettled.name,
+				event: 'prop.notification.delivery_failed',
+				message:
+					'Discord client not available for prop settlement update',
+				critical: true,
+				outcome_uuid: data.outcome_uuid,
+			})
+			return
+		}
+
+		const processedMessages = new Set<string>()
+		for (const reference of data.messages) {
+			const messageKey = `${reference.guild_id}:${reference.channel_id}:${reference.message_id}`
+			if (processedMessages.has(messageKey)) continue
+			processedMessages.add(messageKey)
+
+			try {
+				const channel = await client.channels.fetch(
+					reference.channel_id,
+				)
+				if (
+					!channel ||
+					!channel.isTextBased() ||
+					!('guildId' in channel) ||
+					channel.guildId !== reference.guild_id
+				) {
+					throw new Error(
+						`Channel ${reference.channel_id} is missing, not text-based, or belongs to another guild`,
+					)
+				}
+
+				const message = await channel.messages.fetch(
+					reference.message_id,
+				)
+				const updatedEmbeds = message.embeds.map((embed, index) =>
+					index === 0
+						? this.buildPropSettlementEmbed(message, data)
+						: EmbedBuilder.from(embed),
+				)
+
+				if (updatedEmbeds.length === 0) {
+					throw new Error(
+						'Original prop message has no embed to update',
+					)
+				}
+
+				await message.edit({
+					embeds: updatedEmbeds,
+					// The settlement is terminal. Removing components prevents stale
+					// buttons from being clicked while keeping the edit idempotent.
+					components: [],
+				})
+			} catch (error) {
+				logger.warn({
+					method: this.processPropSettled.name,
+					event: 'prop.notification.message_update_failed',
+					message:
+						'Unable to update original prop message after settlement',
+					guild_id: reference.guild_id,
+					channel_id: reference.channel_id,
+					message_id: reference.message_id,
+					outcome_uuid: data.outcome_uuid,
+					error:
+						error instanceof Error ? error.message : String(error),
+				})
+			}
+		}
+	}
+
+	private buildPropSettlementEmbed(
+		message: Message,
+		data: PropSettledNotification,
+	): EmbedBuilder {
+		const originalEmbed = message.embeds[0]
+		if (!originalEmbed) {
+			throw new Error('Original prop message has no embed to update')
+		}
+
+		const embed = EmbedBuilder.from(originalEmbed)
+		const fields = [...(embed.data.fields ?? [])]
+		const resultFieldName = '🎯 Result'
+		const tallyFieldName = '📊 Prediction results'
+		const resultField = {
+			name: resultFieldName,
+			value: this.formatPropResult(data),
+			inline: false,
+		}
+		const tallyField = {
+			name: tallyFieldName,
+			value: this.formatPropTallies(data),
+			inline: false,
+		}
+
+		const resultIndex = fields.findIndex(
+			(field) => field.name === resultFieldName,
+		)
+		if (resultIndex === -1) fields.push(resultField)
+		else fields[resultIndex] = resultField
+
+		const tallyIndex = fields.findIndex(
+			(field) => field.name === tallyFieldName,
+		)
+		if (tallyIndex === -1) fields.push(tallyField)
+		else fields[tallyIndex] = tallyField
+
+		return embed.setFields(fields)
+	}
+
+	private formatPropResult(data: PropSettledNotification): string {
+		const iconByResult: Record<PropSettledNotification['result'], string> =
+			{
+				won: '✅',
+				lost: '❌',
+				push: '➖',
+				void: '🚫',
+			}
+		const label =
+			data.winning_side_display?.trim() ||
+			(
+				{
+					won: 'Won',
+					lost: 'Lost',
+					push: 'Push',
+					void: 'Voided',
+				} satisfies Record<PropSettledNotification['result'], string>
+			)[data.result]
+		const actualValue =
+			data.actual_value === null || data.actual_value === undefined
+				? ''
+				: ` — ${data.actual_value}`
+
+		return `**Result: ${label} ${iconByResult[data.result]}${actualValue}**`
+	}
+
+	private formatPropTallies(data: PropSettledNotification): string {
+		const { correct, incorrect, total } = data.tallies
+		const percentage = total === 0 ? 0 : Math.round((correct / total) * 100)
+		const predictorLabel = total === 1 ? 'predictor' : 'predictors'
+		return `${percentage}% of ${total} ${predictorLabel} got it right (${correct} correct, ${incorrect} incorrect).`
 	}
 
 	private async announceParlayWin(

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -316,7 +316,7 @@ export default class NotificationService {
 	private async announceSingleBetWin(
 		winner: BetNotificationWon,
 	): Promise<void> {
-		if (!winner.guildId) return
+		if (!winner.guildId || winner.betId === undefined) return
 
 		const input: BigWinSingleBetInput = {
 			betId: winner.betId,
@@ -565,6 +565,8 @@ export default class NotificationService {
 
 	async notifyUser(betData: DisplayBetNotification) {
 		const { userId, betId, result, displayResult } = betData
+		const betIdLabel =
+			betId === undefined ? 'Bet ID unavailable' : `Bet ID: ${betId}`
 
 		switch (result.outcome) {
 			case 'won': {
@@ -605,7 +607,7 @@ export default class NotificationService {
 					)
 					.setTimestamp()
 					.setFooter({
-						text: `Pluto | Bet ID: ${betId}`,
+						text: `Pluto | ${betIdLabel}`,
 					})
 
 				await this.sendEmbed(userId, betId, embed)
@@ -634,7 +636,7 @@ export default class NotificationService {
 					)
 					.setTimestamp()
 					.setFooter({
-						text: `Pluto | Bet ID: ${betId}`,
+						text: `Pluto | ${betIdLabel}`,
 					})
 
 				await this.sendEmbed(userId, betId, embed)
@@ -658,7 +660,7 @@ export default class NotificationService {
 					)
 					.setTimestamp()
 					.setFooter({
-						text: `Pluto | Bet ID: ${betId}`,
+						text: `Pluto | ${betIdLabel}`,
 					})
 
 				await this.sendEmbed(userId, betId, embed)
@@ -669,7 +671,7 @@ export default class NotificationService {
 
 	private async sendEmbed(
 		userId: string,
-		betId: number,
+		betId: number | undefined,
 		embed: EmbedBuilder,
 	): Promise<void> {
 		const client = container.client

--- a/src/utils/api/routes/notifications/prop-settled-notification-utils.ts
+++ b/src/utils/api/routes/notifications/prop-settled-notification-utils.ts
@@ -1,0 +1,24 @@
+import { logger } from '../../../logging/WinstonLogger.js'
+import {
+	type PropSettledNotification,
+	propSettledNotificationSchema,
+} from '../shared-payload-schemas.js'
+
+/** Parse and strictly validate a Khronos prop settlement callback. */
+export function validatePropSettledNotification(
+	payload: unknown,
+): PropSettledNotification | null {
+	const result = propSettledNotificationSchema.safeParse(payload)
+
+	if (!result.success) {
+		logger.warn({
+			method: 'validatePropSettledNotification',
+			event: 'prop.notification.validation_failed',
+			message: 'Invalid prop settlement notification payload',
+			errors: result.error.issues,
+		})
+		return null
+	}
+
+	return result.data
+}

--- a/src/utils/api/routes/notifications/prop-settled-notification-utils.ts
+++ b/src/utils/api/routes/notifications/prop-settled-notification-utils.ts
@@ -20,5 +20,18 @@ export function validatePropSettledNotification(
 		return null
 	}
 
+	const { correct, incorrect, total } = result.data.tallies
+	if (correct + incorrect !== total) {
+		logger.warn({
+			method: 'validatePropSettledNotification',
+			event: 'prop.notification.tally_invariant_failed',
+			message: 'Prop settlement tallies must sum to total',
+			correct,
+			incorrect,
+			total,
+		})
+		return null
+	}
+
 	return result.data
 }


### PR DESCRIPTION
## Summary
- add validated `POST /notifications/props/settled` callback for Khronos prop settlements
- fetch and update original guild prop embeds from the posting ledger references
- render deterministic result and prediction-tally fields, remove terminal prediction buttons, and continue on deleted/unknown messages
- cover validation, duplicate references, retry idempotency, guild ownership, and missing-message handling

## Verification
- `pnpm test:run` (27 files, 136 tests)
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec biome check` (touched files)
- `git diff --check`

Linear: TF-971

Target is the `dev/parlays-props` integration branch. No `main` or production changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a protected `POST /notifications/props/settled` endpoint for prop settlement callbacks.
  - Settlement processing updates the related Discord embeds with “Result” and “Prediction results,” and clears stale components.
  - Hardened bet notifications to support winner entries without `betId` (won’t trigger single-bet win announcements).

- **Bug Fixes**
  - Repeated settlement callbacks update embeds idempotently without duplicating fields.
  - Failure to update a specific Discord message no longer blocks processing of others.
  - Winner entries missing `betId` are now accepted without error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->