### PR TITLE
fix(pluto): harden parlay builder review follow-ups

### DIFF
--- a/src/commands/betting/parlay.ts
+++ b/src/commands/betting/parlay.ts
@@ -29,7 +29,10 @@ export class UserCommand extends Command {
 		await interaction.deferReply({ flags: MessageFlags.Ephemeral })
 		try {
 			const service = this.getService()
-			const session = await service.start(interaction.user.id)
+			const session = await service.start(
+				interaction.user.id,
+				interaction.guildId!,
+			)
 			return interaction.editReply(service.render(session))
 		} catch (error) {
 			this.container.logger.error({

--- a/src/interaction-handlers/__tests__/parlay-modal-handler.test.ts
+++ b/src/interaction-handlers/__tests__/parlay-modal-handler.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { builderService } = vi.hoisted(() => ({
+	builderService: {
+		render: vi.fn(),
+		renderMessage: vi.fn(),
+		setStake: vi.fn(),
+		addLeg: vi.fn(),
+	},
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	InteractionHandler: class {
+		public none() {
+			return { kind: 'none' }
+		}
+		public some(value: unknown) {
+			return { kind: 'some', value }
+		}
+	},
+	InteractionHandlerTypes: { ModalSubmit: 'modal-submit' },
+}))
+
+vi.mock('../../services/ParlayBuilderService.js', () => ({
+	ParlayBuilderService: class {
+		constructor() {
+			return builderService
+		}
+	},
+	getParlayErrorMessage: (error: unknown) =>
+		error instanceof Error ? error.message : 'Unable to process parlay.',
+	logParlayBuilderError: vi.fn(),
+}))
+
+vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
+	default: vi.fn(),
+}))
+
+vi.mock('../../utils/cache/cache-manager.js', () => ({
+	CacheManager: vi.fn(),
+}))
+
+const { ParlayModalHandler } = await import('../parlay-modal-handler.js')
+
+describe('ParlayModalHandler', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('reports modal validation errors ephemerally without overwriting the builder', async () => {
+		const message = { edit: vi.fn() }
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			fields: { getTextInputValue: vi.fn(() => 'not-a-number') },
+			isFromMessage: vi.fn(() => true),
+			message,
+			replied: false,
+			deferred: false,
+			reply: vi.fn(),
+			deferReply: vi.fn(),
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, { kind: 'stake' })
+
+		expect(message.edit).not.toHaveBeenCalled()
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: 'Stake must be a whole number. Try again.',
+			flags: 64,
+		})
+	})
+})

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -91,9 +91,13 @@ export class ParlayButtonHandler extends InteractionHandler {
 			| { action: 'confirm' },
 	) {
 		const userId = interaction.user.id
+		const guildId = interaction.guildId
 		try {
+			if (!guildId) {
+				throw new Error('Parlays can only be built inside a server.')
+			}
 			if (payload.action === 'cancel') {
-				await this.builderService.clear(userId)
+				await this.builderService.clear(userId, guildId)
 				return interaction.editReply(
 					this.builderService.renderMessage(
 						'Parlay builder cancelled.',
@@ -103,44 +107,66 @@ export class ParlayButtonHandler extends InteractionHandler {
 			if (payload.action === 'remove') {
 				const session = await this.builderService.removeLeg(
 					userId,
+					guildId,
 					payload.index,
 				)
 				return interaction.editReply(
 					this.builderService.render(session),
 				)
 			}
-			const session = await this.builderService.get(userId)
-			if (!session)
-				throw new Error(
-					'Your parlay builder expired. Run `/parlay` to start again.',
-				)
-			this.builderService.validateForPlacement(session)
-			const initialized = await this.parlayApi.init({
-				legs: session.legs.map(({ event_id, outcome_uuid }) => ({
-					event_id,
-					outcome_uuid,
-				})),
-				stake: session.stake!,
-				guild_id: interaction.guildId!,
-				user_id: userId,
-			})
-			const placed = await this.parlayApi.place(initialized.init_token)
-			await new BetslipManager(
-				new BetslipWrapper(),
-				new BetsCacheService(new CacheManager()),
-			).announceParlayPlaced(interaction, {
-				parlayId: placed.id,
-				legCount: placed.leg_count,
-				stake: Number(placed.stake),
-				potentialPayout: Number(placed.potential_payout),
-			})
-			await this.builderService.clear(userId)
-			return interaction.editReply(
-				this.builderService.renderMessage(
-					`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
-					0x57f287,
-				),
+			const reservation = await this.builderService.reserveForPlacement(
+				userId,
+				guildId,
 			)
+			if (!reservation) {
+				throw new Error(
+					'Your parlay is already being placed. Please wait for the result.',
+				)
+			}
+			const { session, token } = reservation
+			try {
+				this.builderService.validateForPlacement(session)
+				const initialized = await this.parlayApi.init({
+					legs: session.legs.map(({ event_id, outcome_uuid }) => ({
+						event_id,
+						outcome_uuid,
+					})),
+					stake: session.stake!,
+					guild_id: guildId,
+					user_id: userId,
+				})
+				const placed = await this.parlayApi.place(
+					initialized.init_token,
+				)
+				await new BetslipManager(
+					new BetslipWrapper(),
+					new BetsCacheService(new CacheManager()),
+				).announceParlayPlaced(interaction, {
+					parlayId: placed.id,
+					legCount: placed.leg_count,
+					stake: Number(placed.stake),
+					potentialPayout: Number(placed.potential_payout),
+				})
+				await this.builderService.clear(userId, guildId)
+				await this.builderService.releasePlacement(
+					userId,
+					guildId,
+					token,
+				)
+				return interaction.editReply(
+					this.builderService.renderMessage(
+						`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
+						0x57f287,
+					),
+				)
+			} catch (error) {
+				await this.builderService.releasePlacement(
+					userId,
+					guildId,
+					token,
+				)
+				throw error
+			}
 		} catch (error) {
 			logParlayBuilderError(error, { action: payload.action, userId })
 			const message = getParlayErrorMessage(error)

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -124,18 +124,36 @@ export class ParlayButtonHandler extends InteractionHandler {
 				)
 			}
 			const { session, token } = reservation
-			const leaseHeartbeat = setInterval(() => {
-				void this.builderService
-					.refreshPlacement(userId, guildId, token)
-					.catch((error) =>
-						logParlayBuilderError(error, {
-							action: 'refresh_placement_reservation',
-							userId,
-						}),
+			let leaseLost = false
+			const assertPlacementLease = async () => {
+				if (leaseLost) {
+					throw new Error(
+						'Parlay placement lost its reservation. Please try again.',
 					)
+				}
+				const refreshed = await this.builderService.refreshPlacement(
+					userId,
+					guildId,
+					token,
+				)
+				if (!refreshed) {
+					leaseLost = true
+					throw new Error(
+						'Parlay placement lost its reservation. Please try again.',
+					)
+				}
+			}
+			const leaseHeartbeat = setInterval(() => {
+				void assertPlacementLease().catch((error) =>
+					logParlayBuilderError(error, {
+						action: 'refresh_placement_reservation',
+						userId,
+					}),
+				)
 			}, 30_000)
 			leaseHeartbeat.unref?.()
 			try {
+				await assertPlacementLease()
 				this.builderService.validateForPlacement(session)
 				const initialized = await this.parlayApi.init({
 					legs: session.legs.map(({ event_id, outcome_uuid }) => ({
@@ -146,9 +164,11 @@ export class ParlayButtonHandler extends InteractionHandler {
 					guild_id: guildId,
 					user_id: userId,
 				})
+				await assertPlacementLease()
 				const placed = await this.parlayApi.place(
 					initialized.init_token,
 				)
+				await assertPlacementLease()
 				await new BetslipManager(
 					new BetslipWrapper(),
 					new BetsCacheService(new CacheManager()),

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -124,6 +124,17 @@ export class ParlayButtonHandler extends InteractionHandler {
 				)
 			}
 			const { session, token } = reservation
+			const leaseHeartbeat = setInterval(() => {
+				void this.builderService
+					.refreshPlacement(userId, guildId, token)
+					.catch((error) =>
+						logParlayBuilderError(error, {
+							action: 'refresh_placement_reservation',
+							userId,
+						}),
+					)
+			}, 30_000)
+			leaseHeartbeat.unref?.()
 			try {
 				this.builderService.validateForPlacement(session)
 				const initialized = await this.parlayApi.init({
@@ -147,8 +158,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 					stake: Number(placed.stake),
 					potentialPayout: Number(placed.potential_payout),
 				})
-				await this.builderService.clear(userId, guildId)
-				await this.builderService.releasePlacement(
+				await this.builderService.clearWithPlacementToken(
 					userId,
 					guildId,
 					token,
@@ -160,12 +170,14 @@ export class ParlayButtonHandler extends InteractionHandler {
 					),
 				)
 			} catch (error) {
+				throw error
+			} finally {
+				clearInterval(leaseHeartbeat)
 				await this.builderService.releasePlacement(
 					userId,
 					guildId,
 					token,
 				)
-				throw error
 			}
 		} catch (error) {
 			logParlayBuilderError(error, { action: payload.action, userId })

--- a/src/interaction-handlers/parlay-modal-handler.ts
+++ b/src/interaction-handlers/parlay-modal-handler.ts
@@ -115,6 +115,12 @@ export class ParlayModalHandler extends InteractionHandler {
 			return updateBuilder(this.builderService.render(session))
 		} catch (error) {
 			logParlayBuilderError(error, { userId, modal: payload.kind })
+			if (interaction.isFromMessage() && interaction.message) {
+				return interaction.reply({
+					content: getParlayErrorMessage(error),
+					flags: MessageFlags.Ephemeral,
+				})
+			}
 			return updateBuilder(
 				this.builderService.renderMessage(getParlayErrorMessage(error)),
 				'Unable to update parlay builder.',

--- a/src/interaction-handlers/parlay-modal-handler.ts
+++ b/src/interaction-handlers/parlay-modal-handler.ts
@@ -2,7 +2,7 @@ import {
 	InteractionHandler,
 	InteractionHandlerTypes,
 } from '@sapphire/framework'
-import { type ModalSubmitInteraction } from 'discord.js'
+import { MessageFlags, type ModalSubmitInteraction } from 'discord.js'
 import {
 	getParlayErrorMessage,
 	logParlayBuilderError,
@@ -39,8 +39,30 @@ export class ParlayModalHandler extends InteractionHandler {
 		interaction: ModalSubmitInteraction,
 		payload: { kind: 'add_leg' | 'stake' },
 	) {
-		await interaction.deferReply({ ephemeral: true })
 		const userId = interaction.user.id
+		const guildId = interaction.guildId
+		if (!guildId) {
+			return interaction.reply({
+				content: 'Parlays can only be built inside a server.',
+				flags: MessageFlags.Ephemeral,
+			})
+		}
+		const updateBuilder = async (
+			options: ReturnType<ParlayBuilderService['render']>,
+			confirmation = 'Parlay builder updated.',
+		) => {
+			if (interaction.isFromMessage() && interaction.message) {
+				await interaction.message.edit(options)
+				return interaction.reply({
+					content: confirmation,
+					flags: MessageFlags.Ephemeral,
+				})
+			}
+			if (!interaction.deferred && !interaction.replied) {
+				await interaction.deferReply({ ephemeral: true })
+			}
+			return interaction.editReply(options)
+		}
 		try {
 			if (payload.kind === 'stake') {
 				const rawStake = interaction.fields
@@ -50,11 +72,10 @@ export class ParlayModalHandler extends InteractionHandler {
 					throw new Error('Stake must be a whole number. Try again.')
 				const session = await this.builderService.setStake(
 					userId,
+					guildId,
 					Number(rawStake),
 				)
-				return interaction.editReply(
-					this.builderService.render(session),
-				)
+				return updateBuilder(this.builderService.render(session))
 			}
 
 			const gameId =
@@ -86,16 +107,17 @@ export class ParlayModalHandler extends InteractionHandler {
 			) {
 				throw new Error('Totals require Over or Under.')
 			}
-			const session = await this.builderService.addLeg(userId, {
+			const session = await this.builderService.addLeg(userId, guildId, {
 				matchId: gameId,
 				marketKey,
 				side,
 			})
-			return interaction.editReply(this.builderService.render(session))
+			return updateBuilder(this.builderService.render(session))
 		} catch (error) {
 			logParlayBuilderError(error, { userId, modal: payload.kind })
-			return interaction.editReply(
+			return updateBuilder(
 				this.builderService.renderMessage(getParlayErrorMessage(error)),
+				'Unable to update parlay builder.',
 			)
 		}
 	}

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -125,7 +125,9 @@ export class ParlayBuilderService {
 			}
 			if (this.cache.setIfAbsent) {
 				const active = await this.cache.get(reservationKey)
-				if (active && active !== placementToken) {
+				if (
+					placementToken ? active !== placementToken : Boolean(active)
+				) {
 					throw new Error(
 						'Your parlay is already being placed. Please wait for the result.',
 					)

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import {
 	ActionRowBuilder,
 	ButtonBuilder,
@@ -42,18 +43,35 @@ export interface AddParlayLegSelection {
 	side: ParlaySide
 }
 
-export const parlayBuilderKey = (userId: string): string =>
-	`parlay-builder:${userId}`
+export const parlayBuilderKey = (userId: string, guildId: string): string =>
+	`parlay-builder:${guildId}:${userId}`
+
+const parlayBuilderLockKey = (userId: string, guildId: string): string =>
+	`${parlayBuilderKey(userId, guildId)}:lock`
+
+const parlayBuilderPlacementKey = (userId: string, guildId: string): string =>
+	`${parlayBuilderKey(userId, guildId)}:placement`
+
+type BuilderCache = Pick<CacheManager, 'get' | 'set' | 'remove'> & {
+	setIfAbsent?: CacheManager['setIfAbsent']
+	compareAndRemove?: CacheManager['compareAndRemove']
+}
+
+const mutationQueues = new Map<string, Promise<unknown>>()
+const localPlacementReservations = new Set<string>()
 
 export class ParlayBuilderService {
 	constructor(
-		private readonly cache: CacheManager = new CacheManager(),
+		private readonly cache: BuilderCache = new CacheManager(),
 		private readonly matchCache = new MatchCacheService(new CacheManager()),
 		private readonly parlayApi = new ParlayApiWrapper(),
 	) {}
 
-	async get(userId: string): Promise<ParlayBuilderSession | null> {
-		const value = await this.cache.get(parlayBuilderKey(userId))
+	async get(
+		userId: string,
+		guildId: string,
+	): Promise<ParlayBuilderSession | null> {
+		const value = await this.cache.get(parlayBuilderKey(userId, guildId))
 		if (!value || typeof value !== 'object') return null
 		const session = value as Partial<ParlayBuilderSession>
 		if (!Array.isArray(session.legs)) return null
@@ -63,81 +81,210 @@ export class ParlayBuilderService {
 		}
 	}
 
-	async start(userId: string): Promise<ParlayBuilderSession> {
-		const session: ParlayBuilderSession = { legs: [], stake: null }
-		await this.save(userId, session)
-		return session
+	async start(
+		userId: string,
+		guildId: string,
+	): Promise<ParlayBuilderSession> {
+		return this.withSessionLock(userId, guildId, async () => {
+			await this.ensureNotReserved(userId, guildId)
+			const session: ParlayBuilderSession = { legs: [], stake: null }
+			await this.saveUnlocked(userId, guildId, session)
+			return session
+		})
 	}
 
-	async save(userId: string, session: ParlayBuilderSession): Promise<void> {
+	private async saveUnlocked(
+		userId: string,
+		guildId: string,
+		session: ParlayBuilderSession,
+	): Promise<void> {
 		await this.cache.set(
-			parlayBuilderKey(userId),
+			parlayBuilderKey(userId, guildId),
 			session,
 			PARLAY_BUILDER_TTL_SECONDS,
 		)
 	}
 
-	async clear(userId: string): Promise<void> {
-		await this.cache.remove(parlayBuilderKey(userId))
+	async clear(userId: string, guildId: string): Promise<void> {
+		await this.withSessionLock(userId, guildId, async () => {
+			await this.cache.remove(parlayBuilderKey(userId, guildId))
+		})
 	}
 
 	async setStake(
 		userId: string,
+		guildId: string,
 		stake: number,
 	): Promise<ParlayBuilderSession> {
 		if (!Number.isSafeInteger(stake) || stake <= 0) {
 			throw new Error('Stake must be a whole number greater than $0.')
 		}
-		const session = await this.get(userId)
-		if (!session)
-			throw new Error(
-				'Your parlay builder expired. Run `/parlay` to start again.',
-			)
-		const updated = { ...session, stake }
-		await this.save(userId, updated)
-		return updated
+		return this.mutateSession(userId, guildId, (session) => ({
+			...session,
+			stake,
+		}))
 	}
 
 	async removeLeg(
 		userId: string,
+		guildId: string,
 		index: number,
 	): Promise<ParlayBuilderSession> {
-		const session = await this.get(userId)
-		if (!session)
-			throw new Error(
-				'Your parlay builder expired. Run `/parlay` to start again.',
-			)
-		if (index < 0 || index >= session.legs.length) {
-			throw new Error('That parlay leg is no longer available.')
-		}
-		const updated = {
-			...session,
-			legs: session.legs.filter((_, i) => i !== index),
-		}
-		await this.save(userId, updated)
-		return updated
+		return this.mutateSession(userId, guildId, (session) => {
+			if (index < 0 || index >= session.legs.length) {
+				throw new Error('That parlay leg is no longer available.')
+			}
+			return {
+				...session,
+				legs: session.legs.filter((_, i) => i !== index),
+			}
+		})
 	}
 
 	async addLeg(
 		userId: string,
+		guildId: string,
 		selection: AddParlayLegSelection,
 	): Promise<ParlayBuilderSession> {
-		const session = await this.get(userId)
-		if (!session)
-			throw new Error(
-				'Your parlay builder expired. Run `/parlay` to start again.',
-			)
-		if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
-			throw new Error('A parlay can contain at most 6 legs.')
-		}
-		if (session.legs.some((leg) => leg.event_id === selection.matchId)) {
-			throw new Error('Each parlay leg must use a different game.')
-		}
+		return this.mutateSession(userId, guildId, async (session) => {
+			if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
+				throw new Error('A parlay can contain at most 6 legs.')
+			}
+			if (
+				session.legs.some((item) => item.event_id === selection.matchId)
+			) {
+				throw new Error('Each parlay leg must use a different game.')
+			}
+			const leg = await this.resolveLeg(selection)
+			return { ...session, legs: [...session.legs, leg] }
+		})
+	}
 
-		const leg = await this.resolveLeg(selection)
-		const updated = { ...session, legs: [...session.legs, leg] }
-		await this.save(userId, updated)
-		return updated
+	/**
+	 * Reserve a builder before calling Khronos. The Redis NX boundary keeps
+	 * duplicate confirm interactions from placing the same wager twice.
+	 */
+	async reserveForPlacement(
+		userId: string,
+		guildId: string,
+	): Promise<{ session: ParlayBuilderSession; token: string } | null> {
+		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+		if (localPlacementReservations.has(reservationKey)) return null
+		localPlacementReservations.add(reservationKey)
+		const token = randomUUID()
+		let acquired = !this.cache.setIfAbsent
+		let sessionFound = false
+		try {
+			if (this.cache.setIfAbsent) {
+				acquired = await this.cache.setIfAbsent(
+					reservationKey,
+					token,
+					120,
+				)
+				if (!acquired) return null
+			}
+			const session = await this.get(userId, guildId)
+			if (!session) return null
+			sessionFound = true
+			return { session, token }
+		} finally {
+			if (!acquired || !sessionFound) {
+				await this.releasePlacement(userId, guildId, token)
+			}
+		}
+	}
+
+	async releasePlacement(
+		userId: string,
+		guildId: string,
+		token?: string,
+	): Promise<void> {
+		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+		if (token && this.cache.compareAndRemove) {
+			await this.cache.compareAndRemove(reservationKey, token)
+		} else {
+			await this.cache.remove(reservationKey)
+		}
+		localPlacementReservations.delete(reservationKey)
+	}
+
+	private async mutateSession(
+		userId: string,
+		guildId: string,
+		mutator: (
+			session: ParlayBuilderSession,
+		) => ParlayBuilderSession | Promise<ParlayBuilderSession>,
+	): Promise<ParlayBuilderSession> {
+		return this.withSessionLock(userId, guildId, async () => {
+			await this.ensureNotReserved(userId, guildId)
+			const session = await this.get(userId, guildId)
+			if (!session)
+				throw new Error(
+					'Your parlay builder expired. Run `/parlay` to start again.',
+				)
+			const updated = await mutator(session)
+			await this.saveUnlocked(userId, guildId, updated)
+			return updated
+		})
+	}
+
+	private async ensureNotReserved(
+		userId: string,
+		guildId: string,
+	): Promise<void> {
+		if (!this.cache.setIfAbsent) return
+		if (await this.cache.get(parlayBuilderPlacementKey(userId, guildId))) {
+			throw new Error(
+				'Your parlay is already being placed. Please wait for the result.',
+			)
+		}
+	}
+
+	private async withSessionLock<T>(
+		userId: string,
+		guildId: string,
+		operation: () => Promise<T>,
+	): Promise<T> {
+		const scope = parlayBuilderKey(userId, guildId)
+		const previous = mutationQueues.get(scope) ?? Promise.resolve()
+		const current = previous
+			.catch(() => undefined)
+			.then(async () => {
+				const token = randomUUID()
+				const lockKey = parlayBuilderLockKey(userId, guildId)
+				let locked = false
+				if (this.cache.setIfAbsent) {
+					for (let attempt = 0; attempt < 40; attempt += 1) {
+						if (await this.cache.setIfAbsent(lockKey, token, 120)) {
+							locked = true
+							break
+						}
+						await new Promise((resolve) => setTimeout(resolve, 25))
+					}
+					if (!locked)
+						throw new Error(
+							'Your parlay builder is busy. Please try again in a moment.',
+						)
+				}
+				try {
+					return await operation()
+				} finally {
+					if (locked) {
+						if (this.cache.compareAndRemove) {
+							await this.cache.compareAndRemove(lockKey, token)
+						} else {
+							await this.cache.remove(lockKey)
+						}
+					}
+				}
+			})
+		mutationQueues.set(scope, current)
+		try {
+			return await current
+		} finally {
+			if (mutationQueues.get(scope) === current)
+				mutationQueues.delete(scope)
+		}
 	}
 
 	async resolveLeg(
@@ -155,9 +302,14 @@ export class ParlayBuilderService {
 				'That game has already started. Choose another game.',
 			)
 		}
+		if (!match.sport) {
+			throw new Error(
+				'That game is missing sport information. Please try again.',
+			)
+		}
 
 		const outcomes = await this.parlayApi.getEventOutcomes(
-			match.sport ?? 'nba',
+			match.sport,
 			match.id,
 		)
 		const marketOutcomes = outcomes.filter(

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -55,10 +55,11 @@ const parlayBuilderPlacementKey = (userId: string, guildId: string): string =>
 type BuilderCache = Pick<CacheManager, 'get' | 'set' | 'remove'> & {
 	setIfAbsent?: CacheManager['setIfAbsent']
 	compareAndRemove?: CacheManager['compareAndRemove']
+	refreshIfOwned?: CacheManager['refreshIfOwned']
 }
 
 const mutationQueues = new Map<string, Promise<unknown>>()
-const localPlacementReservations = new Set<string>()
+const localPlacementReservations = new Map<string, string>()
 
 export class ParlayBuilderService {
 	constructor(
@@ -106,7 +107,30 @@ export class ParlayBuilderService {
 	}
 
 	async clear(userId: string, guildId: string): Promise<void> {
+		await this.clearWithPlacementToken(userId, guildId)
+	}
+
+	async clearWithPlacementToken(
+		userId: string,
+		guildId: string,
+		placementToken?: string,
+	): Promise<void> {
 		await this.withSessionLock(userId, guildId, async () => {
+			const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+			const localOwner = localPlacementReservations.get(reservationKey)
+			if (localOwner && localOwner !== placementToken) {
+				throw new Error(
+					'Your parlay is already being placed. Please wait for the result.',
+				)
+			}
+			if (this.cache.setIfAbsent) {
+				const active = await this.cache.get(reservationKey)
+				if (active && active !== placementToken) {
+					throw new Error(
+						'Your parlay is already being placed. Please wait for the result.',
+					)
+				}
+			}
 			await this.cache.remove(parlayBuilderKey(userId, guildId))
 		})
 	}
@@ -170,8 +194,8 @@ export class ParlayBuilderService {
 	): Promise<{ session: ParlayBuilderSession; token: string } | null> {
 		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
 		if (localPlacementReservations.has(reservationKey)) return null
-		localPlacementReservations.add(reservationKey)
 		const token = randomUUID()
+		localPlacementReservations.set(reservationKey, token)
 		let acquired = !this.cache.setIfAbsent
 		let sessionFound = false
 		try {
@@ -205,7 +229,25 @@ export class ParlayBuilderService {
 		} else {
 			await this.cache.remove(reservationKey)
 		}
-		localPlacementReservations.delete(reservationKey)
+		if (
+			!token ||
+			localPlacementReservations.get(reservationKey) === token
+		) {
+			localPlacementReservations.delete(reservationKey)
+		}
+	}
+
+	async refreshPlacement(
+		userId: string,
+		guildId: string,
+		token: string,
+	): Promise<boolean> {
+		if (!this.cache.refreshIfOwned) return true
+		return this.cache.refreshIfOwned(
+			parlayBuilderPlacementKey(userId, guildId),
+			token,
+			120,
+		)
 	}
 
 	private async mutateSession(
@@ -232,8 +274,13 @@ export class ParlayBuilderService {
 		userId: string,
 		guildId: string,
 	): Promise<void> {
-		if (!this.cache.setIfAbsent) return
-		if (await this.cache.get(parlayBuilderPlacementKey(userId, guildId))) {
+		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+		if (localPlacementReservations.has(reservationKey)) {
+			throw new Error(
+				'Your parlay is already being placed. Please wait for the result.',
+			)
+		}
+		if (this.cache.setIfAbsent && (await this.cache.get(reservationKey))) {
 			throw new Error(
 				'Your parlay is already being placed. Please wait for the result.',
 			)

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -30,6 +30,8 @@ type CacheStub = {
 	get: ReturnType<typeof vi.fn>
 	set: ReturnType<typeof vi.fn>
 	remove: ReturnType<typeof vi.fn>
+	setIfAbsent?: ReturnType<typeof vi.fn>
+	compareAndRemove?: ReturnType<typeof vi.fn>
 }
 
 const makeCache = (): CacheStub => ({
@@ -69,10 +71,10 @@ describe('ParlayBuilderService', () => {
 	})
 
 	it('stores one user session with the 15 minute TTL', async () => {
-		await service.start('user-1')
+		await service.start('user-1', 'guild-1')
 
 		expect(cache.set).toHaveBeenCalledWith(
-			'parlay-builder:user-1',
+			'parlay-builder:guild-1:user-1',
 			{ legs: [], stake: null },
 			PARLAY_BUILDER_TTL_SECONDS,
 		)
@@ -81,7 +83,7 @@ describe('ParlayBuilderService', () => {
 	it('rejects duplicate events and the seventh leg', async () => {
 		cache.get.mockResolvedValue(makeSession(1))
 		await expect(
-			service.addLeg('user-1', {
+			service.addLeg('user-1', 'guild-1', {
 				matchId: 'event-0',
 				marketKey: 'h2h',
 				side: 'home',
@@ -90,7 +92,7 @@ describe('ParlayBuilderService', () => {
 
 		cache.get.mockResolvedValue(makeSession(PARLAY_BUILDER_MAX_LEGS))
 		await expect(
-			service.addLeg('user-1', {
+			service.addLeg('user-1', 'guild-1', {
 				matchId: 'event-new',
 				marketKey: 'h2h',
 				side: 'home',
@@ -116,7 +118,7 @@ describe('ParlayBuilderService', () => {
 			},
 		])
 
-		const result = await service.addLeg('user-1', {
+		const result = await service.addLeg('user-1', 'guild-1', {
 			matchId: 'event-1',
 			marketKey: 'h2h',
 			side: 'home',
@@ -129,10 +131,45 @@ describe('ParlayBuilderService', () => {
 			odds_american: -110,
 		})
 		expect(cache.set).toHaveBeenLastCalledWith(
-			'parlay-builder:user-1',
+			'parlay-builder:guild-1:user-1',
 			expect.objectContaining({ legs: expect.any(Array) }),
 			PARLAY_BUILDER_TTL_SECONDS,
 		)
+	})
+
+	it('rejects matches without sport metadata instead of defaulting to NBA', async () => {
+		cache.get.mockResolvedValue(makeSession())
+		matchCache.getMatch.mockResolvedValue({
+			id: 'event-no-sport',
+			home_team: 'Home Team',
+			away_team: 'Away Team',
+			commence_time: '2099-01-01T00:00:00.000Z',
+		})
+
+		await expect(
+			service.addLeg('user-1', 'guild-1', {
+				matchId: 'event-no-sport',
+				marketKey: 'h2h',
+				side: 'home',
+			}),
+		).rejects.toThrow('missing sport information')
+		expect(parlayApi.getEventOutcomes).not.toHaveBeenCalled()
+	})
+
+	it('reserves a session so concurrent confirmation can only place once', async () => {
+		cache.get.mockResolvedValue({ ...makeSession(2), stake: 10 })
+		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
+		cache.compareAndRemove = vi.fn().mockResolvedValue(true)
+
+		const first = await service.reserveForPlacement('user-1', 'guild-1')
+		const second = await service.reserveForPlacement('user-1', 'guild-1')
+
+		expect(first).not.toBeNull()
+		expect(second).toBeNull()
+		await service.releasePlacement('user-1', 'guild-1', first?.token)
+		const third = await service.reserveForPlacement('user-1', 'guild-1')
+		expect(third).not.toBeNull()
+		await service.releasePlacement('user-1', 'guild-1', third?.token)
 	})
 
 	it('calculates combined odds and stake-aware payout', async () => {

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -202,6 +202,19 @@ describe('ParlayBuilderService', () => {
 		)
 	})
 
+	it('reports a lost placement lease instead of fencing a new owner', async () => {
+		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
+		cache.refreshIfOwned = vi.fn().mockResolvedValue(false)
+		await expect(
+			service.refreshPlacement('user-1', 'guild-1', 'owner-token'),
+		).resolves.toBe(false)
+
+		cache.get.mockResolvedValue(false)
+		await expect(
+			service.clearWithPlacementToken('user-1', 'guild-1', 'owner-token'),
+		).rejects.toThrow('already being placed')
+	})
+
 	it('calculates combined odds and stake-aware payout', async () => {
 		const session = {
 			...makeSession(2),

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -32,6 +32,7 @@ type CacheStub = {
 	remove: ReturnType<typeof vi.fn>
 	setIfAbsent?: ReturnType<typeof vi.fn>
 	compareAndRemove?: ReturnType<typeof vi.fn>
+	refreshIfOwned?: ReturnType<typeof vi.fn>
 }
 
 const makeCache = (): CacheStub => ({
@@ -170,6 +171,35 @@ describe('ParlayBuilderService', () => {
 		const third = await service.reserveForPlacement('user-1', 'guild-1')
 		expect(third).not.toBeNull()
 		await service.releasePlacement('user-1', 'guild-1', third?.token)
+	})
+
+	it('rejects cancellation while placement owns the builder', async () => {
+		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
+		cache.get.mockImplementation((key: string) =>
+			key.endsWith(':placement')
+				? Promise.resolve('active-token')
+				: Promise.resolve({ ...makeSession(2), stake: 10 }),
+		)
+
+		await expect(service.clear('user-1', 'guild-1')).rejects.toThrow(
+			'already being placed',
+		)
+		expect(cache.remove).not.toHaveBeenCalledWith(
+			'parlay-builder:guild-1:user-1',
+		)
+	})
+
+	it('refreshes a placement lease through the cache owner check', async () => {
+		cache.refreshIfOwned = vi.fn().mockResolvedValue(true)
+
+		await expect(
+			service.refreshPlacement('user-1', 'guild-1', 'owner-token'),
+		).resolves.toBe(true)
+		expect(cache.refreshIfOwned).toHaveBeenCalledWith(
+			'parlay-builder:guild-1:user-1:placement',
+			'owner-token',
+			120,
+		)
 	})
 
 	it('calculates combined odds and stake-aware payout', async () => {

--- a/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
+++ b/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
@@ -160,7 +160,7 @@ describe('MyBetsFormatterService parlays', () => {
 			groupedBets: [],
 		})
 
-		expect(response.embeds?.[0]?.toJSON().description).toContain(
+		expect(JSON.stringify(response.embeds?.[0])).toContain(
 			'Some parlays could not be loaded',
 		)
 	})

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -1,4 +1,5 @@
 import type { AxiosRequestConfig } from 'axios'
+import type { MockBackend } from '../../../dev/mock-backend.js'
 import { AxiosKhronosInstance } from '../../common/axios-config.js'
 
 export type ParlayMarketKey = 'h2h' | 'spreads' | 'totals'
@@ -83,8 +84,20 @@ export default class ParlayApiWrapper {
 	private readonly requestConfig: AxiosRequestConfig = {
 		validateStatus: (status) => status >= 200 && status < 300,
 	}
+	private readonly mockPromise: Promise<MockBackend | undefined>
+
+	constructor() {
+		this.mockPromise =
+			process.env.USE_MOCK_DATA === 'true'
+				? import('../../../dev/index.js').then(({ MockBackend }) =>
+						MockBackend.instance(),
+					)
+				: Promise.resolve(undefined)
+	}
 
 	async init(payload: InitParlayRequest): Promise<InitParlayResponse> {
+		const mock = await this.mockPromise
+		if (mock) return mock.initParlay(payload)
 		const response = await AxiosKhronosInstance.post<InitParlayResponse>(
 			'/parlays/init',
 			payload,
@@ -94,6 +107,8 @@ export default class ParlayApiWrapper {
 	}
 
 	async place(initToken: string): Promise<ParlayResponse> {
+		const mock = await this.mockPromise
+		if (mock) return mock.placeParlay(initToken)
 		const response = await AxiosKhronosInstance.post<ParlayResponse>(
 			'/parlays/place',
 			{ init_token: initToken },
@@ -106,6 +121,8 @@ export default class ParlayApiWrapper {
 		userId: string,
 		options: { page?: number; limit?: number; status?: string } = {},
 	): Promise<UserParlaysResponse> {
+		const mock = await this.mockPromise
+		if (mock) return mock.getUserParlays(userId, options)
 		const response = await AxiosKhronosInstance.get<UserParlaysResponse>(
 			`/parlays/user/${encodeURIComponent(userId)}`,
 			{ ...this.requestConfig, params: options },
@@ -114,6 +131,8 @@ export default class ParlayApiWrapper {
 	}
 
 	async cancel(parlayId: string, userId: string): Promise<ParlayResponse> {
+		const mock = await this.mockPromise
+		if (mock) return mock.cancelParlay(parlayId, userId)
 		const response = await AxiosKhronosInstance.delete<ParlayResponse>(
 			`/parlays/${encodeURIComponent(parlayId)}`,
 			{
@@ -128,6 +147,8 @@ export default class ParlayApiWrapper {
 		sport: string,
 		eventId: string,
 	): Promise<EventOutcome[]> {
+		const mock = await this.mockPromise
+		if (mock) return mock.getEventOutcomes(sport, eventId)
 		const response = await AxiosKhronosInstance.get<EventOutcome[]>(
 			`/outcomes/event/${encodeURIComponent(sport)}/${encodeURIComponent(eventId)}`,
 			this.requestConfig,

--- a/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.mock.test.ts
+++ b/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.mock.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockBackend = {
+	initParlay: vi.fn(),
+	placeParlay: vi.fn(),
+	getUserParlays: vi.fn(),
+	cancelParlay: vi.fn(),
+	getEventOutcomes: vi.fn(),
+}
+
+vi.mock('../../../../dev/index.js', () => ({
+	MockBackend: { instance: () => mockBackend },
+}))
+
+vi.mock('../../../common/axios-config.js', () => ({
+	AxiosKhronosInstance: { post: vi.fn(), get: vi.fn(), delete: vi.fn() },
+}))
+
+const { default: ParlayApiWrapper } = await import('../ParlayApiWrapper.js')
+
+describe('ParlayApiWrapper mock mode', () => {
+	beforeEach(() => {
+		vi.stubEnv('USE_MOCK_DATA', 'true')
+		vi.clearAllMocks()
+	})
+
+	it('routes parlay initialization through MockBackend', async () => {
+		const response = { init_token: 'mock-token' }
+		mockBackend.initParlay.mockReturnValue(response)
+
+		await expect(
+			new ParlayApiWrapper().init({
+				legs: [],
+				stake: 10,
+				guild_id: 'guild-1',
+				user_id: 'user-1',
+			}),
+		).resolves.toBe(response)
+		expect(mockBackend.initParlay).toHaveBeenCalledOnce()
+	})
+
+	it('routes outcome lookup through MockBackend', async () => {
+		const response = [{ uuid: 'outcome-1' }]
+		mockBackend.getEventOutcomes.mockReturnValue(response)
+
+		await expect(
+			new ParlayApiWrapper().getEventOutcomes('nba', 'event-1'),
+		).resolves.toBe(response)
+		expect(mockBackend.getEventOutcomes).toHaveBeenCalledWith(
+			'nba',
+			'event-1',
+		)
+	})
+})

--- a/src/utils/cache/__tests__/cache-manager.test.ts
+++ b/src/utils/cache/__tests__/cache-manager.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const evalRedis = vi.fn()
+
+vi.mock('../redis-instance.js', () => ({
+	default: { eval: evalRedis },
+}))
+
+const { CacheManager } = await import('../cache-manager.js')
+
+describe('CacheManager lock ownership', () => {
+	it('compares the serialized token written by setIfAbsent', async () => {
+		evalRedis.mockResolvedValueOnce(1)
+		const cache = new CacheManager()
+
+		await expect(
+			cache.compareAndRemove('lock-key', 'owner-token'),
+		).resolves.toBe(true)
+		expect(evalRedis).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('get', KEYS[1])"),
+			1,
+			'lock-key',
+			JSON.stringify('owner-token'),
+		)
+	})
+
+	it('refreshes a reservation only while the serialized owner token matches', async () => {
+		evalRedis.mockResolvedValueOnce(1)
+		const cache = new CacheManager()
+
+		await expect(
+			cache.refreshIfOwned('placement-key', 'owner-token', 120),
+		).resolves.toBe(true)
+		expect(evalRedis).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('expire', KEYS[1], ARGV[2])"),
+			1,
+			'placement-key',
+			JSON.stringify('owner-token'),
+			120,
+		)
+	})
+})

--- a/src/utils/cache/cache-manager.ts
+++ b/src/utils/cache/cache-manager.ts
@@ -44,7 +44,23 @@ export class CacheManager {
 			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end`,
 			1,
 			key,
-			value,
+			JSON.stringify(value),
+		)
+		return result === 1
+	}
+
+	/** Extend a lock or reservation only while the caller still owns it. */
+	async refreshIfOwned(
+		key: string,
+		value: string,
+		seconds: number,
+	): Promise<boolean> {
+		const result = await this.cache.eval(
+			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end`,
+			1,
+			key,
+			JSON.stringify(value),
+			seconds,
 		)
 		return result === 1
 	}

--- a/src/utils/cache/cache-manager.ts
+++ b/src/utils/cache/cache-manager.ts
@@ -38,6 +38,17 @@ export class CacheManager {
 		return result === 'OK'
 	}
 
+	/** Remove a lock only when it is still owned by the caller. */
+	async compareAndRemove(key: string, value: string): Promise<boolean> {
+		const result = await this.cache.eval(
+			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end`,
+			1,
+			key,
+			value,
+		)
+		return result === 1
+	}
+
 	async get(key: string) {
 		if (!key) {
 			throw new Error('No key was provided to save into cache')

--- a/src/utils/dev/__tests__/mock-backend-parlays.test.ts
+++ b/src/utils/dev/__tests__/mock-backend-parlays.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../lib/startup/env.js', () => ({
+	default: {
+		NODE_ENV: 'development',
+		MOCK_GUILD_SPORT: 'nba',
+		MOCK_GUILD_BETTING_CHAN_ID: '123456789012345678',
+		DEV_GUILD_GAMES_CATEGORY_ID: '123456789012345678',
+	},
+}))
+
+const { MockBackend } = await import('../mock-backend.js')
+
+describe('MockBackend parlay lifecycle', () => {
+	it('preserves spread and totals market metadata in mock parlays', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		const game = backend.seedGames('nba', 1).matches[0]
+		if (!game?.id) throw new Error('mock game did not have an id')
+
+		const preview = backend.initParlay({
+			legs: [
+				{
+					event_id: game.id,
+					outcome_uuid: `${game.id}-spread-home`,
+				},
+				{
+					event_id: game.id,
+					outcome_uuid: `${game.id}-total-over`,
+				},
+			],
+			stake: 10,
+			guild_id: 'guild-1',
+			user_id: 'user-1',
+		})
+
+		expect(preview.legs.map((leg) => leg.market_key)).toEqual([
+			'spreads',
+			'totals',
+		])
+		expect(backend.placeParlay(preview.init_token).legs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ market_key: 'spreads' }),
+				expect.objectContaining({ market_key: 'totals' }),
+			]),
+		)
+	})
+})

--- a/src/utils/dev/mock-backend.ts
+++ b/src/utils/dev/mock-backend.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type {
 	Account,
 	CancelBetslipRequest,
@@ -26,6 +27,13 @@ import {
 import { DEV_IDS } from '../../lib/configs/constants.js'
 import env from '../../lib/startup/env.js'
 import { DiscordConfigEnums } from '../api/common/interfaces/kh-pluto/kh-pluto.interface.js'
+import type {
+	EventOutcome,
+	InitParlayRequest,
+	InitParlayResponse,
+	ParlayResponse,
+	UserParlaysResponse,
+} from '../api/Khronos/parlays/ParlayApiWrapper.js'
 import {
 	makeBetslipWithAggregation,
 	makePlacedBetslip,
@@ -42,6 +50,12 @@ export class MockBackend {
 		GetAllMatchesDto['matches']
 	>()
 	private nextBetId = 10_000
+	private nextParlayId = 20_000
+	private readonly pendingParlays = new Map<
+		string,
+		{ request: InitParlayRequest; preview: InitParlayResponse }
+	>()
+	private readonly parlays = new Map<string, ParlayResponse>()
 
 	private constructor() {
 		if (env.NODE_ENV === 'production') {
@@ -178,6 +192,164 @@ export class MockBackend {
 		return this.store.getBets(request.userid)
 	}
 
+	initParlay(request: InitParlayRequest): InitParlayResponse {
+		const legs = request.legs.map((leg) => ({
+			event_id: leg.event_id,
+			outcome_uuid: leg.outcome_uuid,
+			market_key: 'h2h' as const,
+			selection_display: `Mock selection ${leg.outcome_uuid.slice(0, 8)}`,
+			odds_american: -110,
+			point: null,
+			commence_time: new Date(Date.now() + 6 * 3_600_000).toISOString(),
+		}))
+		const decimal = Math.pow(210 / 110, legs.length)
+		const preview: InitParlayResponse = {
+			init_token: randomUUID(),
+			combined_odds_american: Math.round((decimal - 1) * 100),
+			potential_payout: Math.round(request.stake * decimal * 100) / 100,
+			legs,
+			expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+		}
+		this.pendingParlays.set(preview.init_token, { request, preview })
+		return preview
+	}
+
+	placeParlay(initToken: string): ParlayResponse {
+		const pending = this.pendingParlays.get(initToken)
+		if (!pending) throw new Error('Mock parlay initialization expired.')
+		this.pendingParlays.delete(initToken)
+		const { request, preview } = pending
+		const id = `mock-parlay-${this.nextParlayId++}`
+		const parlay: ParlayResponse = {
+			id,
+			user_id: request.user_id,
+			guild_id: request.guild_id,
+			stake: request.stake,
+			combined_odds_american: preview.combined_odds_american,
+			potential_payout: preview.potential_payout,
+			actual_payout: null,
+			status: 'pending',
+			leg_count: preview.legs.length,
+			created_at: new Date().toISOString(),
+			settled_at: null,
+			legs: preview.legs.map((leg, index) => ({
+				...leg,
+				id: `${id}-leg-${index + 1}`,
+				result: 'pending',
+				settled_at: null,
+			})),
+		}
+		this.parlays.set(id, parlay)
+		return parlay
+	}
+
+	getUserParlays(
+		userId: string,
+		options: { page?: number; limit?: number; status?: string } = {},
+	): UserParlaysResponse {
+		const limit = options.limit ?? 10
+		const page = options.page ?? 1
+		const all = [...this.parlays.values()].filter(
+			(parlay) =>
+				parlay.user_id === userId &&
+				(!options.status || parlay.status === options.status),
+		)
+		const start = (page - 1) * limit
+		return {
+			parlays: all.slice(start, start + limit),
+			page,
+			limit,
+			total: all.length,
+			total_pages: Math.max(1, Math.ceil(all.length / limit)),
+		}
+	}
+
+	cancelParlay(parlayId: string, userId: string): ParlayResponse {
+		const parlay = this.parlays.get(parlayId)
+		if (!parlay || parlay.user_id !== userId) {
+			throw new Error('Mock parlay was not found for this user.')
+		}
+		if (parlay.status !== 'pending') {
+			throw new Error('Mock parlay is no longer cancellable.')
+		}
+		const cancelled = { ...parlay, status: 'cancelled' as const }
+		this.parlays.set(parlayId, cancelled)
+		return cancelled
+	}
+
+	getEventOutcomes(sport: string, eventId: string): EventOutcome[] {
+		const game = this.findGameById(eventId)
+		if (!game?.home_team || !game.away_team) return []
+		const context = {
+			home_team: game.home_team,
+			away_team: game.away_team,
+		}
+		return [
+			{
+				uuid: `${eventId}-home`,
+				event_id: eventId,
+				market_key: 'h2h',
+				name: game.home_team,
+				price: -110,
+				position: 'home',
+				outcome_type: 'team_home',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-away`,
+				event_id: eventId,
+				market_key: 'h2h',
+				name: game.away_team,
+				price: 100,
+				position: 'away',
+				outcome_type: 'team_away',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-spread-home`,
+				event_id: eventId,
+				market_key: 'spreads',
+				name: game.home_team,
+				price: -110,
+				point: -1.5,
+				position: 'home',
+				outcome_type: 'team_home',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-spread-away`,
+				event_id: eventId,
+				market_key: 'spreads',
+				name: game.away_team,
+				price: 100,
+				point: 1.5,
+				position: 'away',
+				outcome_type: 'team_away',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-total-over`,
+				event_id: eventId,
+				market_key: 'totals',
+				name: 'Over',
+				price: -110,
+				point: 220.5,
+				outcome_type: 'over',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-total-under`,
+				event_id: eventId,
+				market_key: 'totals',
+				name: 'Under',
+				price: -110,
+				point: 220.5,
+				outcome_type: 'under',
+				event_context: context,
+			},
+		]
+	}
+
 	clearPendingBets(request: ClearPendingBetsRequest) {
 		this.store.clearPending(request.userid)
 		return { statusCode: 200, message: 'Mock pending bet cleared' }
@@ -275,6 +447,9 @@ export class MockBackend {
 		this.store.reset()
 		this.matchesBySport.clear()
 		this.nextBetId = 10_000
+		this.nextParlayId = 20_000
+		this.pendingParlays.clear()
+		this.parlays.clear()
 	}
 
 	private findGameForBet(

--- a/src/utils/dev/mock-backend.ts
+++ b/src/utils/dev/mock-backend.ts
@@ -193,15 +193,38 @@ export class MockBackend {
 	}
 
 	initParlay(request: InitParlayRequest): InitParlayResponse {
-		const legs = request.legs.map((leg) => ({
-			event_id: leg.event_id,
-			outcome_uuid: leg.outcome_uuid,
-			market_key: 'h2h' as const,
-			selection_display: `Mock selection ${leg.outcome_uuid.slice(0, 8)}`,
-			odds_american: -110,
-			point: null,
-			commence_time: new Date(Date.now() + 6 * 3_600_000).toISOString(),
-		}))
+		const legs = request.legs.map((leg) => {
+			const market_key = leg.outcome_uuid.includes('-spread-')
+				? ('spreads' as const)
+				: leg.outcome_uuid.includes('-total-')
+					? ('totals' as const)
+					: ('h2h' as const)
+			const isHome = leg.outcome_uuid.endsWith('-home')
+			const isOver = leg.outcome_uuid.endsWith('-over')
+			return {
+				event_id: leg.event_id,
+				outcome_uuid: leg.outcome_uuid,
+				market_key,
+				selection_display:
+					market_key === 'totals'
+						? isOver
+							? 'Over 220.5'
+							: 'Under 220.5'
+						: `Mock ${isHome ? 'home' : 'away'} selection`,
+				odds_american: -110,
+				point:
+					market_key === 'spreads'
+						? isHome
+							? -1.5
+							: 1.5
+						: market_key === 'totals'
+							? 220.5
+							: null,
+				commence_time: new Date(
+					Date.now() + 6 * 3_600_000,
+				).toISOString(),
+			}
+		})
 		const decimal = Math.pow(210 / 110, legs.length)
 		const preview: InitParlayResponse = {
 			init_token: randomUUID(),


### PR DESCRIPTION
## Summary
Follow-up to merged TF-968 parlay builder review findings.

- Scope builder sessions by guild and serialize mutations with a Redis lock plus local queue.
- Reserve placement with a tokenized Redis NX key so duplicate confirms cannot place twice.
- Reject missing sport metadata instead of silently routing outcomes to NBA.
- Route parlay API operations through MockBackend in mock mode with deterministic mock lifecycle/outcomes.
- Update modal submissions on the originating builder message.
- Add focused tests and keep installed Discord Components V2 APIs covered by existing render tests.
- Correct the merged mybets test assertion so typecheck is green.

## Verification
- pnpm typecheck
- pnpm build (237 files)
- pnpm test:run (30 files, 163 tests)
- Biome changed-file check
- git diff --check

Target: dev/parlays-props only; no main or production changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fearandesire/pluto-betting-bot/pull/578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->