### PR TITLE
fix(parlays): remediate builder and cache audit findings

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
   pull_request:
-    branches: [main]
+    branches: [main, dev/parlays-props]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -51,6 +51,17 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:7.4-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,6 +81,15 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test with required Redis contract
+        run: pnpm test:run
+        env:
+          PLUTO_REQUIRE_REDIS_TESTS: "1"
+          PLUTO_TEST_REDIS_URL: redis://localhost:6379/15
 
       - name: Build
         run: pnpm build

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@sapphire/framework'
 import '@sapphire/plugin-hmr/register'
 import { GatewayIntentBits, Partials } from 'discord.js'
-import env from './lib/startup/env.js'
+import { startPluto } from './lib/startup/pluto.js'
 import { logger } from './utils/logging/WinstonLogger.js'
 
 const SapDiscClient = new SapphireClient({
@@ -39,37 +39,6 @@ logger.info({
 	message: 'Pluto is starting up',
 })
 
-const initializeStartupServices = async () => {
-	if (env.USE_MOCK_DATA) {
-		logger.info({
-			message:
-				'Mock data mode enabled; skipping Redis-backed startup services',
-			source: 'startup:mock-data',
-		})
-		return
-	}
-
-	await import('./lib/startup/cache.js')
-	await import('./utils/api/Khronos/KhronosInstances.js')
-	await import('./utils/api/koa/index.js')
-	await import('./utils/cache/queue/ChannelCreationQueue.js')
-	await import('./utils/cron/index.js')
-}
-
-const login = async () => {
-	try {
-		await initializeStartupServices()
-		await SapDiscClient.login(process.env.TOKEN)
-		logger.info('Pluto is up and running!')
-	} catch (error) {
-		logger.error({
-			message: 'Failed to login',
-		})
-		SapDiscClient.logger.fatal(error)
-		SapDiscClient.destroy()
-		process.exit(1)
-	}
-}
-login()
+void startPluto({ client: SapDiscClient })
 
 export { SapDiscClient }

--- a/src/interaction-handlers/__tests__/parlay-button-handler.test.ts
+++ b/src/interaction-handlers/__tests__/parlay-button-handler.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { builderService, matchCache } = vi.hoisted(() => ({
+	builderService: {
+		assertCurrent: vi.fn(),
+		clear: vi.fn(),
+		removeLeg: vi.fn(),
+		reserveForPlacement: vi.fn(),
+		refreshPlacement: vi.fn(),
+		validateForPlacement: vi.fn(),
+		releasePlacement: vi.fn(),
+		render: vi.fn(),
+		renderMessage: vi.fn(),
+	},
+	matchCache: { getMatches: vi.fn(), getMatch: vi.fn() },
+}))
+
+vi.mock('../../utils/logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	InteractionHandler: class {
+		public none() {
+			return { kind: 'none' }
+		}
+		public some(value: unknown) {
+			return { kind: 'some', value }
+		}
+	},
+	InteractionHandlerTypes: { Button: 'button' },
+}))
+
+vi.mock('../../services/ParlayBuilderService.js', async (importOriginal) => {
+	const original =
+		await importOriginal<
+			typeof import('../../services/ParlayBuilderService.js')
+		>()
+	return {
+		...original,
+		ParlayBuilderService: class {
+			constructor() {
+				return builderService
+			}
+		},
+		logParlayBuilderError: vi.fn(),
+	}
+})
+
+vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
+	default: class {
+		constructor() {
+			return matchCache
+		}
+	},
+}))
+vi.mock('../../utils/api/Khronos/parlays/ParlayApiWrapper.js', () => ({
+	default: class {},
+}))
+vi.mock('../../utils/api/common/bets/BetsCacheService.js', () => ({
+	BetsCacheService: class {},
+}))
+vi.mock('../../utils/api/Khronos/bets/BetslipsManager.js', () => ({
+	BetslipManager: class {},
+}))
+vi.mock('../../utils/api/Khronos/bets/betslip-wrapper.js', () => ({
+	default: class {},
+}))
+vi.mock('../../utils/cache/cache-manager.js', () => ({
+	CacheManager: class {},
+}))
+
+const { STALE_PARLAY_BUILDER_MESSAGE } = await import(
+	'../../services/ParlayBuilderService.js'
+)
+const { ParlayButtonHandler } = await import('../parlay-button-handler.js')
+
+describe('ParlayButtonHandler', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		matchCache.getMatches.mockResolvedValue([
+			{
+				id: 'event-1',
+				home_team: 'Home',
+				away_team: 'Away',
+				commence_time: '2099-01-01T00:00:00.000Z',
+			},
+		])
+	})
+
+	it('rejects a stale add control ephemerally without opening a modal', async () => {
+		builderService.assertCurrent.mockRejectedValueOnce(
+			new Error(STALE_PARLAY_BUILDER_MESSAGE),
+		)
+		const interaction = {
+			customId: 'parlay.btn.sessionA0001.2.add',
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			showModal: vi.fn(),
+			reply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.parse(interaction as never)
+
+		expect(builderService.assertCurrent).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 2 },
+		)
+		expect(interaction.showModal).not.toHaveBeenCalled()
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: STALE_PARLAY_BUILDER_MESSAGE,
+			flags: 64,
+		})
+	})
+
+	it('expires legacy buttons instead of binding them to the active builder', async () => {
+		const interaction = {
+			customId: 'parlay_btn_remove:0',
+			reply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.parse(interaction as never)
+
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: STALE_PARLAY_BUILDER_MESSAGE,
+			flags: 64,
+		})
+		expect(builderService.removeLeg).not.toHaveBeenCalled()
+	})
+
+	it('carries the builder identity into the add modal', async () => {
+		builderService.assertCurrent.mockResolvedValueOnce({})
+		const interaction = {
+			customId: 'parlay.btn.sessionA0001.2.add',
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			showModal: vi.fn(),
+			reply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.parse(interaction as never)
+
+		const modal = interaction.showModal.mock.calls[0]?.[0]
+		expect(modal.toJSON().custom_id).toBe(
+			'parlay.modal.sessionA0001.2.add-leg',
+		)
+	})
+
+	it('passes the rendered identity to remove mutations', async () => {
+		builderService.removeLeg.mockResolvedValueOnce({})
+		builderService.render.mockReturnValueOnce({ components: [] })
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'remove',
+			index: 0,
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(builderService.removeLeg).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 2 },
+			0,
+		)
+	})
+
+	it('passes stale cancel identity to the guarded clear operation', async () => {
+		builderService.clear.mockRejectedValueOnce(
+			new Error(STALE_PARLAY_BUILDER_MESSAGE),
+		)
+		builderService.renderMessage.mockReturnValueOnce({ components: [] })
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'cancel',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(builderService.clear).toHaveBeenCalledWith('user-1', 'guild-1', {
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			components: [],
+			flags: 32768,
+		})
+	})
+
+	it('passes stale confirm identity to reservation without placing', async () => {
+		builderService.reserveForPlacement.mockRejectedValueOnce(
+			new Error(STALE_PARLAY_BUILDER_MESSAGE),
+		)
+		builderService.renderMessage.mockReturnValueOnce({ components: [] })
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'confirm',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(builderService.reserveForPlacement).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 2 },
+		)
+		expect(builderService.releasePlacement).not.toHaveBeenCalled()
+	})
+})

--- a/src/interaction-handlers/__tests__/parlay-button-handler.test.ts
+++ b/src/interaction-handlers/__tests__/parlay-button-handler.test.ts
@@ -1,19 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { builderService, matchCache } = vi.hoisted(() => ({
-	builderService: {
-		assertCurrent: vi.fn(),
-		clear: vi.fn(),
-		removeLeg: vi.fn(),
-		reserveForPlacement: vi.fn(),
-		refreshPlacement: vi.fn(),
-		validateForPlacement: vi.fn(),
-		releasePlacement: vi.fn(),
-		render: vi.fn(),
-		renderMessage: vi.fn(),
-	},
-	matchCache: { getMatches: vi.fn(), getMatch: vi.fn() },
-}))
+const { builderService, matchCache, parlayAnnouncement, parlayApi } =
+	vi.hoisted(() => ({
+		builderService: {
+			assertCurrent: vi.fn(),
+			clear: vi.fn(),
+			clearWithPlacementToken: vi.fn(),
+			removeLeg: vi.fn(),
+			reserveForPlacement: vi.fn(),
+			refreshPlacement: vi.fn(),
+			setPlacementState: vi.fn(),
+			validateForPlacement: vi.fn(),
+			releasePlacement: vi.fn(),
+			render: vi.fn(),
+			renderMessage: vi.fn(),
+		},
+		parlayApi: {
+			init: vi.fn(),
+			place: vi.fn(),
+			findByPlacement: vi.fn(),
+		},
+		parlayAnnouncement: { announceParlayPlaced: vi.fn() },
+		matchCache: { getMatches: vi.fn(), getMatch: vi.fn() },
+	}))
 
 vi.mock('../../utils/logging/WinstonLogger.js', () => ({
 	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
@@ -55,13 +64,21 @@ vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
 	},
 }))
 vi.mock('../../utils/api/Khronos/parlays/ParlayApiWrapper.js', () => ({
-	default: class {},
+	default: class {
+		constructor() {
+			return parlayApi
+		}
+	},
 }))
 vi.mock('../../utils/api/common/bets/BetsCacheService.js', () => ({
 	BetsCacheService: class {},
 }))
 vi.mock('../../utils/api/Khronos/bets/BetslipsManager.js', () => ({
-	BetslipManager: class {},
+	BetslipManager: class {
+		constructor() {
+			return parlayAnnouncement
+		}
+	},
 }))
 vi.mock('../../utils/api/Khronos/bets/betslip-wrapper.js', () => ({
 	default: class {},
@@ -78,6 +95,43 @@ const { ParlayButtonHandler } = await import('../parlay-button-handler.js')
 describe('ParlayButtonHandler', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		const session = {
+			sessionId: 'sessionA0001',
+			revision: 2,
+			legs: [
+				{ event_id: 'event-1', outcome_uuid: 'outcome-1' },
+				{ event_id: 'event-2', outcome_uuid: 'outcome-2' },
+			],
+			stake: 10,
+			placementId: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			placementPhase: 'editing',
+			lastPlacementResponse: null,
+		}
+		builderService.assertCurrent.mockResolvedValue(session)
+		builderService.reserveForPlacement.mockResolvedValue({
+			session: { ...session, placementPhase: 'placing' },
+			token: 'placement-token',
+		})
+		builderService.refreshPlacement.mockResolvedValue(true)
+		builderService.setPlacementState.mockImplementation(
+			async (
+				_userId,
+				_guildId,
+				_expected,
+				placementPhase,
+				response = null,
+			) => ({
+				...session,
+				placementPhase,
+				lastPlacementResponse: response,
+			}),
+		)
+		builderService.clear.mockResolvedValue(undefined)
+		builderService.clearWithPlacementToken.mockResolvedValue(undefined)
+		builderService.releasePlacement.mockResolvedValue(undefined)
+		builderService.validateForPlacement.mockReturnValue(undefined)
+		builderService.renderMessage.mockReturnValue({ components: [] })
+		parlayAnnouncement.announceParlayPlaced.mockResolvedValue(undefined)
 		matchCache.getMatches.mockResolvedValue([
 			{
 				id: 'event-1',
@@ -175,8 +229,8 @@ describe('ParlayButtonHandler', () => {
 		)
 	})
 
-	it('passes stale cancel identity to the guarded clear operation', async () => {
-		builderService.clear.mockRejectedValueOnce(
+	it('rejects a stale cancel identity before it clears the builder', async () => {
+		builderService.assertCurrent.mockRejectedValueOnce(
 			new Error(STALE_PARLAY_BUILDER_MESSAGE),
 		)
 		builderService.renderMessage.mockReturnValueOnce({ components: [] })
@@ -193,18 +247,15 @@ describe('ParlayButtonHandler', () => {
 			revision: 2,
 		})
 
-		expect(builderService.clear).toHaveBeenCalledWith('user-1', 'guild-1', {
-			sessionId: 'sessionA0001',
-			revision: 2,
-		})
+		expect(builderService.clear).not.toHaveBeenCalled()
 		expect(interaction.editReply).toHaveBeenCalledWith({
 			components: [],
 			flags: 32768,
 		})
 	})
 
-	it('passes stale confirm identity to reservation without placing', async () => {
-		builderService.reserveForPlacement.mockRejectedValueOnce(
+	it('rejects a stale confirm identity before it reserves placement', async () => {
+		builderService.assertCurrent.mockRejectedValueOnce(
 			new Error(STALE_PARLAY_BUILDER_MESSAGE),
 		)
 		builderService.renderMessage.mockReturnValueOnce({ components: [] })
@@ -221,11 +272,167 @@ describe('ParlayButtonHandler', () => {
 			revision: 2,
 		})
 
-		expect(builderService.reserveForPlacement).toHaveBeenCalledWith(
+		expect(builderService.reserveForPlacement).not.toHaveBeenCalled()
+		expect(builderService.releasePlacement).not.toHaveBeenCalled()
+	})
+
+	it('reconciles a timeout after Khronos committed and renders one placement', async () => {
+		parlayApi.init.mockResolvedValueOnce({ init_token: 'init-token' })
+		parlayApi.place.mockRejectedValueOnce(new Error('socket timeout'))
+		parlayApi.findByPlacement.mockResolvedValueOnce({
+			id: 'parlay-1',
+			leg_count: 2,
+			stake: 10,
+			potential_payout: 40,
+			combined_odds_american: 300,
+		})
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'confirm',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(parlayApi.place).toHaveBeenCalledWith(
+			'init-token',
+			'7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+		)
+		expect(parlayApi.findByPlacement).toHaveBeenCalledWith(
+			'7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+		)
+		expect(builderService.setPlacementState).toHaveBeenCalledWith(
 			'user-1',
 			'guild-1',
 			{ sessionId: 'sessionA0001', revision: 2 },
+			'unknown',
 		)
-		expect(builderService.releasePlacement).not.toHaveBeenCalled()
+		expect(interaction.editReply).toHaveBeenCalledWith({ components: [] })
+	})
+
+	it('renders placement success even when lease cleanup fails after a response', async () => {
+		parlayApi.init.mockResolvedValueOnce({ init_token: 'init-token' })
+		parlayApi.place.mockResolvedValueOnce({
+			id: 'parlay-1',
+			leg_count: 2,
+			stake: 10,
+			potential_payout: 40,
+			combined_odds_american: 300,
+		})
+		builderService.clearWithPlacementToken.mockRejectedValueOnce(
+			new Error('lost lease'),
+		)
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'confirm',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(interaction.editReply).toHaveBeenCalledWith({ components: [] })
+		expect(builderService.releasePlacement).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			'placement-token',
+		)
+	})
+
+	it('prevents a second replica from placing while the first holds the reservation', async () => {
+		parlayApi.init.mockResolvedValue({ init_token: 'init-token' })
+		parlayApi.place.mockResolvedValue({
+			id: 'parlay-1',
+			leg_count: 2,
+			stake: 10,
+			potential_payout: 40,
+			combined_odds_american: 300,
+		})
+		builderService.reserveForPlacement
+			.mockResolvedValueOnce({
+				session: {
+					sessionId: 'sessionA0001',
+					revision: 2,
+					legs: [
+						{ event_id: 'event-1', outcome_uuid: 'outcome-1' },
+						{ event_id: 'event-2', outcome_uuid: 'outcome-2' },
+					],
+					stake: 10,
+					placementId: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+					placementPhase: 'placing',
+					lastPlacementResponse: null,
+				},
+				token: 'placement-token',
+			})
+			.mockResolvedValueOnce(null)
+		const first = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const second = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+		const payload = {
+			action: 'confirm' as const,
+			sessionId: 'sessionA0001',
+			revision: 2,
+		}
+
+		await Promise.all([
+			handler.run(first as never, payload),
+			handler.run(second as never, payload),
+		])
+
+		expect(parlayApi.place).toHaveBeenCalledTimes(1)
+	})
+
+	it('reconciles an unknown placement before cancellation clears the builder', async () => {
+		builderService.assertCurrent.mockResolvedValueOnce({
+			sessionId: 'sessionA0001',
+			revision: 2,
+			placementId: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			placementPhase: 'unknown',
+			lastPlacementResponse: null,
+		})
+		parlayApi.findByPlacement.mockResolvedValueOnce(null)
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'cancel',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(parlayApi.findByPlacement).toHaveBeenCalledWith(
+			'7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+		)
+		expect(builderService.setPlacementState).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 2 },
+			'editing',
+		)
+		expect(builderService.clear).toHaveBeenCalledWith('user-1', 'guild-1', {
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
 	})
 })

--- a/src/interaction-handlers/__tests__/parlay-button-handler.test.ts
+++ b/src/interaction-handlers/__tests__/parlay-button-handler.test.ts
@@ -103,7 +103,7 @@ describe('ParlayButtonHandler', () => {
 				{ event_id: 'event-2', outcome_uuid: 'outcome-2' },
 			],
 			stake: 10,
-			placementId: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			placementId: '00000000-0000-4000-8000-000000000001',
 			placementPhase: 'editing',
 			lastPlacementResponse: null,
 		}
@@ -301,10 +301,10 @@ describe('ParlayButtonHandler', () => {
 
 		expect(parlayApi.place).toHaveBeenCalledWith(
 			'init-token',
-			'7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			'00000000-0000-4000-8000-000000000001',
 		)
 		expect(parlayApi.findByPlacement).toHaveBeenCalledWith(
-			'7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			'00000000-0000-4000-8000-000000000001',
 		)
 		expect(builderService.setPlacementState).toHaveBeenCalledWith(
 			'user-1',
@@ -367,7 +367,7 @@ describe('ParlayButtonHandler', () => {
 						{ event_id: 'event-2', outcome_uuid: 'outcome-2' },
 					],
 					stake: 10,
-					placementId: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+					placementId: '00000000-0000-4000-8000-000000000001',
 					placementPhase: 'placing',
 					lastPlacementResponse: null,
 				},
@@ -403,7 +403,7 @@ describe('ParlayButtonHandler', () => {
 		builderService.assertCurrent.mockResolvedValueOnce({
 			sessionId: 'sessionA0001',
 			revision: 2,
-			placementId: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			placementId: '00000000-0000-4000-8000-000000000001',
 			placementPhase: 'unknown',
 			lastPlacementResponse: null,
 		})
@@ -422,7 +422,7 @@ describe('ParlayButtonHandler', () => {
 		})
 
 		expect(parlayApi.findByPlacement).toHaveBeenCalledWith(
-			'7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			'00000000-0000-4000-8000-000000000001',
 		)
 		expect(builderService.setPlacementState).toHaveBeenCalledWith(
 			'user-1',

--- a/src/interaction-handlers/__tests__/parlay-modal-handler.test.ts
+++ b/src/interaction-handlers/__tests__/parlay-modal-handler.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { builderService } = vi.hoisted(() => ({
+const { builderService, matchCache } = vi.hoisted(() => ({
 	builderService: {
 		render: vi.fn(),
 		renderMessage: vi.fn(),
 		setStake: vi.fn(),
 		addLeg: vi.fn(),
 	},
+	matchCache: { getMatch: vi.fn() },
+}))
+
+vi.mock('../../utils/logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }))
 
 vi.mock('@sapphire/framework', () => ({
@@ -21,19 +26,32 @@ vi.mock('@sapphire/framework', () => ({
 	InteractionHandlerTypes: { ModalSubmit: 'modal-submit' },
 }))
 
-vi.mock('../../services/ParlayBuilderService.js', () => ({
-	ParlayBuilderService: class {
-		constructor() {
-			return builderService
-		}
-	},
-	getParlayErrorMessage: (error: unknown) =>
-		error instanceof Error ? error.message : 'Unable to process parlay.',
-	logParlayBuilderError: vi.fn(),
-}))
+vi.mock('../../services/ParlayBuilderService.js', async (importOriginal) => {
+	const original =
+		await importOriginal<
+			typeof import('../../services/ParlayBuilderService.js')
+		>()
+	return {
+		...original,
+		ParlayBuilderService: class {
+			constructor() {
+				return builderService
+			}
+		},
+		logParlayBuilderError: vi.fn(),
+	}
+})
 
 vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
-	default: vi.fn(),
+	default: class {
+		constructor() {
+			return matchCache
+		}
+	},
+}))
+
+vi.mock('../../utils/api/Khronos/parlays/ParlayApiWrapper.js', () => ({
+	default: class {},
 }))
 
 vi.mock('../../utils/cache/cache-manager.js', () => ({
@@ -41,9 +59,167 @@ vi.mock('../../utils/cache/cache-manager.js', () => ({
 }))
 
 const { ParlayModalHandler } = await import('../parlay-modal-handler.js')
+const { STALE_PARLAY_BUILDER_MESSAGE } = await import(
+	'../../services/ParlayBuilderService.js'
+)
 
 describe('ParlayModalHandler', () => {
 	beforeEach(() => vi.clearAllMocks())
+
+	it('parses the builder identity from a versioned modal', () => {
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		expect(
+			handler.parse({
+				customId: 'parlay.modal.sessionA0001.4.stake',
+			} as never),
+		).toEqual({
+			kind: 'some',
+			value: {
+				kind: 'stake',
+				sessionId: 'sessionA0001',
+				revision: 4,
+			},
+		})
+	})
+
+	it('rejects a legacy modal as stale', async () => {
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			reply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, { kind: 'legacy' })
+
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: STALE_PARLAY_BUILDER_MESSAGE,
+			flags: 64,
+		})
+		expect(builderService.setStake).not.toHaveBeenCalled()
+		expect(builderService.addLeg).not.toHaveBeenCalled()
+	})
+
+	it('passes the modal identity to the stake mutation', async () => {
+		const session = {
+			sessionId: 'sessionA0001',
+			revision: 5,
+			legs: [],
+			stake: 25,
+		}
+		builderService.setStake.mockResolvedValueOnce(session)
+		builderService.render.mockReturnValueOnce({ components: [] })
+		const message = { edit: vi.fn() }
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			fields: { getTextInputValue: vi.fn(() => '25') },
+			isFromMessage: vi.fn(() => true),
+			message,
+			replied: false,
+			deferred: false,
+			reply: vi.fn(),
+			deferReply: vi.fn(),
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			kind: 'stake',
+			sessionId: 'sessionA0001',
+			revision: 4,
+		})
+
+		expect(builderService.setStake).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 4 },
+			25,
+		)
+		expect(message.edit).toHaveBeenCalledWith({ components: [] })
+	})
+
+	it('reports a stale versioned modal without editing the builder message', async () => {
+		builderService.setStake.mockRejectedValueOnce(
+			new Error(STALE_PARLAY_BUILDER_MESSAGE),
+		)
+		const message = { edit: vi.fn() }
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			fields: { getTextInputValue: vi.fn(() => '25') },
+			isFromMessage: vi.fn(() => true),
+			message,
+			replied: false,
+			deferred: false,
+			reply: vi.fn(),
+			deferReply: vi.fn(),
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			kind: 'stake',
+			sessionId: 'sessionA0001',
+			revision: 4,
+		})
+
+		expect(message.edit).not.toHaveBeenCalled()
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: STALE_PARLAY_BUILDER_MESSAGE,
+			flags: 64,
+		})
+	})
+
+	it('passes the modal identity to the add-leg mutation', async () => {
+		const session = {
+			sessionId: 'sessionA0001',
+			revision: 5,
+			legs: [],
+			stake: null,
+		}
+		matchCache.getMatch.mockResolvedValueOnce({ id: 'event-1' })
+		builderService.addLeg.mockResolvedValueOnce(session)
+		builderService.render.mockReturnValueOnce({ components: [] })
+		const message = { edit: vi.fn() }
+		const values = {
+			parlay_game: ['event-1'],
+			parlay_market: ['totals'],
+			parlay_side: ['over'],
+		}
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			fields: {
+				getStringSelectValues: vi.fn(
+					(id: keyof typeof values) => values[id],
+				),
+			},
+			isFromMessage: vi.fn(() => true),
+			message,
+			replied: false,
+			deferred: false,
+			reply: vi.fn(),
+			deferReply: vi.fn(),
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			kind: 'add-leg',
+			sessionId: 'sessionA0001',
+			revision: 4,
+		})
+
+		expect(builderService.addLeg).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 4 },
+			{ matchId: 'event-1', marketKey: 'totals', side: 'over' },
+		)
+		expect(message.edit).toHaveBeenCalledWith({ components: [] })
+	})
 
 	it('reports modal validation errors ephemerally without overwriting the builder', async () => {
 		const message = { edit: vi.fn() }
@@ -61,7 +237,11 @@ describe('ParlayModalHandler', () => {
 		}
 		const handler = new ParlayModalHandler({} as never, {} as never)
 
-		await handler.run(interaction as never, { kind: 'stake' })
+		await handler.run(interaction as never, {
+			kind: 'stake',
+			sessionId: 'sessionA0001',
+			revision: 4,
+		})
 
 		expect(message.edit).not.toHaveBeenCalled()
 		expect(interaction.reply).toHaveBeenCalledWith({

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -12,9 +12,13 @@ import {
 	TextInputStyle,
 } from 'discord.js'
 import {
+	buildParlayModalId,
 	getParlayErrorMessage,
 	logParlayBuilderError,
+	type ParlayBuilderIdentity,
 	ParlayBuilderService,
+	parseParlayButtonId,
+	STALE_PARLAY_BUILDER_MESSAGE,
 } from '../services/ParlayBuilderService.js'
 import { BetsCacheService } from '../utils/api/common/bets/BetsCacheService.js'
 import { BetslipManager } from '../utils/api/Khronos/bets/BetslipsManager.js'
@@ -22,8 +26,6 @@ import BetslipWrapper from '../utils/api/Khronos/bets/betslip-wrapper.js'
 import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
 import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
 import { CacheManager } from '../utils/cache/cache-manager.js'
-
-const removeId = /^parlay_btn_remove_(\d+)$/
 
 export class ParlayButtonHandler extends InteractionHandler {
 	private readonly builderService = new ParlayBuilderService()
@@ -41,44 +43,64 @@ export class ParlayButtonHandler extends InteractionHandler {
 	}
 
 	public override async parse(interaction: ButtonInteraction) {
-		if (!interaction.customId.startsWith('parlay_btn_')) return this.none()
-		if (interaction.customId === 'parlay_btn_add') {
-			try {
-				await interaction.showModal(await this.buildAddLegModal())
-			} catch (error) {
-				logParlayBuilderError(error, {
-					action: 'open_add_leg_modal',
-					userId: interaction.user.id,
-				})
+		const control = parseParlayButtonId(interaction.customId)
+		if (!control) {
+			if (interaction.customId.startsWith('parlay_btn_')) {
 				await interaction.reply({
-					content:
-						error instanceof Error
-							? error.message
-							: 'No upcoming games are available right now.',
-					ephemeral: true,
+					content: STALE_PARLAY_BUILDER_MESSAGE,
+					flags: MessageFlags.Ephemeral,
 				})
 			}
 			return this.none()
 		}
-		if (interaction.customId === 'parlay_btn_stake') {
-			await interaction.showModal(this.buildStakeModal())
+		const identity = {
+			sessionId: control.sessionId,
+			revision: control.revision,
+		}
+		if (control.action === 'add' || control.action === 'stake') {
+			try {
+				if (!interaction.guildId) {
+					throw new Error(
+						'Parlays can only be built inside a server.',
+					)
+				}
+				await this.builderService.assertCurrent(
+					interaction.user.id,
+					interaction.guildId,
+					identity,
+				)
+				await interaction.showModal(
+					control.action === 'add'
+						? await this.buildAddLegModal(identity)
+						: this.buildStakeModal(identity),
+				)
+			} catch (error) {
+				logParlayBuilderError(error, {
+					action: `open_${control.action}_modal`,
+					userId: interaction.user.id,
+				})
+				await interaction.reply({
+					content: getParlayErrorMessage(error),
+					flags: MessageFlags.Ephemeral,
+				})
+			}
 			return this.none()
 		}
-		const removeMatch = removeId.exec(interaction.customId)
-		if (removeMatch) {
+		if (control.action === 'remove') {
 			await interaction.deferUpdate()
 			return this.some({
 				action: 'remove',
-				index: Number(removeMatch[1]),
+				index: control.index!,
+				...identity,
 			})
 		}
-		if (interaction.customId === 'parlay_btn_cancel') {
+		if (control.action === 'cancel') {
 			await interaction.deferUpdate()
-			return this.some({ action: 'cancel' })
+			return this.some({ action: 'cancel', ...identity })
 		}
-		if (interaction.customId === 'parlay_btn_confirm') {
+		if (control.action === 'confirm') {
 			await interaction.deferUpdate()
-			return this.some({ action: 'confirm' })
+			return this.some({ action: 'confirm', ...identity })
 		}
 		return this.none()
 	}
@@ -86,18 +108,22 @@ export class ParlayButtonHandler extends InteractionHandler {
 	public async run(
 		interaction: ButtonInteraction,
 		payload:
-			| { action: 'remove'; index: number }
-			| { action: 'cancel' }
-			| { action: 'confirm' },
+			| ({ action: 'remove'; index: number } & ParlayBuilderIdentity)
+			| ({ action: 'cancel' } & ParlayBuilderIdentity)
+			| ({ action: 'confirm' } & ParlayBuilderIdentity),
 	) {
 		const userId = interaction.user.id
 		const guildId = interaction.guildId
+		const expected = {
+			sessionId: payload.sessionId,
+			revision: payload.revision,
+		}
 		try {
 			if (!guildId) {
 				throw new Error('Parlays can only be built inside a server.')
 			}
 			if (payload.action === 'cancel') {
-				await this.builderService.clear(userId, guildId)
+				await this.builderService.clear(userId, guildId, expected)
 				return interaction.editReply(
 					this.builderService.renderMessage(
 						'Parlay builder cancelled.',
@@ -108,6 +134,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 				const session = await this.builderService.removeLeg(
 					userId,
 					guildId,
+					expected,
 					payload.index,
 				)
 				return interaction.editReply(
@@ -117,6 +144,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 			const reservation = await this.builderService.reserveForPlacement(
 				userId,
 				guildId,
+				expected,
 			)
 			if (!reservation) {
 				throw new Error(
@@ -209,7 +237,9 @@ export class ParlayButtonHandler extends InteractionHandler {
 		}
 	}
 
-	private async buildAddLegModal(): Promise<ModalBuilder> {
+	private async buildAddLegModal(
+		identity: ParlayBuilderIdentity,
+	): Promise<ModalBuilder> {
 		const matches = ((await this.matchCache.getMatches()) ?? [])
 			.filter((match) => match.id && match.home_team && match.away_team)
 			.filter(
@@ -245,7 +275,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 				})),
 			)
 		return new ModalBuilder()
-			.setCustomId('parlay_modal_add_leg')
+			.setCustomId(buildParlayModalId(identity, 'add-leg'))
 			.setTitle('Add a parlay leg')
 			.addLabelComponents(
 				new LabelBuilder()
@@ -286,9 +316,9 @@ export class ParlayButtonHandler extends InteractionHandler {
 			)
 	}
 
-	private buildStakeModal(): ModalBuilder {
+	private buildStakeModal(identity: ParlayBuilderIdentity): ModalBuilder {
 		return new ModalBuilder()
-			.setCustomId('parlay_modal_stake')
+			.setCustomId(buildParlayModalId(identity, 'stake'))
 			.setTitle('Set parlay stake')
 			.addLabelComponents(
 				new LabelBuilder()

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -23,7 +23,9 @@ import {
 import { BetsCacheService } from '../utils/api/common/bets/BetsCacheService.js'
 import { BetslipManager } from '../utils/api/Khronos/bets/BetslipsManager.js'
 import BetslipWrapper from '../utils/api/Khronos/bets/betslip-wrapper.js'
-import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+import ParlayApiWrapper, {
+	type ParlayResponse,
+} from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
 import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
 import { CacheManager } from '../utils/cache/cache-manager.js'
 
@@ -118,11 +120,46 @@ export class ParlayButtonHandler extends InteractionHandler {
 			sessionId: payload.sessionId,
 			revision: payload.revision,
 		}
+		let placementToken: string | undefined
+		let leaseHeartbeat: NodeJS.Timeout | undefined
 		try {
 			if (!guildId) {
 				throw new Error('Parlays can only be built inside a server.')
 			}
 			if (payload.action === 'cancel') {
+				const session = await this.builderService.assertCurrent(
+					userId,
+					guildId,
+					expected,
+				)
+				if (
+					session.placementPhase === 'placing' ||
+					session.placementPhase === 'unknown'
+				) {
+					const placed = await this.parlayApi.findByPlacement(
+						session.placementId,
+					)
+					if (placed) {
+						return this.finishPlacement(
+							interaction,
+							userId,
+							guildId,
+							expected,
+							placed,
+						)
+					}
+					if (session.placementPhase === 'placing') {
+						throw new Error(
+							'Your parlay placement is still being reconciled. Please wait for the result.',
+						)
+					}
+					await this.builderService.setPlacementState(
+						userId,
+						guildId,
+						expected,
+						'editing',
+					)
+				}
 				await this.builderService.clear(userId, guildId, expected)
 				return interaction.editReply(
 					this.builderService.renderMessage(
@@ -141,6 +178,48 @@ export class ParlayButtonHandler extends InteractionHandler {
 					this.builderService.render(session),
 				)
 			}
+			let current = await this.builderService.assertCurrent(
+				userId,
+				guildId,
+				expected,
+			)
+			if (
+				current.placementPhase === 'placed' &&
+				current.lastPlacementResponse
+			) {
+				return this.finishPlacement(
+					interaction,
+					userId,
+					guildId,
+					expected,
+					current.lastPlacementResponse,
+				)
+			}
+			if (current.placementPhase === 'unknown') {
+				const placed = await this.parlayApi.findByPlacement(
+					current.placementId,
+				)
+				if (placed) {
+					return this.finishPlacement(
+						interaction,
+						userId,
+						guildId,
+						expected,
+						placed,
+					)
+				}
+				current = await this.builderService.setPlacementState(
+					userId,
+					guildId,
+					expected,
+					'editing',
+				)
+			}
+			if (current.placementPhase === 'placing') {
+				throw new Error(
+					'Your parlay is already being placed. Please wait for the result.',
+				)
+			}
 			const reservation = await this.builderService.reserveForPlacement(
 				userId,
 				guildId,
@@ -152,6 +231,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 				)
 			}
 			const { session, token } = reservation
+			placementToken = token
 			let leaseLost = false
 			const assertPlacementLease = async () => {
 				if (leaseLost) {
@@ -171,7 +251,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 					)
 				}
 			}
-			const leaseHeartbeat = setInterval(() => {
+			leaseHeartbeat = setInterval(() => {
 				void assertPlacementLease().catch((error) =>
 					logParlayBuilderError(error, {
 						action: 'refresh_placement_reservation',
@@ -180,6 +260,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 				)
 			}, 30_000)
 			leaseHeartbeat.unref?.()
+			let placementRequested = false
 			try {
 				await assertPlacementLease()
 				this.builderService.validateForPlacement(session)
@@ -193,39 +274,67 @@ export class ParlayButtonHandler extends InteractionHandler {
 					user_id: userId,
 				})
 				await assertPlacementLease()
+				placementRequested = true
 				const placed = await this.parlayApi.place(
 					initialized.init_token,
+					session.placementId,
 				)
-				await assertPlacementLease()
-				await new BetslipManager(
-					new BetslipWrapper(),
-					new BetsCacheService(new CacheManager()),
-				).announceParlayPlaced(interaction, {
-					parlayId: placed.id,
-					legCount: placed.leg_count,
-					stake: Number(placed.stake),
-					potentialPayout: Number(placed.potential_payout),
-				})
-				await this.builderService.clearWithPlacementToken(
+				return this.finishPlacement(
+					interaction,
 					userId,
 					guildId,
+					expected,
+					placed,
 					token,
 				)
-				return interaction.editReply(
-					this.builderService.renderMessage(
-						`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
-						0x57f287,
-					),
-				)
 			} catch (error) {
+				if (!placementRequested) {
+					await this.builderService.setPlacementState(
+						userId,
+						guildId,
+						expected,
+						'editing',
+					)
+					throw error
+				}
+				await this.builderService.setPlacementState(
+					userId,
+					guildId,
+					expected,
+					'unknown',
+				)
+				try {
+					const placed = await this.parlayApi.findByPlacement(
+						session.placementId,
+					)
+					if (placed) {
+						return this.finishPlacement(
+							interaction,
+							userId,
+							guildId,
+							expected,
+							placed,
+							token,
+						)
+					}
+				} catch (reconciliationError) {
+					logParlayBuilderError(reconciliationError, {
+						action: 'reconcile_placement',
+						userId,
+					})
+					throw new Error(
+						'Your parlay placement is still being reconciled. Do not confirm again yet.',
+					)
+				}
+				await this.builderService.setPlacementState(
+					userId,
+					guildId,
+					expected,
+					'editing',
+				)
 				throw error
 			} finally {
 				clearInterval(leaseHeartbeat)
-				await this.builderService.releasePlacement(
-					userId,
-					guildId,
-					token,
-				)
 			}
 		} catch (error) {
 			logParlayBuilderError(error, { action: payload.action, userId })
@@ -234,7 +343,83 @@ export class ParlayButtonHandler extends InteractionHandler {
 				...this.builderService.renderMessage(message),
 				flags: MessageFlags.IsComponentsV2,
 			})
+		} finally {
+			if (leaseHeartbeat) clearInterval(leaseHeartbeat)
+			if (placementToken) {
+				try {
+					await this.builderService.releasePlacement(
+						userId,
+						guildId!,
+						placementToken,
+					)
+				} catch (error) {
+					logParlayBuilderError(error, {
+						action: 'release_placement_reservation',
+						userId,
+					})
+				}
+			}
 		}
+	}
+
+	private async finishPlacement(
+		interaction: ButtonInteraction,
+		userId: string,
+		guildId: string,
+		expected: ParlayBuilderIdentity,
+		placed: ParlayResponse,
+		placementToken?: string,
+	) {
+		try {
+			await this.builderService.setPlacementState(
+				userId,
+				guildId,
+				expected,
+				'placed',
+				placed,
+			)
+		} catch (error) {
+			logParlayBuilderError(error, {
+				action: 'persist_placed_parlay',
+				userId,
+			})
+		}
+		try {
+			await new BetslipManager(
+				new BetslipWrapper(),
+				new BetsCacheService(new CacheManager()),
+			).announceParlayPlaced(interaction, {
+				parlayId: placed.id,
+				legCount: placed.leg_count,
+				stake: Number(placed.stake),
+				potentialPayout: Number(placed.potential_payout),
+			})
+		} catch (error) {
+			logParlayBuilderError(error, {
+				action: 'announce_placed_parlay',
+				userId,
+			})
+		}
+		if (placementToken) {
+			try {
+				await this.builderService.clearWithPlacementToken(
+					userId,
+					guildId,
+					placementToken,
+				)
+			} catch (error) {
+				logParlayBuilderError(error, {
+					action: 'clear_placed_parlay_builder',
+					userId,
+				})
+			}
+		}
+		return interaction.editReply(
+			this.builderService.renderMessage(
+				`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
+				0x57f287,
+			),
+		)
 	}
 
 	private async buildAddLegModal(

--- a/src/interaction-handlers/parlay-modal-handler.ts
+++ b/src/interaction-handlers/parlay-modal-handler.ts
@@ -6,7 +6,11 @@ import { MessageFlags, type ModalSubmitInteraction } from 'discord.js'
 import {
 	getParlayErrorMessage,
 	logParlayBuilderError,
+	type ParlayBuilderIdentity,
 	ParlayBuilderService,
+	type ParlayModalKind,
+	parseParlayModalId,
+	STALE_PARLAY_BUILDER_MESSAGE,
 } from '../services/ParlayBuilderService.js'
 import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
 import { CacheManager } from '../utils/cache/cache-manager.js'
@@ -26,19 +30,26 @@ export class ParlayModalHandler extends InteractionHandler {
 	}
 
 	public override parse(interaction: ModalSubmitInteraction) {
-		if (!interaction.customId.startsWith('parlay_modal_'))
-			return this.none()
-		const kind = interaction.customId.replace('parlay_modal_', '')
-		if (kind !== 'add_leg' && kind !== 'stake') return this.none()
-		return this.some({
-			kind,
-		})
+		const parsed = parseParlayModalId(interaction.customId)
+		if (parsed) return this.some(parsed)
+		if (interaction.customId.startsWith('parlay_modal_')) {
+			return this.some({ kind: 'legacy' as const })
+		}
+		return this.none()
 	}
 
 	public async run(
 		interaction: ModalSubmitInteraction,
-		payload: { kind: 'add_leg' | 'stake' },
+		payload:
+			| ({ kind: ParlayModalKind } & ParlayBuilderIdentity)
+			| { kind: 'legacy' },
 	) {
+		if (payload.kind === 'legacy') {
+			return interaction.reply({
+				content: STALE_PARLAY_BUILDER_MESSAGE,
+				flags: MessageFlags.Ephemeral,
+			})
+		}
 		const userId = interaction.user.id
 		const guildId = interaction.guildId
 		if (!guildId) {
@@ -64,6 +75,10 @@ export class ParlayModalHandler extends InteractionHandler {
 			return interaction.editReply(options)
 		}
 		try {
+			const expected = {
+				sessionId: payload.sessionId,
+				revision: payload.revision,
+			}
 			if (payload.kind === 'stake') {
 				const rawStake = interaction.fields
 					.getTextInputValue('parlay_stake')
@@ -73,6 +88,7 @@ export class ParlayModalHandler extends InteractionHandler {
 				const session = await this.builderService.setStake(
 					userId,
 					guildId,
+					expected,
 					Number(rawStake),
 				)
 				return updateBuilder(this.builderService.render(session))
@@ -107,11 +123,16 @@ export class ParlayModalHandler extends InteractionHandler {
 			) {
 				throw new Error('Totals require Over or Under.')
 			}
-			const session = await this.builderService.addLeg(userId, guildId, {
-				matchId: gameId,
-				marketKey,
-				side,
-			})
+			const session = await this.builderService.addLeg(
+				userId,
+				guildId,
+				expected,
+				{
+					matchId: gameId,
+					marketKey,
+					side,
+				},
+			)
 			return updateBuilder(this.builderService.render(session))
 		} catch (error) {
 			logParlayBuilderError(error, { userId, modal: payload.kind })

--- a/src/lib/startup/__tests__/env.test.ts
+++ b/src/lib/startup/__tests__/env.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const requiredEnv = {
+	NODE_ENV: 'development',
+	TOKEN: 'discord-token',
+	PREFIX: '!',
+	PROJECT_VERSION: 'test',
+	KH_API_URL: 'http://khronos:3000',
+	KH_API_TOKEN: 'kh-token',
+	R_HOST: 'redis',
+	R_PORT: '6379',
+	R_DB: '0',
+	R_PASS: 'redis-pass',
+	API_URL: 'http://pluto:2090',
+	API_KEY: 'api-key',
+	PATREON_API_URL: 'http://patreon:3000',
+	KH_PLUTO_CLIENT_KEY: 'client-key',
+	APP_OWNER_ID: 'owner',
+	AXIOM_DATASET: 'dataset',
+	AXIOM_API_TOKEN: 'axiom-token',
+	AXIOM_ORG_ID: 'org',
+	BULL_BOARD_USERNAME: 'admin',
+	BULL_BOARD_PASSWORD: 'password',
+	LOKI_URL: 'http://loki:3100',
+	LOKI_USER: 'loki',
+	LOKI_PASS: 'loki-pass',
+}
+
+for (const [key, value] of Object.entries(requiredEnv)) {
+	vi.stubEnv(key, value)
+}
+
+const { isSystemStartupMode, parseStartupEnv } = await import('../env.js')
+
+describe('Pluto system startup env gate', () => {
+	it('cannot activate system mode in production', () => {
+		expect(() =>
+			parseStartupEnv({
+				...requiredEnv,
+				NODE_ENV: 'production',
+				PLUTO_SYSTEM_MODE: '1',
+				PLUTO_SYSTEM_ALLOW: '1',
+			}),
+		).toThrow(/PLUTO_SYSTEM_MODE cannot be enabled/)
+	})
+
+	it('activates system mode only when both system flags are set outside production', () => {
+		const env = parseStartupEnv({
+			...requiredEnv,
+			TOKEN: undefined,
+			PLUTO_SYSTEM_MODE: '1',
+			PLUTO_SYSTEM_ALLOW: '1',
+		})
+
+		expect(isSystemStartupMode(env)).toBe(true)
+		expect(env.TOKEN).toBeUndefined()
+	})
+
+	it('keeps TOKEN required for normal production startup', () => {
+		expect(() =>
+			parseStartupEnv({
+				...requiredEnv,
+				NODE_ENV: 'production',
+				TOKEN: undefined,
+			}),
+		).toThrow(/TOKEN is required/)
+	})
+})

--- a/src/lib/startup/__tests__/pluto.test.ts
+++ b/src/lib/startup/__tests__/pluto.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ParsedStartupEnv } from '../env.js'
+
+const baseEnv: ParsedStartupEnv = {
+	NODE_ENV: 'development',
+	TOKEN: 'discord-token',
+	PREFIX: '!',
+	PROJECT_VERSION: 'test',
+	KH_API_URL: 'http://khronos:3000',
+	KH_API_TOKEN: 'kh-token',
+	R_HOST: 'redis',
+	R_PORT: 6379,
+	R_DB: 0,
+	R_PASS: 'redis-pass',
+	API_PORT: 2090,
+	API_URL: 'http://pluto:2090',
+	LOG_LEVEL: 'Info',
+	PATREON_API_URL: 'http://patreon:3000',
+	KH_PLUTO_CLIENT_KEY: 'client-key',
+	APP_OWNER_ID: 'owner',
+	AXIOM_DATASET: 'dataset',
+	AXIOM_API_TOKEN: 'axiom-token',
+	AXIOM_ORG_ID: 'org',
+	BULL_BOARD_USERNAME: 'admin',
+	BULL_BOARD_PASSWORD: 'password',
+	API_KEY: 'api-key',
+	LOKI_URL: 'http://loki:3100',
+	LOKI_USER: 'loki',
+	LOKI_PASS: 'loki-pass',
+	MAINTENANCE_MODE: false,
+	USE_MOCK_DATA: false,
+	MOCK_GUILD_SPORT: 'nba',
+	ANNOUNCE_PAYOUT_THRESHOLD: 100,
+	ANNOUNCE_MAX_PER_HOUR: 5,
+	BIG_WIN_ANNOUNCEMENTS_ENABLED: true,
+	RECAP_CRON: '0 9 * * 1',
+	RECAP_ENABLED: true,
+	RECAP_GUILD_IDS: '',
+	PLUTO_SYSTEM_MODE: false,
+	PLUTO_SYSTEM_ALLOW: false,
+}
+
+vi.mock('../env.js', () => ({
+	default: {},
+	isSystemStartupMode: (env: ParsedStartupEnv) =>
+		env.PLUTO_SYSTEM_MODE &&
+		env.PLUTO_SYSTEM_ALLOW &&
+		env.NODE_ENV !== 'production',
+}))
+
+vi.mock('../../../utils/api/routes/notifications/delivery-queue.js', () => ({
+	configureSystemNotificationDelivery: vi.fn(),
+	resetNotificationDeliveryQueue: vi.fn(),
+}))
+
+vi.mock('../../../utils/logging/WinstonLogger.js', () => ({
+	logger: { info: vi.fn(), error: vi.fn() },
+}))
+
+const { startPluto } = await import('../pluto.js')
+
+describe('Pluto startup orchestration', () => {
+	it('does not call Discord gateway login in system mode', async () => {
+		const client = {
+			login: vi.fn(),
+			destroy: vi.fn(),
+			logger: { fatal: vi.fn() },
+		}
+		const initializeSystemStartupServices = vi.fn(async () => undefined)
+
+		await startPluto({
+			client,
+			env: {
+				...baseEnv,
+				TOKEN: undefined,
+				PLUTO_SYSTEM_MODE: true,
+				PLUTO_SYSTEM_ALLOW: true,
+			},
+			initializeSystemStartupServices,
+			initializeStartupServices: vi.fn(async () => undefined),
+			exitProcess: vi.fn(),
+		})
+
+		expect(initializeSystemStartupServices).toHaveBeenCalledOnce()
+		expect(client.login).not.toHaveBeenCalled()
+		expect(client.destroy).not.toHaveBeenCalled()
+	})
+
+	it('still calls Discord gateway login for normal startup', async () => {
+		const client = {
+			login: vi.fn(async () => 'ready'),
+			destroy: vi.fn(),
+			logger: { fatal: vi.fn() },
+		}
+
+		await startPluto({
+			client,
+			env: baseEnv,
+			initializeStartupServices: vi.fn(async () => undefined),
+			initializeSystemStartupServices: vi.fn(async () => undefined),
+			exitProcess: vi.fn(),
+		})
+
+		expect(client.login).toHaveBeenCalledWith('discord-token')
+	})
+})

--- a/src/lib/startup/env.ts
+++ b/src/lib/startup/env.ts
@@ -1,25 +1,32 @@
 import { z } from 'zod'
 
+const envFlag = (value: unknown): boolean =>
+	value === true || value === 'true' || value === '1'
+
+const optionalNonEmptyString = z.preprocess(
+	(value) => (value === '' ? undefined : value),
+	z.string().min(1).optional(),
+)
+
+const requiredString = (message: string) => z.string().min(1, { message })
+
 // Define the schema for our environment variables
 const envSchema = z
 	.object({
-		NODE_ENV: z.enum(['development', 'production']),
-		TOKEN: z
-			.string()
-			.min(1, {
-				message: 'TOKEN is required for Discord bot authentication',
-			})
-			.describe('Discord bot token used for authentication'),
+		NODE_ENV: z.enum(['development', 'production', 'test']),
+		TOKEN: optionalNonEmptyString.describe(
+			'Discord bot token used for authentication',
+		),
 		PREFIX: z.string(),
 		PROJECT_VERSION: z.string(),
 		KH_API_URL: z.url(),
-		KH_API_TOKEN: z.string().min(1, {
-			message: 'KH_API_TOKEN is required for Khronos API authentication',
-		}),
+		KH_API_TOKEN: requiredString(
+			'KH_API_TOKEN is required for Khronos API authentication',
+		),
 		R_HOST: z.string(),
 		R_PORT: z.number().int().positive(),
 		R_DB: z.number().int().nonnegative(),
-		R_PASS: z.string().min(1, { message: 'R_PASS is required' }),
+		R_PASS: requiredString('R_PASS is required'),
 		API_PORT: z.number().int().positive(),
 		API_URL: z.string().url().min(1, { message: 'API_URL is required' }),
 		LOG_LEVEL: z.enum(['Trace', 'Debug', 'Info', 'Warn', 'Error', 'Fatal']),
@@ -27,28 +34,21 @@ const envSchema = z
 			.string()
 			.url()
 			.min(1, { message: 'PATREON_API_URL is required' }),
-		KH_PLUTO_CLIENT_KEY: z.string().min(1, {
-			message:
-				'KH_PLUTO_CLIENT_KEY is required for Khronos API authentication',
-		}),
+		KH_PLUTO_CLIENT_KEY: requiredString(
+			'KH_PLUTO_CLIENT_KEY is required for Khronos API authentication',
+		),
 		APP_OWNER_ID: z.string(),
 		AXIOM_DATASET: z.string(),
-		AXIOM_API_TOKEN: z.string().min(1, {
-			message: 'AXIOM_API_TOKEN is required for Axiom logging',
-		}),
+		AXIOM_API_TOKEN: requiredString(
+			'AXIOM_API_TOKEN is required for Axiom logging',
+		),
 		AXIOM_ORG_ID: z.string(),
-		BULL_BOARD_USERNAME: z
-			.string()
-			.min(1, { message: 'BULL_BOARD_USERNAME is required' }),
-		BULL_BOARD_PASSWORD: z
-			.string()
-			.min(1, { message: 'BULL_BOARD_PASSWORD is required' }),
-		API_KEY: z
-			.string()
-			.min(1, { message: 'API_KEY is required for API authentication' }),
+		BULL_BOARD_USERNAME: requiredString('BULL_BOARD_USERNAME is required'),
+		BULL_BOARD_PASSWORD: requiredString('BULL_BOARD_PASSWORD is required'),
+		API_KEY: requiredString('API_KEY is required for API authentication'),
 		LOKI_URL: z.string(),
-		LOKI_USER: z.string().min(1, { message: 'LOKI_USER is required' }),
-		LOKI_PASS: z.string().min(1, { message: 'LOKI_PASS is required' }),
+		LOKI_USER: requiredString('LOKI_USER is required'),
+		LOKI_PASS: requiredString('LOKI_PASS is required'),
 		MAINTENANCE_MODE: z.boolean(),
 		USE_MOCK_DATA: z.boolean().default(false),
 		MOCK_GUILD_BETTING_CHAN_ID: z.string().optional(),
@@ -65,8 +65,41 @@ const envSchema = z
 		RECAP_CHANNEL_ID: z.string().optional(),
 		RECAP_ENABLED: z.boolean().default(true),
 		RECAP_GUILD_IDS: z.string().default(''),
+		PLUTO_SYSTEM_MODE: z.boolean().default(false),
+		PLUTO_SYSTEM_ALLOW: z.boolean().default(false),
 	})
 	.superRefine((data, ctx) => {
+		const systemFlagsSet = data.PLUTO_SYSTEM_MODE && data.PLUTO_SYSTEM_ALLOW
+		// Hermetic XR/system boot requires both flags and NODE_ENV != production:
+		// PLUTO_SYSTEM_MODE=1 PLUTO_SYSTEM_ALLOW=1 NODE_ENV=development|test.
+		if (
+			data.NODE_ENV === 'production' &&
+			(data.PLUTO_SYSTEM_MODE || data.PLUTO_SYSTEM_ALLOW)
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['PLUTO_SYSTEM_MODE'],
+				message:
+					'PLUTO_SYSTEM_MODE cannot be enabled when NODE_ENV=production',
+			})
+		}
+		if (data.PLUTO_SYSTEM_MODE !== data.PLUTO_SYSTEM_ALLOW) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['PLUTO_SYSTEM_ALLOW'],
+				message:
+					'PLUTO_SYSTEM_MODE and PLUTO_SYSTEM_ALLOW must both be enabled for system startup',
+			})
+		}
+		const systemModeActive =
+			systemFlagsSet && data.NODE_ENV !== 'production'
+		if (!systemModeActive && !data.TOKEN) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['TOKEN'],
+				message: 'TOKEN is required for Discord bot authentication',
+			})
+		}
 		if (data.USE_MOCK_DATA && data.NODE_ENV === 'production') {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
@@ -95,52 +128,70 @@ const envSchema = z
 		}
 	})
 
+export type ParsedStartupEnv = z.infer<typeof envSchema>
+
+export function parseStartupEnv(
+	source: NodeJS.ProcessEnv = process.env,
+): ParsedStartupEnv {
+	return envSchema.parse({
+		NODE_ENV: source.NODE_ENV,
+		TOKEN: source.TOKEN,
+		PREFIX: source.PREFIX,
+		PROJECT_VERSION: source.PROJECT_VERSION,
+		KH_API_URL: source.KH_API_URL,
+		KH_API_TOKEN: source.KH_API_TOKEN,
+		R_HOST: source.R_HOST,
+		R_PORT: Number.parseInt(source.R_PORT || '6379', 10),
+		R_DB: Number.parseInt(source.R_DB || '0', 10),
+		R_PASS: source.R_PASS,
+		API_PORT: Number.parseInt(source.APIPORT || '2090', 10),
+		API_URL: source.API_URL,
+		LOG_LEVEL: source.LOG_LEVEL || 'Info',
+		PATREON_API_URL: source.PATREON_API_URL,
+		KH_PLUTO_CLIENT_KEY: source.KH_PLUTO_CLIENT_KEY,
+		APP_OWNER_ID: source.APP_OWNER_ID,
+		AXIOM_DATASET: source.AXIOM_DATASET,
+		AXIOM_API_TOKEN: source.AXIOM_API_TOKEN,
+		AXIOM_ORG_ID: source.AXIOM_ORG_ID,
+		BULL_BOARD_USERNAME: source.BULL_BOARD_USERNAME,
+		BULL_BOARD_PASSWORD: source.BULL_BOARD_PASSWORD,
+		API_KEY: source.API_KEY,
+		LOKI_URL: source.LOKI_URL,
+		LOKI_USER: source.LOKI_USER,
+		LOKI_PASS: source.LOKI_PASS,
+		MAINTENANCE_MODE: envFlag(source.MAINTENANCE_MODE),
+		USE_MOCK_DATA: envFlag(source.USE_MOCK_DATA),
+		MOCK_GUILD_BETTING_CHAN_ID: source.MOCK_GUILD_BETTING_CHAN_ID,
+		DEV_GUILD_GAMES_CATEGORY_ID: source.DEV_GUILD_GAMES_CATEGORY_ID,
+		MOCK_GUILD_SPORT: source.MOCK_GUILD_SPORT || 'nba',
+		ANNOUNCE_PAYOUT_THRESHOLD: Number.parseFloat(
+			source.ANNOUNCE_PAYOUT_THRESHOLD || '100',
+		),
+		ANNOUNCE_MAX_PER_HOUR: Number.parseInt(
+			source.ANNOUNCE_MAX_PER_HOUR || '5',
+			10,
+		),
+		BIG_WIN_ANNOUNCEMENTS_ENABLED:
+			source.BIG_WIN_ANNOUNCEMENTS_ENABLED !== 'false',
+		RECAP_CRON: source.RECAP_CRON,
+		RECAP_CHANNEL_ID: source.RECAP_CHANNEL_ID,
+		RECAP_ENABLED: source.RECAP_ENABLED !== 'false',
+		RECAP_GUILD_IDS: source.RECAP_GUILD_IDS || source.GUILD_ID || '',
+		PLUTO_SYSTEM_MODE: envFlag(source.PLUTO_SYSTEM_MODE),
+		PLUTO_SYSTEM_ALLOW: envFlag(source.PLUTO_SYSTEM_ALLOW),
+	})
+}
+
+export function isSystemStartupMode(env: ParsedStartupEnv): boolean {
+	return (
+		env.PLUTO_SYSTEM_MODE &&
+		env.PLUTO_SYSTEM_ALLOW &&
+		env.NODE_ENV !== 'production'
+	)
+}
+
 // Parse and validate the environment variables
-const env = envSchema.parse({
-	NODE_ENV: process.env.NODE_ENV,
-	TOKEN: process.env.TOKEN,
-	PREFIX: process.env.PREFIX,
-	PROJECT_VERSION: process.env.PROJECT_VERSION,
-	KH_API_URL: process.env.KH_API_URL,
-	KH_API_TOKEN: process.env.KH_API_TOKEN,
-	R_HOST: process.env.R_HOST,
-	R_PORT: Number.parseInt(process.env.R_PORT || '6379', 10),
-	R_DB: Number.parseInt(process.env.R_DB || '0', 10),
-	R_PASS: process.env.R_PASS,
-	API_PORT: Number.parseInt(process.env.APIPORT || '2090', 10),
-	API_URL: process.env.API_URL,
-	LOG_LEVEL: process.env.LOG_LEVEL || 'Info',
-	PATREON_API_URL: process.env.PATREON_API_URL,
-	KH_PLUTO_CLIENT_KEY: process.env.KH_PLUTO_CLIENT_KEY,
-	APP_OWNER_ID: process.env.APP_OWNER_ID,
-	AXIOM_DATASET: process.env.AXIOM_DATASET,
-	AXIOM_API_TOKEN: process.env.AXIOM_API_TOKEN,
-	AXIOM_ORG_ID: process.env.AXIOM_ORG_ID,
-	BULL_BOARD_USERNAME: process.env.BULL_BOARD_USERNAME,
-	BULL_BOARD_PASSWORD: process.env.BULL_BOARD_PASSWORD,
-	API_KEY: process.env.API_KEY,
-	LOKI_URL: process.env.LOKI_URL,
-	LOKI_USER: process.env.LOKI_USER,
-	LOKI_PASS: process.env.LOKI_PASS,
-	MAINTENANCE_MODE: process.env.MAINTENANCE_MODE === 'true',
-	USE_MOCK_DATA: process.env.USE_MOCK_DATA === 'true',
-	MOCK_GUILD_BETTING_CHAN_ID: process.env.MOCK_GUILD_BETTING_CHAN_ID,
-	DEV_GUILD_GAMES_CATEGORY_ID: process.env.DEV_GUILD_GAMES_CATEGORY_ID,
-	MOCK_GUILD_SPORT: process.env.MOCK_GUILD_SPORT || 'nba',
-	ANNOUNCE_PAYOUT_THRESHOLD: Number.parseFloat(
-		process.env.ANNOUNCE_PAYOUT_THRESHOLD || '100',
-	),
-	ANNOUNCE_MAX_PER_HOUR: Number.parseInt(
-		process.env.ANNOUNCE_MAX_PER_HOUR || '5',
-		10,
-	),
-	BIG_WIN_ANNOUNCEMENTS_ENABLED:
-		process.env.BIG_WIN_ANNOUNCEMENTS_ENABLED !== 'false',
-	RECAP_CRON: process.env.RECAP_CRON,
-	RECAP_CHANNEL_ID: process.env.RECAP_CHANNEL_ID,
-	RECAP_ENABLED: process.env.RECAP_ENABLED !== 'false',
-	RECAP_GUILD_IDS: process.env.RECAP_GUILD_IDS || process.env.GUILD_ID || '',
-})
+const env = parseStartupEnv()
 
 // Debug logging for environment validation (redacts sensitive values)
 const shouldLogDebug =
@@ -166,6 +217,8 @@ if (shouldLogDebug) {
 		LOKI_USER: env.LOKI_USER,
 		MAINTENANCE_MODE: env.MAINTENANCE_MODE,
 		USE_MOCK_DATA: env.USE_MOCK_DATA,
+		PLUTO_SYSTEM_MODE: env.PLUTO_SYSTEM_MODE,
+		PLUTO_SYSTEM_ALLOW: env.PLUTO_SYSTEM_ALLOW,
 		MOCK_GUILD_BETTING_CHAN_ID: env.MOCK_GUILD_BETTING_CHAN_ID,
 		DEV_GUILD_GAMES_CATEGORY_ID: env.DEV_GUILD_GAMES_CATEGORY_ID,
 		MOCK_GUILD_SPORT: env.MOCK_GUILD_SPORT,

--- a/src/lib/startup/pluto.ts
+++ b/src/lib/startup/pluto.ts
@@ -1,0 +1,82 @@
+import { configureSystemNotificationDelivery } from '../../utils/api/routes/notifications/delivery-queue.js'
+import { logger } from '../../utils/logging/WinstonLogger.js'
+import env, { isSystemStartupMode, type ParsedStartupEnv } from './env.js'
+
+interface StartupClient {
+	login(token: string): Promise<unknown>
+	destroy(): void
+	logger: {
+		fatal(error: unknown): unknown
+	}
+}
+
+export interface StartPlutoOptions {
+	client: StartupClient
+	env?: ParsedStartupEnv
+	initializeStartupServices?: () => Promise<void>
+	initializeSystemStartupServices?: () => Promise<void>
+	exitProcess?: (code: number) => never | void
+}
+
+async function initializeRedisBackedStartupServices() {
+	// These modules intentionally start Koa, Redis queues, and cron workers when
+	// loaded, so startup keeps the side-effect imports behind the explicit boot step.
+	await import('./cache.js')
+	await import('../../utils/api/Khronos/KhronosInstances.js')
+	await import('../../utils/api/koa/index.js')
+	await import('../../utils/cache/queue/ChannelCreationQueue.js')
+	await import('../../utils/cron/index.js')
+}
+
+export async function initializeStartupServices(
+	startupEnv: ParsedStartupEnv = env,
+) {
+	if (startupEnv.USE_MOCK_DATA) {
+		logger.info({
+			message:
+				'Mock data mode enabled; skipping Redis-backed startup services',
+			source: 'startup:mock-data',
+		})
+		return
+	}
+
+	await initializeRedisBackedStartupServices()
+}
+
+export async function initializeSystemStartupServices() {
+	configureSystemNotificationDelivery()
+	await initializeRedisBackedStartupServices()
+}
+
+export async function startPluto({
+	client,
+	env: startupEnv = env,
+	initializeStartupServices: initializeServices = () =>
+		initializeStartupServices(startupEnv),
+	initializeSystemStartupServices:
+		initializeSystemServices = initializeSystemStartupServices,
+	exitProcess = process.exit,
+}: StartPlutoOptions): Promise<void> {
+	try {
+		if (isSystemStartupMode(startupEnv)) {
+			await initializeSystemServices()
+			logger.info({
+				message:
+					'Pluto system mode is up without Discord gateway login',
+				source: 'startup:system',
+			})
+			return
+		}
+
+		await initializeServices()
+		await client.login(startupEnv.TOKEN)
+		logger.info('Pluto is up and running!')
+	} catch (error) {
+		logger.error({
+			message: 'Failed to login',
+		})
+		client.logger.fatal(error)
+		client.destroy()
+		exitProcess(1)
+	}
+}

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { randomBytes, randomUUID } from 'node:crypto'
 import {
 	ActionRowBuilder,
 	ButtonBuilder,
@@ -31,8 +31,91 @@ export interface ParlayBuilderLeg extends ParlayLegInput {
 }
 
 export interface ParlayBuilderSession {
+	sessionId: string
+	revision: number
 	legs: ParlayBuilderLeg[]
 	stake: number | null
+}
+
+export type ParlayBuilderIdentity = Pick<
+	ParlayBuilderSession,
+	'sessionId' | 'revision'
+>
+
+export type ParlayButtonAction =
+	| 'add'
+	| 'stake'
+	| 'confirm'
+	| 'cancel'
+	| 'remove'
+
+export type ParlayModalKind = 'add-leg' | 'stake'
+
+export const STALE_PARLAY_BUILDER_MESSAGE =
+	'This parlay builder is no longer current. Use the latest builder or run `/parlay` again.'
+
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{12}$/
+const BUTTON_ID_PATTERN =
+	/^parlay\.btn\.([A-Za-z0-9_-]{12})\.(0|[1-9]\d*)\.(add|stake|confirm|cancel|remove)(?:\.(0|[1-9]\d*))?$/
+const MODAL_ID_PATTERN =
+	/^parlay\.modal\.([A-Za-z0-9_-]{12})\.(0|[1-9]\d*)\.(add-leg|stake)$/
+
+export function parlayIdentity(
+	session: ParlayBuilderSession,
+): ParlayBuilderIdentity {
+	return { sessionId: session.sessionId, revision: session.revision }
+}
+
+export function buildParlayButtonId(
+	identity: ParlayBuilderIdentity,
+	action: ParlayButtonAction,
+	index?: number,
+): string {
+	if (action === 'remove') {
+		if (!Number.isSafeInteger(index) || Number(index) < 0) {
+			throw new Error('Remove controls require a nonnegative leg index.')
+		}
+		return `parlay.btn.${identity.sessionId}.${identity.revision}.${action}.${index}`
+	}
+	return `parlay.btn.${identity.sessionId}.${identity.revision}.${action}`
+}
+
+export function parseParlayButtonId(customId: string):
+	| (ParlayBuilderIdentity & {
+			action: ParlayButtonAction
+			index?: number
+	  })
+	| null {
+	const match = BUTTON_ID_PATTERN.exec(customId)
+	if (!match) return null
+	const action = match[3] as ParlayButtonAction
+	const index = match[4] === undefined ? undefined : Number(match[4])
+	if ((action === 'remove') !== (index !== undefined)) return null
+	return {
+		sessionId: match[1],
+		revision: Number(match[2]),
+		action,
+		...(index === undefined ? {} : { index }),
+	}
+}
+
+export function buildParlayModalId(
+	identity: ParlayBuilderIdentity,
+	kind: ParlayModalKind,
+): string {
+	return `parlay.modal.${identity.sessionId}.${identity.revision}.${kind}`
+}
+
+export function parseParlayModalId(
+	customId: string,
+): (ParlayBuilderIdentity & { kind: ParlayModalKind }) | null {
+	const match = MODAL_ID_PATTERN.exec(customId)
+	if (!match) return null
+	return {
+		sessionId: match[1],
+		revision: Number(match[2]),
+		kind: match[3] as ParlayModalKind,
+	}
 }
 
 export type ParlaySide = 'home' | 'away' | 'over' | 'under'
@@ -75,8 +158,17 @@ export class ParlayBuilderService {
 		const value = await this.cache.get(parlayBuilderKey(userId, guildId))
 		if (!value || typeof value !== 'object') return null
 		const session = value as Partial<ParlayBuilderSession>
-		if (!Array.isArray(session.legs)) return null
+		if (
+			!SESSION_ID_PATTERN.test(session.sessionId ?? '') ||
+			!Number.isSafeInteger(session.revision) ||
+			Number(session.revision) < 0 ||
+			!Array.isArray(session.legs)
+		) {
+			return null
+		}
 		return {
+			sessionId: session.sessionId!,
+			revision: session.revision!,
 			legs: session.legs as ParlayBuilderLeg[],
 			stake: typeof session.stake === 'number' ? session.stake : null,
 		}
@@ -88,7 +180,12 @@ export class ParlayBuilderService {
 	): Promise<ParlayBuilderSession> {
 		return this.withSessionLock(userId, guildId, async () => {
 			await this.ensureNotReserved(userId, guildId)
-			const session: ParlayBuilderSession = { legs: [], stake: null }
+			const session: ParlayBuilderSession = {
+				sessionId: randomBytes(9).toString('base64url'),
+				revision: 0,
+				legs: [],
+				stake: null,
+			}
 			await this.saveUnlocked(userId, guildId, session)
 			return session
 		})
@@ -106,8 +203,17 @@ export class ParlayBuilderService {
 		)
 	}
 
-	async clear(userId: string, guildId: string): Promise<void> {
-		await this.clearWithPlacementToken(userId, guildId)
+	async clear(
+		userId: string,
+		guildId: string,
+		expected: ParlayBuilderIdentity,
+	): Promise<void> {
+		await this.withSessionLock(userId, guildId, async () => {
+			await this.ensureNotReserved(userId, guildId)
+			const session = await this.requireSession(userId, guildId)
+			this.assertIdentity(session, expected)
+			await this.cache.remove(parlayBuilderKey(userId, guildId))
+		})
 	}
 
 	async clearWithPlacementToken(
@@ -140,12 +246,13 @@ export class ParlayBuilderService {
 	async setStake(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 		stake: number,
 	): Promise<ParlayBuilderSession> {
 		if (!Number.isSafeInteger(stake) || stake <= 0) {
 			throw new Error('Stake must be a whole number greater than $0.')
 		}
-		return this.mutateSession(userId, guildId, (session) => ({
+		return this.mutateSession(userId, guildId, expected, (session) => ({
 			...session,
 			stake,
 		}))
@@ -154,9 +261,10 @@ export class ParlayBuilderService {
 	async removeLeg(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 		index: number,
 	): Promise<ParlayBuilderSession> {
-		return this.mutateSession(userId, guildId, (session) => {
+		return this.mutateSession(userId, guildId, expected, (session) => {
 			if (index < 0 || index >= session.legs.length) {
 				throw new Error('That parlay leg is no longer available.')
 			}
@@ -170,20 +278,30 @@ export class ParlayBuilderService {
 	async addLeg(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 		selection: AddParlayLegSelection,
 	): Promise<ParlayBuilderSession> {
-		return this.mutateSession(userId, guildId, async (session) => {
-			if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
-				throw new Error('A parlay can contain at most 6 legs.')
-			}
-			if (
-				session.legs.some((item) => item.event_id === selection.matchId)
-			) {
-				throw new Error('Each parlay leg must use a different game.')
-			}
-			const leg = await this.resolveLeg(selection)
-			return { ...session, legs: [...session.legs, leg] }
-		})
+		return this.mutateSession(
+			userId,
+			guildId,
+			expected,
+			async (session) => {
+				if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
+					throw new Error('A parlay can contain at most 6 legs.')
+				}
+				if (
+					session.legs.some(
+						(item) => item.event_id === selection.matchId,
+					)
+				) {
+					throw new Error(
+						'Each parlay leg must use a different game.',
+					)
+				}
+				const leg = await this.resolveLeg(selection)
+				return { ...session, legs: [...session.legs, leg] }
+			},
+		)
 	}
 
 	/**
@@ -193,31 +311,42 @@ export class ParlayBuilderService {
 	async reserveForPlacement(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 	): Promise<{ session: ParlayBuilderSession; token: string } | null> {
-		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
-		if (localPlacementReservations.has(reservationKey)) return null
-		const token = randomUUID()
-		localPlacementReservations.set(reservationKey, token)
-		let acquired = !this.cache.setIfAbsent
-		let sessionFound = false
-		try {
-			if (this.cache.setIfAbsent) {
-				acquired = await this.cache.setIfAbsent(
-					reservationKey,
-					token,
-					120,
-				)
-				if (!acquired) return null
+		return this.withSessionLock(userId, guildId, async () => {
+			const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+			if (localPlacementReservations.has(reservationKey)) return null
+			const session = await this.requireSession(userId, guildId)
+			this.assertIdentity(session, expected)
+			const token = randomUUID()
+			localPlacementReservations.set(reservationKey, token)
+			let acquired = !this.cache.setIfAbsent
+			try {
+				if (this.cache.setIfAbsent) {
+					acquired = await this.cache.setIfAbsent(
+						reservationKey,
+						token,
+						120,
+					)
+					if (!acquired) return null
+				}
+				return { session, token }
+			} finally {
+				if (!acquired) {
+					await this.releasePlacement(userId, guildId, token)
+				}
 			}
-			const session = await this.get(userId, guildId)
-			if (!session) return null
-			sessionFound = true
-			return { session, token }
-		} finally {
-			if (!acquired || !sessionFound) {
-				await this.releasePlacement(userId, guildId, token)
-			}
-		}
+		})
+	}
+
+	async assertCurrent(
+		userId: string,
+		guildId: string,
+		expected: ParlayBuilderIdentity,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.requireSession(userId, guildId)
+		this.assertIdentity(session, expected)
+		return session
 	}
 
 	async releasePlacement(
@@ -255,21 +384,49 @@ export class ParlayBuilderService {
 	private async mutateSession(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 		mutator: (
 			session: ParlayBuilderSession,
 		) => ParlayBuilderSession | Promise<ParlayBuilderSession>,
 	): Promise<ParlayBuilderSession> {
 		return this.withSessionLock(userId, guildId, async () => {
 			await this.ensureNotReserved(userId, guildId)
-			const session = await this.get(userId, guildId)
-			if (!session)
-				throw new Error(
-					'Your parlay builder expired. Run `/parlay` to start again.',
-				)
+			const session = await this.requireSession(userId, guildId)
+			this.assertIdentity(session, expected)
 			const updated = await mutator(session)
-			await this.saveUnlocked(userId, guildId, updated)
-			return updated
+			const versioned: ParlayBuilderSession = {
+				...updated,
+				sessionId: session.sessionId,
+				revision: session.revision + 1,
+			}
+			await this.saveUnlocked(userId, guildId, versioned)
+			return versioned
 		})
+	}
+
+	private async requireSession(
+		userId: string,
+		guildId: string,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.get(userId, guildId)
+		if (!session) {
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		}
+		return session
+	}
+
+	private assertIdentity(
+		session: ParlayBuilderSession,
+		expected: ParlayBuilderIdentity,
+	): void {
+		if (
+			session.sessionId !== expected.sessionId ||
+			session.revision !== expected.revision
+		) {
+			throw new Error(STALE_PARLAY_BUILDER_MESSAGE)
+		}
 	}
 
 	private async ensureNotReserved(
@@ -484,7 +641,9 @@ export class ParlayBuilderService {
 				)
 				.setButtonAccessory(
 					new ButtonBuilder()
-						.setCustomId(`parlay_btn_remove_${index}`)
+						.setCustomId(
+							buildParlayButtonId(session, 'remove', index),
+						)
 						.setLabel('Remove')
 						.setStyle(ButtonStyle.Danger),
 				)
@@ -505,22 +664,22 @@ export class ParlayBuilderService {
 		container.addActionRowComponents((row) =>
 			row.addComponents(
 				new ButtonBuilder()
-					.setCustomId('parlay_btn_add')
+					.setCustomId(buildParlayButtonId(session, 'add'))
 					.setLabel('Add Leg')
 					.setStyle(ButtonStyle.Primary),
 				new ButtonBuilder()
-					.setCustomId('parlay_btn_stake')
+					.setCustomId(buildParlayButtonId(session, 'stake'))
 					.setLabel('Set Stake')
 					.setStyle(ButtonStyle.Secondary),
 				new ButtonBuilder()
-					.setCustomId('parlay_btn_confirm')
+					.setCustomId(buildParlayButtonId(session, 'confirm'))
 					.setLabel('Confirm')
 					.setStyle(ButtonStyle.Success)
 					.setDisabled(
 						session.legs.length < 2 || session.stake === null,
 					),
 				new ButtonBuilder()
-					.setCustomId('parlay_btn_cancel')
+					.setCustomId(buildParlayButtonId(session, 'cancel'))
 					.setLabel('Cancel')
 					.setStyle(ButtonStyle.Danger),
 			),

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -13,6 +13,7 @@ import ParlayApiWrapper, {
 	type EventOutcome,
 	type ParlayLegInput,
 	type ParlayMarketKey,
+	type ParlayResponse,
 } from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
 import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
 import { combineAmericanOdds } from '../utils/betting/american-odds.js'
@@ -35,7 +36,12 @@ export interface ParlayBuilderSession {
 	revision: number
 	legs: ParlayBuilderLeg[]
 	stake: number | null
+	placementId: string
+	placementPhase: ParlayPlacementPhase
+	lastPlacementResponse: ParlayResponse | null
 }
+
+export type ParlayPlacementPhase = 'editing' | 'placing' | 'placed' | 'unknown'
 
 export type ParlayBuilderIdentity = Pick<
 	ParlayBuilderSession,
@@ -55,10 +61,21 @@ export const STALE_PARLAY_BUILDER_MESSAGE =
 	'This parlay builder is no longer current. Use the latest builder or run `/parlay` again.'
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{12}$/
+const PLACEMENT_ID_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const BUTTON_ID_PATTERN =
 	/^parlay\.btn\.([A-Za-z0-9_-]{12})\.(0|[1-9]\d*)\.(add|stake|confirm|cancel|remove)(?:\.(0|[1-9]\d*))?$/
 const MODAL_ID_PATTERN =
 	/^parlay\.modal\.([A-Za-z0-9_-]{12})\.(0|[1-9]\d*)\.(add-leg|stake)$/
+
+function isPlacementPhase(value: unknown): value is ParlayPlacementPhase {
+	return (
+		value === 'editing' ||
+		value === 'placing' ||
+		value === 'placed' ||
+		value === 'unknown'
+	)
+}
 
 export function parlayIdentity(
 	session: ParlayBuilderSession,
@@ -162,7 +179,11 @@ export class ParlayBuilderService {
 			!SESSION_ID_PATTERN.test(session.sessionId ?? '') ||
 			!Number.isSafeInteger(session.revision) ||
 			Number(session.revision) < 0 ||
-			!Array.isArray(session.legs)
+			!Array.isArray(session.legs) ||
+			!PLACEMENT_ID_PATTERN.test(session.placementId ?? '') ||
+			!isPlacementPhase(session.placementPhase) ||
+			(session.lastPlacementResponse !== null &&
+				typeof session.lastPlacementResponse !== 'object')
 		) {
 			return null
 		}
@@ -171,6 +192,10 @@ export class ParlayBuilderService {
 			revision: session.revision!,
 			legs: session.legs as ParlayBuilderLeg[],
 			stake: typeof session.stake === 'number' ? session.stake : null,
+			placementId: session.placementId!,
+			placementPhase: session.placementPhase!,
+			lastPlacementResponse:
+				session.lastPlacementResponse as ParlayResponse | null,
 		}
 	}
 
@@ -185,6 +210,9 @@ export class ParlayBuilderService {
 				revision: 0,
 				legs: [],
 				stake: null,
+				placementId: randomUUID(),
+				placementPhase: 'editing',
+				lastPlacementResponse: null,
 			}
 			await this.saveUnlocked(userId, guildId, session)
 			return session
@@ -318,9 +346,11 @@ export class ParlayBuilderService {
 			if (localPlacementReservations.has(reservationKey)) return null
 			const session = await this.requireSession(userId, guildId)
 			this.assertIdentity(session, expected)
+			if (session.placementPhase !== 'editing') return null
 			const token = randomUUID()
 			localPlacementReservations.set(reservationKey, token)
 			let acquired = !this.cache.setIfAbsent
+			let reserved = false
 			try {
 				if (this.cache.setIfAbsent) {
 					acquired = await this.cache.setIfAbsent(
@@ -330,12 +360,38 @@ export class ParlayBuilderService {
 					)
 					if (!acquired) return null
 				}
-				return { session, token }
+				const placingSession: ParlayBuilderSession = {
+					...session,
+					placementPhase: 'placing',
+				}
+				await this.saveUnlocked(userId, guildId, placingSession)
+				reserved = true
+				return { session: placingSession, token }
 			} finally {
-				if (!acquired) {
+				if (!reserved) {
 					await this.releasePlacement(userId, guildId, token)
 				}
 			}
+		})
+	}
+
+	async setPlacementState(
+		userId: string,
+		guildId: string,
+		expected: ParlayBuilderIdentity,
+		placementPhase: ParlayPlacementPhase,
+		lastPlacementResponse: ParlayResponse | null = null,
+	): Promise<ParlayBuilderSession> {
+		return this.withSessionLock(userId, guildId, async () => {
+			const session = await this.requireSession(userId, guildId)
+			this.assertIdentity(session, expected)
+			const updated: ParlayBuilderSession = {
+				...session,
+				placementPhase,
+				lastPlacementResponse,
+			}
+			await this.saveUnlocked(userId, guildId, updated)
+			return updated
 		})
 	}
 

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -21,8 +21,12 @@ vi.mock('../../utils/cache/cache-manager.js', () => ({
 }))
 
 const {
+	buildParlayButtonId,
+	buildParlayModalId,
 	PARLAY_BUILDER_MAX_LEGS,
 	PARLAY_BUILDER_TTL_SECONDS,
+	parseParlayButtonId,
+	parseParlayModalId,
 	ParlayBuilderService,
 } = await import('../ParlayBuilderService.js')
 
@@ -41,7 +45,9 @@ const makeCache = (): CacheStub => ({
 	remove: vi.fn().mockResolvedValue(true),
 })
 
-const makeSession = (legs = 0) => ({
+const makeSession = (legs = 0, revision = 0) => ({
+	sessionId: 'sessionA0001',
+	revision,
 	legs: Array.from({ length: legs }, (_, index) => ({
 		event_id: `event-${index}`,
 		outcome_uuid: `outcome-${index}`,
@@ -53,6 +59,27 @@ const makeSession = (legs = 0) => ({
 	})),
 	stake: null,
 })
+
+const identityOf = (session: ReturnType<typeof makeSession>) => ({
+	sessionId: session.sessionId,
+	revision: session.revision,
+})
+
+const useStatefulSessionCache = (cache: CacheStub) => {
+	const values = new Map<string, unknown>()
+	cache.get.mockImplementation((key: string) =>
+		Promise.resolve(values.get(key)),
+	)
+	cache.set.mockImplementation((key: string, value: unknown) => {
+		values.set(key, structuredClone(value))
+		return Promise.resolve(true)
+	})
+	cache.remove.mockImplementation((key: string) => {
+		values.delete(key)
+		return Promise.resolve(true)
+	})
+	return values
+}
 
 describe('ParlayBuilderService', () => {
 	let cache: CacheStub
@@ -71,29 +98,129 @@ describe('ParlayBuilderService', () => {
 		)
 	})
 
-	it('stores one user session with the 15 minute TTL', async () => {
-		await service.start('user-1', 'guild-1')
+	it('stores one versioned user session with the 15 minute TTL', async () => {
+		const session = await service.start('user-1', 'guild-1')
 
 		expect(cache.set).toHaveBeenCalledWith(
 			'parlay-builder:guild-1:user-1',
-			{ legs: [], stake: null },
+			{
+				sessionId: expect.stringMatching(/^[A-Za-z0-9_-]{12}$/),
+				revision: 0,
+				legs: [],
+				stake: null,
+			},
 			PARLAY_BUILDER_TTL_SECONDS,
 		)
+		expect(session.revision).toBe(0)
+	})
+
+	it('replaces the previous builder identity and expires legacy sessions', async () => {
+		const values = useStatefulSessionCache(cache)
+		const first = await service.start('user-1', 'guild-1')
+		const second = await service.start('user-1', 'guild-1')
+
+		expect(second.sessionId).not.toBe(first.sessionId)
+		values.set('parlay-builder:guild-2:user-2', { legs: [], stake: null })
+		await expect(service.get('user-2', 'guild-2')).resolves.toBeNull()
+	})
+
+	it('rejects a stale identity without mutating the replacement builder', async () => {
+		const values = useStatefulSessionCache(cache)
+		const current = makeSession(2, 4)
+		values.set('parlay-builder:guild-1:user-1', current)
+
+		await expect(
+			service.setStake(
+				'user-1',
+				'guild-1',
+				{ sessionId: 'sessionOLD01', revision: 3 },
+				25,
+			),
+		).rejects.toThrow('no longer current')
+		expect(values.get('parlay-builder:guild-1:user-1')).toEqual(current)
+	})
+
+	it('rejects stale cancel and confirm actions before any side effect', async () => {
+		const values = useStatefulSessionCache(cache)
+		const current = { ...makeSession(2, 4), stake: 10 }
+		const stale = { sessionId: current.sessionId, revision: 3 }
+		values.set('parlay-builder:guild-1:user-1', current)
+		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
+
+		await expect(service.clear('user-1', 'guild-1', stale)).rejects.toThrow(
+			'no longer current',
+		)
+		await expect(
+			service.reserveForPlacement('user-1', 'guild-1', stale),
+		).rejects.toThrow('no longer current')
+
+		expect(values.get('parlay-builder:guild-1:user-1')).toEqual(current)
+		expect(
+			cache.setIfAbsent.mock.calls.some(([key]) =>
+				String(key).endsWith(':placement'),
+			),
+		).toBe(false)
+	})
+
+	it('allows only one concurrent mutation from the same revision', async () => {
+		const values = useStatefulSessionCache(cache)
+		const current = makeSession(2)
+		values.set('parlay-builder:guild-1:user-1', current)
+
+		const results = await Promise.allSettled([
+			service.setStake('user-1', 'guild-1', identityOf(current), 10),
+			service.setStake('user-1', 'guild-1', identityOf(current), 20),
+		])
+
+		expect(
+			results.filter((result) => result.status === 'fulfilled'),
+		).toHaveLength(1)
+		expect(
+			results.filter((result) => result.status === 'rejected'),
+		).toHaveLength(1)
+		expect(values.get('parlay-builder:guild-1:user-1')).toMatchObject({
+			sessionId: current.sessionId,
+			revision: 1,
+		})
+	})
+
+	it('does not let an old remove-index control target a revised leg list', async () => {
+		const values = useStatefulSessionCache(cache)
+		const original = makeSession(3)
+		values.set('parlay-builder:guild-1:user-1', original)
+
+		const revised = await service.removeLeg(
+			'user-1',
+			'guild-1',
+			identityOf(original),
+			0,
+		)
+		await expect(
+			service.removeLeg('user-1', 'guild-1', identityOf(original), 1),
+		).rejects.toThrow('no longer current')
+
+		expect(values.get('parlay-builder:guild-1:user-1')).toEqual(revised)
+		expect(revised.legs.map((leg) => leg.event_id)).toEqual([
+			'event-1',
+			'event-2',
+		])
 	})
 
 	it('rejects duplicate events and the seventh leg', async () => {
-		cache.get.mockResolvedValue(makeSession(1))
+		const oneLeg = makeSession(1)
+		cache.get.mockResolvedValue(oneLeg)
 		await expect(
-			service.addLeg('user-1', 'guild-1', {
+			service.addLeg('user-1', 'guild-1', identityOf(oneLeg), {
 				matchId: 'event-0',
 				marketKey: 'h2h',
 				side: 'home',
 			}),
 		).rejects.toThrow('different game')
 
-		cache.get.mockResolvedValue(makeSession(PARLAY_BUILDER_MAX_LEGS))
+		const maxLegs = makeSession(PARLAY_BUILDER_MAX_LEGS)
+		cache.get.mockResolvedValue(maxLegs)
 		await expect(
-			service.addLeg('user-1', 'guild-1', {
+			service.addLeg('user-1', 'guild-1', identityOf(maxLegs), {
 				matchId: 'event-new',
 				marketKey: 'h2h',
 				side: 'home',
@@ -102,7 +229,8 @@ describe('ParlayBuilderService', () => {
 	})
 
 	it('resolves a home moneyline outcome from Khronos', async () => {
-		cache.get.mockResolvedValue(makeSession())
+		const session = makeSession()
+		cache.get.mockResolvedValue(session)
 		matchCache.getMatch.mockResolvedValue({
 			id: 'event-1',
 			home_team: 'Home Team',
@@ -119,11 +247,16 @@ describe('ParlayBuilderService', () => {
 			},
 		])
 
-		const result = await service.addLeg('user-1', 'guild-1', {
-			matchId: 'event-1',
-			marketKey: 'h2h',
-			side: 'home',
-		})
+		const result = await service.addLeg(
+			'user-1',
+			'guild-1',
+			identityOf(session),
+			{
+				matchId: 'event-1',
+				marketKey: 'h2h',
+				side: 'home',
+			},
+		)
 
 		expect(result.legs[0]).toMatchObject({
 			event_id: 'event-1',
@@ -139,7 +272,8 @@ describe('ParlayBuilderService', () => {
 	})
 
 	it('rejects matches without sport metadata instead of defaulting to NBA', async () => {
-		cache.get.mockResolvedValue(makeSession())
+		const session = makeSession()
+		cache.get.mockResolvedValue(session)
 		matchCache.getMatch.mockResolvedValue({
 			id: 'event-no-sport',
 			home_team: 'Home Team',
@@ -148,7 +282,7 @@ describe('ParlayBuilderService', () => {
 		})
 
 		await expect(
-			service.addLeg('user-1', 'guild-1', {
+			service.addLeg('user-1', 'guild-1', identityOf(session), {
 				matchId: 'event-no-sport',
 				marketKey: 'h2h',
 				side: 'home',
@@ -158,17 +292,30 @@ describe('ParlayBuilderService', () => {
 	})
 
 	it('reserves a session so concurrent confirmation can only place once', async () => {
-		cache.get.mockResolvedValue({ ...makeSession(2), stake: 10 })
+		const session = { ...makeSession(2), stake: 10 }
+		cache.get.mockResolvedValue(session)
 		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
 		cache.compareAndRemove = vi.fn().mockResolvedValue(true)
 
-		const first = await service.reserveForPlacement('user-1', 'guild-1')
-		const second = await service.reserveForPlacement('user-1', 'guild-1')
+		const first = await service.reserveForPlacement(
+			'user-1',
+			'guild-1',
+			identityOf(session),
+		)
+		const second = await service.reserveForPlacement(
+			'user-1',
+			'guild-1',
+			identityOf(session),
+		)
 
 		expect(first).not.toBeNull()
 		expect(second).toBeNull()
 		await service.releasePlacement('user-1', 'guild-1', first?.token)
-		const third = await service.reserveForPlacement('user-1', 'guild-1')
+		const third = await service.reserveForPlacement(
+			'user-1',
+			'guild-1',
+			identityOf(session),
+		)
 		expect(third).not.toBeNull()
 		await service.releasePlacement('user-1', 'guild-1', third?.token)
 	})
@@ -181,9 +328,9 @@ describe('ParlayBuilderService', () => {
 				: Promise.resolve({ ...makeSession(2), stake: 10 }),
 		)
 
-		await expect(service.clear('user-1', 'guild-1')).rejects.toThrow(
-			'already being placed',
-		)
+		await expect(
+			service.clear('user-1', 'guild-1', identityOf(makeSession(2))),
+		).rejects.toThrow('already being placed')
 		expect(cache.remove).not.toHaveBeenCalledWith(
 			'parlay-builder:guild-1:user-1',
 		)
@@ -236,13 +383,39 @@ describe('ParlayBuilderService', () => {
 		).toThrow('Set a stake')
 	})
 
-	it('renders a Components V2 card with per-leg remove controls', () => {
-		const response = service.render({ ...makeSession(2), stake: 10 })
+	it('renders a Components V2 card with versioned controls', () => {
+		const session = { ...makeSession(2, 7), stake: 10 }
+		const response = service.render(session)
 		const container = response.components?.[0]
 		const json = (container as { toJSON: () => unknown }).toJSON()
 
 		expect(response.flags).toBeDefined()
-		expect(JSON.stringify(json)).toContain('parlay_btn_remove_0')
-		expect(JSON.stringify(json)).toContain('parlay_btn_confirm')
+		expect(JSON.stringify(json)).toContain(
+			'parlay.btn.sessionA0001.7.remove.0',
+		)
+		expect(JSON.stringify(json)).toContain(
+			'parlay.btn.sessionA0001.7.confirm',
+		)
+	})
+
+	it('round-trips only well-formed versioned control identities', () => {
+		const identity = identityOf(makeSession(0, 9))
+		const removeId = buildParlayButtonId(identity, 'remove', 2)
+		const modalId = buildParlayModalId(identity, 'add-leg')
+
+		expect(parseParlayButtonId(removeId)).toEqual({
+			...identity,
+			action: 'remove',
+			index: 2,
+		})
+		expect(parseParlayModalId(modalId)).toEqual({
+			...identity,
+			kind: 'add-leg',
+		})
+		expect(parseParlayButtonId('parlay_btn_remove:2')).toBeNull()
+		expect(
+			parseParlayButtonId(`parlay.btn.${identity.sessionId}.9.remove`),
+		).toBeNull()
+		expect(parseParlayModalId('parlay_modal_add_leg')).toBeNull()
 	})
 })

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -58,7 +58,7 @@ const makeSession = (legs = 0, revision = 0) => ({
 		commence_time: '2099-01-01T00:00:00.000Z',
 	})),
 	stake: null,
-	placementId: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+	placementId: '00000000-0000-4000-8000-000000000001',
 	placementPhase: 'editing' as const,
 	lastPlacementResponse: null,
 })

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -58,6 +58,9 @@ const makeSession = (legs = 0, revision = 0) => ({
 		commence_time: '2099-01-01T00:00:00.000Z',
 	})),
 	stake: null,
+	placementId: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+	placementPhase: 'editing' as const,
+	lastPlacementResponse: null,
 })
 
 const identityOf = (session: ReturnType<typeof makeSession>) => ({
@@ -108,10 +111,25 @@ describe('ParlayBuilderService', () => {
 				revision: 0,
 				legs: [],
 				stake: null,
+				placementId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
+				placementPhase: 'editing',
+				lastPlacementResponse: null,
 			},
 			PARLAY_BUILDER_TTL_SECONDS,
 		)
 		expect(session.revision).toBe(0)
+	})
+
+	it('persists one stable placement identity for the builder lifecycle', async () => {
+		const session = await service.start('user-1', 'guild-1')
+
+		expect(session).toMatchObject({
+			placementPhase: 'editing',
+			lastPlacementResponse: null,
+		})
+		expect(session.placementId).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+		)
 	})
 
 	it('replaces the previous builder identity and expires legacy sessions', async () => {

--- a/src/utils/api/Khronos/guild/guild-wrapper.ts
+++ b/src/utils/api/Khronos/guild/guild-wrapper.ts
@@ -209,7 +209,11 @@ export default class GuildWrapper {
 		options: MessageCreateOptions,
 		expectedGuildId?: string,
 	): Promise<Message> {
-		this.validateSnowflake(channelId, 'target', expectedGuildId ?? 'unknown')
+		this.validateSnowflake(
+			channelId,
+			'target',
+			expectedGuildId ?? 'unknown',
+		)
 
 		let channel: Channel | null
 		try {

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -106,15 +106,42 @@ export default class ParlayApiWrapper {
 		return response.data
 	}
 
-	async place(initToken: string): Promise<ParlayResponse> {
+	async place(
+		initToken: string,
+		placementId: string,
+	): Promise<ParlayResponse> {
 		const mock = await this.mockPromise
 		if (mock) return mock.placeParlay(initToken)
 		const response = await AxiosKhronosInstance.post<ParlayResponse>(
 			'/parlays/place',
-			{ init_token: initToken },
+			{ init_token: initToken, placement_id: placementId },
 			this.requestConfig,
 		)
 		return response.data
+	}
+
+	async findByPlacement(placementId: string): Promise<ParlayResponse | null> {
+		const mock = await this.mockPromise
+		if (mock) return null
+		try {
+			const response = await AxiosKhronosInstance.get<ParlayResponse>(
+				`/parlays/placements/${encodeURIComponent(placementId)}`,
+				this.requestConfig,
+			)
+			return response.data
+		} catch (error) {
+			const status =
+				typeof error === 'object' &&
+				error !== null &&
+				'response' in error &&
+				typeof error.response === 'object' &&
+				error.response !== null &&
+				'status' in error.response
+					? error.response.status
+					: undefined
+			if (status === 404) return null
+			throw error
+		}
 	}
 
 	async getUserParlays(

--- a/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
+++ b/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 
 const get = vi.fn()
 const del = vi.fn()
+const post = vi.fn()
 
 vi.mock('../../../common/axios-config.js', () => ({
-	AxiosKhronosInstance: { get, delete: del },
+	AxiosKhronosInstance: { get, post, delete: del },
 }))
 
 const { default: ParlayApiWrapper } = await import('../ParlayApiWrapper.js')
@@ -39,5 +40,45 @@ describe('ParlayApiWrapper', () => {
 			'/parlays/parlay%2F1',
 			expect.objectContaining({ data: { user_id: 'user-1' } }),
 		)
+	})
+
+	it('sends the stable placement id and reconciles a committed placement', async () => {
+		post.mockResolvedValueOnce({
+			data: { id: 'parlay-1', status: 'pending' },
+		})
+		get.mockResolvedValueOnce({
+			data: { id: 'parlay-1', status: 'pending' },
+		})
+		const api = new ParlayApiWrapper()
+
+		await expect(
+			api.place('init-token', '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b'),
+		).resolves.toMatchObject({ id: 'parlay-1' })
+		await expect(
+			api.findByPlacement('7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b'),
+		).resolves.toMatchObject({ id: 'parlay-1' })
+
+		expect(post).toHaveBeenCalledWith(
+			'/parlays/place',
+			{
+				init_token: 'init-token',
+				placement_id: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			},
+			expect.any(Object),
+		)
+		expect(get).toHaveBeenCalledWith(
+			'/parlays/placements/7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			expect.any(Object),
+		)
+	})
+
+	it('treats a missing placement as a completed reconciliation', async () => {
+		get.mockRejectedValueOnce({ response: { status: 404 } })
+
+		await expect(
+			new ParlayApiWrapper().findByPlacement(
+				'7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			),
+		).resolves.toBeNull()
 	})
 })

--- a/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
+++ b/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
@@ -52,22 +52,22 @@ describe('ParlayApiWrapper', () => {
 		const api = new ParlayApiWrapper()
 
 		await expect(
-			api.place('init-token', '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b'),
+			api.place('init-token', '00000000-0000-4000-8000-000000000001'),
 		).resolves.toMatchObject({ id: 'parlay-1' })
 		await expect(
-			api.findByPlacement('7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b'),
+			api.findByPlacement('00000000-0000-4000-8000-000000000001'),
 		).resolves.toMatchObject({ id: 'parlay-1' })
 
 		expect(post).toHaveBeenCalledWith(
 			'/parlays/place',
 			{
 				init_token: 'init-token',
-				placement_id: '7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+				placement_id: '00000000-0000-4000-8000-000000000001',
 			},
 			expect.any(Object),
 		)
 		expect(get).toHaveBeenCalledWith(
-			'/parlays/placements/7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+			'/parlays/placements/00000000-0000-4000-8000-000000000001',
 			expect.any(Object),
 		)
 	})
@@ -77,7 +77,7 @@ describe('ParlayApiWrapper', () => {
 
 		await expect(
 			new ParlayApiWrapper().findByPlacement(
-				'7b5971d4-2f0d-4cd6-a4e5-5fdab70c701b',
+				'00000000-0000-4000-8000-000000000001',
 			),
 		).resolves.toBeNull()
 	})

--- a/src/utils/api/koa/setup/health.test.ts
+++ b/src/utils/api/koa/setup/health.test.ts
@@ -1,0 +1,60 @@
+import { createServer, type Server } from 'node:http'
+import Koa from 'koa'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApiKeyAuthMiddleware } from './apiKeyAuth.js'
+import { createHealthMiddleware } from './health.js'
+
+vi.mock('../../../../lib/startup/env.js', () => ({
+	default: { API_KEY: 'system-api-key' },
+}))
+
+vi.mock('../../../logging/WinstonLogger.js', () => ({
+	logger: { warn: vi.fn() },
+}))
+
+describe('Koa health route', () => {
+	let server: Server | undefined
+
+	afterEach(async () => {
+		if (server?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()))
+			})
+		}
+	})
+
+	async function request(path: string, init?: RequestInit) {
+		const app = new Koa()
+		app.use(createHealthMiddleware())
+		app.use(createApiKeyAuthMiddleware())
+		app.use(async (ctx) => {
+			ctx.status = 204
+		})
+		server = createServer(app.callback())
+		await new Promise<void>((resolve) => {
+			server.listen(0, '127.0.0.1', () => resolve())
+		})
+		const address = server.address()
+		if (!address || typeof address === 'string') {
+			throw new Error('Test server did not expose a TCP address')
+		}
+
+		return fetch(`http://127.0.0.1:${address.port}${path}`, init)
+	}
+
+	it('allows unauthenticated GET /health', async () => {
+		const response = await request('/health')
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({ status: 'ok' })
+	})
+
+	it('does not weaken API-key auth for mutation routes', async () => {
+		const response = await request('/props/daily', { method: 'POST' })
+
+		expect(response.status).toBe(401)
+		expect(await response.json()).toMatchObject({
+			code: 'MISSING_API_KEY',
+		})
+	})
+})

--- a/src/utils/api/koa/setup/health.ts
+++ b/src/utils/api/koa/setup/health.ts
@@ -1,0 +1,13 @@
+import type { Context, Next } from 'koa'
+
+export function createHealthMiddleware() {
+	return async (ctx: Context, next: Next) => {
+		if (ctx.method === 'GET' && ctx.path === '/health') {
+			ctx.status = 200
+			ctx.body = { status: 'ok' }
+			return
+		}
+
+		await next()
+	}
+}

--- a/src/utils/api/koa/setup/koaSetup.ts
+++ b/src/utils/api/koa/setup/koaSetup.ts
@@ -7,6 +7,7 @@ import { pageNotFound } from '../../requests/middleware.js'
 import { createApiKeyAuthMiddleware } from './apiKeyAuth.js'
 import { setupBullBoard } from './bullBoard.js'
 import { createErrorHandler } from './errorHandler.js'
+import { createHealthMiddleware } from './health.js'
 import { captureRequestIdentity } from './logging.js'
 import { createRequestIdMiddleware } from './requestId.js'
 
@@ -32,6 +33,9 @@ export async function setupKoaApp(): Promise<Koa> {
 			}),
 		}),
 	)
+
+	// Internal harness readiness endpoint; mutation routes remain API-key protected.
+	app.use(createHealthMiddleware())
 
 	// Add API key authentication middleware
 	app.use(createApiKeyAuthMiddleware())

--- a/src/utils/api/routes/notifications/__tests__/delivery-queue.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/delivery-queue.test.ts
@@ -5,6 +5,8 @@ import {
 	type DeliveryDispatcher,
 	type DeliveryQueuePort,
 	NotificationDeliveryQueue,
+	SYSTEM_DISCORD_BASE_URL,
+	SystemDiscordDeliveryDispatcher,
 } from '../delivery-queue.js'
 import { RedisDeliveryStore } from '../delivery-store.js'
 
@@ -86,6 +88,7 @@ describe('notification delivery queue', () => {
 
 	afterEach(async () => {
 		await queue?.close()
+		vi.unstubAllGlobals()
 	})
 
 	it('tracks destinations independently and retries only transient failures', async () => {
@@ -154,5 +157,40 @@ describe('notification delivery queue', () => {
 		expect(record?.state).toBe('retryable_failed')
 		expect(record?.destinations[0]?.state).toBe('delivered')
 		expect(record?.destinations[0]?.receipt).toEqual([])
+	})
+
+	it('routes system prop-post delivery only to fake-discord', async () => {
+		const fetchMock = vi.fn<typeof fetch>(
+			async () =>
+				new Response(JSON.stringify({ id: 'fake-message-1' }), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}),
+		)
+		vi.stubGlobal('fetch', fetchMock)
+
+		const receipt = await new SystemDiscordDeliveryDispatcher().deliver(
+			propPostEnvelope,
+			'prop-post:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440005:550e8400-e29b-41d4-a716-446655440006',
+		)
+
+		expect(fetchMock).toHaveBeenCalledOnce()
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			`${SYSTEM_DISCORD_BASE_URL}/channels/channel-1/messages`,
+		)
+		expect(receipt).toEqual([
+			{
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440005',
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'fake-message-1',
+			},
+			{
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440006',
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'fake-message-1',
+			},
+		])
 	})
 })

--- a/src/utils/api/routes/notifications/__tests__/delivery-queue.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/delivery-queue.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RedisCacheClient } from '../../../../cache/redis-instance.js'
+import { deliveryEnvelopeSchema } from '../delivery-contract.js'
+import {
+	type DeliveryDispatcher,
+	type DeliveryQueuePort,
+	NotificationDeliveryQueue,
+} from '../delivery-queue.js'
+import { RedisDeliveryStore } from '../delivery-store.js'
+
+const envelope = deliveryEnvelopeSchema.parse({
+	delivery_id: '550e8400-e29b-41d4-a716-446655440002',
+	schema_version: 1,
+	kind: 'prop_settled',
+	occurred_at: '2026-07-14T20:00:00.000Z',
+	payload: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440003',
+		result: 'won',
+		market_key: 'player_points',
+		description: 'Stephen Curry',
+		tallies: { correct: 1, incorrect: 0, total: 1 },
+		messages: [
+			{
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-1',
+			},
+			{
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-2',
+			},
+		],
+	},
+})
+
+function fakeRedis(): RedisCacheClient {
+	const values = new Map<string, string>()
+	return {
+		set: async (key, value, ...args) => {
+			if (args.includes('NX') && values.has(key)) return null
+			values.set(key, value)
+			return 'OK'
+		},
+		get: async (key) => values.get(key) ?? null,
+	} as unknown as RedisCacheClient
+}
+
+describe('notification delivery queue', () => {
+	let queue: NotificationDeliveryQueue | undefined
+
+	afterEach(async () => {
+		await queue?.close()
+	})
+
+	it('tracks destinations independently and retries only transient failures', async () => {
+		const redis = fakeRedis()
+		const store = new RedisDeliveryStore(redis)
+		const attempts = new Map<string, number>()
+		const dispatcher: DeliveryDispatcher = {
+			deliver: vi.fn(async (_payload, destinationId) => {
+				const count = (attempts.get(destinationId) ?? 0) + 1
+				attempts.set(destinationId, count)
+				if (destinationId.endsWith('message-2') && count === 1) {
+					throw new Error('Discord timeout')
+				}
+				return { message_id: destinationId }
+			}),
+		}
+		queue = new NotificationDeliveryQueue({
+			store,
+			dispatcher,
+			queue: {
+				add: vi.fn(async () => undefined),
+				close: vi.fn(async () => undefined),
+			} satisfies DeliveryQueuePort,
+			startWorker: false,
+		})
+		await queue.accept(envelope)
+		const job = { data: envelope } as never
+		await expect(queue.processJob(job)).rejects.toThrow(/retry/)
+		const partial = await store.get(envelope.delivery_id)
+		expect(
+			partial?.destinations.map((destination) => destination.state),
+		).toEqual(['delivered', 'retryable_failed'])
+
+		await queue.processJob(job)
+		const complete = await store.get(envelope.delivery_id)
+		expect(complete?.state).toBe('delivered')
+		expect(
+			complete?.destinations.every(
+				(destination) => destination.state === 'delivered',
+			),
+		).toBe(true)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/delivery-queue.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/delivery-queue.test.ts
@@ -34,6 +34,41 @@ const envelope = deliveryEnvelopeSchema.parse({
 	},
 })
 
+const propPostEnvelope = deliveryEnvelopeSchema.parse({
+	delivery_id: '550e8400-e29b-41d4-a716-446655440004',
+	schema_version: 1,
+	kind: 'prop_post',
+	occurred_at: '2026-07-14T20:00:00.000Z',
+	payload: {
+		props: [
+			{
+				event_id: 'event-1',
+				commence_time: '2026-07-14T20:00:00.000Z',
+				home_team: 'Home',
+				away_team: 'Away',
+				sport_title: 'NBA',
+				market_key: 'player_points',
+				bookmaker_key: 'draftkings',
+				description: 'Player',
+				point: 20.5,
+				over: {
+					outcome_uuid: '550e8400-e29b-41d4-a716-446655440005',
+					outcome_name: 'Over',
+					price: -110,
+				},
+				under: {
+					outcome_uuid: '550e8400-e29b-41d4-a716-446655440006',
+					outcome_name: 'Under',
+					price: -110,
+				},
+			},
+		],
+		guilds: [
+			{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' },
+		],
+	},
+})
+
 function fakeRedis(): RedisCacheClient {
 	const values = new Map<string, string>()
 	return {
@@ -92,5 +127,32 @@ describe('notification delivery queue', () => {
 				(destination) => destination.state === 'delivered',
 			),
 		).toBe(true)
+	})
+
+	it('does not report prop-post delivery until the complete receipt set exists', async () => {
+		const redis = fakeRedis()
+		const store = new RedisDeliveryStore(redis)
+		const dispatcher: DeliveryDispatcher = {
+			deliver: vi.fn(async () => []),
+		}
+		queue = new NotificationDeliveryQueue({
+			store,
+			dispatcher,
+			queue: {
+				add: vi.fn(async () => undefined),
+				close: vi.fn(async () => undefined),
+			} satisfies DeliveryQueuePort,
+			startWorker: false,
+		})
+
+		await queue.accept(propPostEnvelope)
+		await expect(
+			queue.processJob({ data: propPostEnvelope } as never),
+		).rejects.toThrow(/retry/)
+
+		const record = await store.get(propPostEnvelope.delivery_id)
+		expect(record?.state).toBe('retryable_failed')
+		expect(record?.destinations[0]?.state).toBe('delivered')
+		expect(record?.destinations[0]?.receipt).toEqual([])
 	})
 })

--- a/src/utils/api/routes/notifications/__tests__/delivery-store.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/delivery-store.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { RedisCacheClient } from '../../../../cache/redis-instance.js'
+import {
+	classifyDeliveryError,
+	deliveryEnvelopeSchema,
+} from '../delivery-contract.js'
+import { deriveDeliveryState, RedisDeliveryStore } from '../delivery-store.js'
+
+const envelope = {
+	delivery_id: '550e8400-e29b-41d4-a716-446655440000',
+	schema_version: 1 as const,
+	kind: 'prop_settled' as const,
+	occurred_at: '2026-07-14T20:00:00.000Z',
+	payload: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+		result: 'won' as const,
+		winning_side_display: 'Over',
+		actual_value: 37,
+		market_key: 'player_points',
+		description: 'Stephen Curry',
+		point: 35.5,
+		tallies: { correct: 1, incorrect: 0, total: 1 },
+		messages: [
+			{
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-1',
+			},
+		],
+	},
+}
+
+function fakeRedis(): RedisCacheClient {
+	const values = new Map<string, string>()
+	return {
+		set: async (key, value, ...args) => {
+			if (args.includes('NX') && values.has(key)) return null
+			values.set(key, value)
+			return 'OK'
+		},
+		get: async (key) => values.get(key) ?? null,
+	} as unknown as RedisCacheClient
+}
+
+describe('durable notification delivery contract', () => {
+	it('accepts once, deduplicates same payload, and rejects changed payload', async () => {
+		const parsed = deliveryEnvelopeSchema.parse(envelope)
+		const store = new RedisDeliveryStore(fakeRedis())
+
+		expect((await store.accept(parsed)).kind).toBe('accepted')
+		expect((await store.accept(parsed)).kind).toBe('duplicate')
+
+		const changed = deliveryEnvelopeSchema.parse({
+			...parsed,
+			payload: { ...parsed.payload, actual_value: 38 },
+		})
+		expect((await store.accept(changed)).kind).toBe('conflict')
+	})
+
+	it('classifies permanent Discord destinations without retrying forever', () => {
+		expect(
+			classifyDeliveryError(
+				Object.assign(new Error('blocked'), { code: 50007 }),
+			),
+		).toMatchObject({
+			classification: 'permanent',
+		})
+		expect(classifyDeliveryError(new Error('timeout'))).toMatchObject({
+			classification: 'transient',
+		})
+	})
+
+	it('derives delivered and permanent terminal states from destinations', async () => {
+		const record = (
+			await new RedisDeliveryStore(fakeRedis()).accept(
+				deliveryEnvelopeSchema.parse(envelope),
+			)
+		).record
+		record.destinations[0].state = 'delivered'
+		expect(deriveDeliveryState(record)).toBe('delivered')
+		record.destinations[0].state = 'permanent_failed'
+		expect(deriveDeliveryState(record)).toBe('permanent_failed')
+	})
+})

--- a/src/utils/api/routes/notifications/delivery-contract.ts
+++ b/src/utils/api/routes/notifications/delivery-contract.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import {
+	type DailyPropsPayload,
+	dailyPropsPayloadSchema,
 	type PropSettledNotification,
 	propSettledNotificationSchema,
 } from '../shared-payload-schemas.js'
@@ -9,7 +11,11 @@ import {
 	parlayResultNotificationSchema,
 } from './parlay-notification-contract.js'
 
-export const deliveryKindSchema = z.enum(['parlay_result', 'prop_settled'])
+export const deliveryKindSchema = z.enum([
+	'parlay_result',
+	'prop_settled',
+	'prop_post',
+])
 
 const deliveryEnvelopeBaseSchema = z.object({
 	delivery_id: z.string().uuid(),
@@ -26,10 +32,24 @@ export const deliveryEnvelopeSchema = z.discriminatedUnion('kind', [
 		kind: z.literal('prop_settled'),
 		payload: propSettledNotificationSchema,
 	}),
+	deliveryEnvelopeBaseSchema.extend({
+		kind: z.literal('prop_post'),
+		payload: dailyPropsPayloadSchema,
+	}),
 ])
 
 export type DeliveryEnvelope = z.infer<typeof deliveryEnvelopeSchema>
-export type DeliveryPayload = ParlayResultNotification | PropSettledNotification
+export type DeliveryPayload =
+	| ParlayResultNotification
+	| PropSettledNotification
+	| DailyPropsPayload
+
+export interface PropPostReceipt {
+	outcome_uuid: string
+	guild_id: string
+	channel_id: string
+	message_id: string
+}
 
 export type DeliveryState =
 	| 'queued'
@@ -101,6 +121,14 @@ export function destinationIds(envelope: DeliveryEnvelope): string[] {
 	if (envelope.kind === 'parlay_result') {
 		return [`dm:${envelope.payload.user_id}`]
 	}
+	if (envelope.kind === 'prop_post') {
+		return envelope.payload.guilds.flatMap((guild) =>
+			envelope.payload.props.map(
+				(prop) =>
+					`prop-post:${guild.guild_id}:${guild.channel_id}:${prop.over.outcome_uuid}:${prop.under.outcome_uuid}`,
+			),
+		)
+	}
 	return [
 		...new Set(
 			envelope.payload.messages.map(
@@ -109,6 +137,56 @@ export function destinationIds(envelope: DeliveryEnvelope): string[] {
 			),
 		),
 	]
+}
+
+/** Flatten durable per-destination receipts for status/reconciliation APIs. */
+export function deliveryReceipts(
+	record: Pick<DeliveryRecord, 'kind' | 'destinations'>,
+): PropPostReceipt[] {
+	if (record.kind !== 'prop_post') return []
+	return record.destinations.flatMap((destination) => {
+		if (!Array.isArray(destination.receipt)) return []
+		return destination.receipt.filter(isPropPostReceipt)
+	})
+}
+
+/** A prop-post is terminally delivered only when every expected receipt exists exactly once. */
+export function hasExactPropPostReceipts(
+	payload: DailyPropsPayload,
+	receipts: readonly PropPostReceipt[],
+): boolean {
+	const expected = new Set<string>()
+	for (const prop of payload.props) {
+		for (const outcomeUuid of [
+			prop.over.outcome_uuid,
+			prop.under.outcome_uuid,
+		]) {
+			for (const guild of payload.guilds) {
+				expected.add(
+					`${outcomeUuid}:${guild.guild_id}:${guild.channel_id}`,
+				)
+			}
+		}
+	}
+	if (receipts.length !== expected.size) return false
+	const actual = new Set<string>()
+	for (const receipt of receipts) {
+		const key = `${receipt.outcome_uuid}:${receipt.guild_id}:${receipt.channel_id}`
+		if (actual.has(key) || !expected.has(key)) return false
+		actual.add(key)
+	}
+	return actual.size === expected.size
+}
+
+function isPropPostReceipt(value: unknown): value is PropPostReceipt {
+	if (!value || typeof value !== 'object') return false
+	const candidate = value as Record<string, unknown>
+	return (
+		typeof candidate.outcome_uuid === 'string' &&
+		typeof candidate.guild_id === 'string' &&
+		typeof candidate.channel_id === 'string' &&
+		typeof candidate.message_id === 'string'
+	)
 }
 
 export function classifyDeliveryError(error: unknown): {

--- a/src/utils/api/routes/notifications/delivery-contract.ts
+++ b/src/utils/api/routes/notifications/delivery-contract.ts
@@ -1,0 +1,131 @@
+import { createHash } from 'node:crypto'
+import { z } from 'zod'
+import {
+	type PropSettledNotification,
+	propSettledNotificationSchema,
+} from '../shared-payload-schemas.js'
+import {
+	type ParlayResultNotification,
+	parlayResultNotificationSchema,
+} from './parlay-notification-contract.js'
+
+export const deliveryKindSchema = z.enum(['parlay_result', 'prop_settled'])
+
+const deliveryEnvelopeBaseSchema = z.object({
+	delivery_id: z.string().uuid(),
+	schema_version: z.literal(1),
+	occurred_at: z.string().datetime({ offset: true }),
+})
+
+export const deliveryEnvelopeSchema = z.discriminatedUnion('kind', [
+	deliveryEnvelopeBaseSchema.extend({
+		kind: z.literal('parlay_result'),
+		payload: parlayResultNotificationSchema,
+	}),
+	deliveryEnvelopeBaseSchema.extend({
+		kind: z.literal('prop_settled'),
+		payload: propSettledNotificationSchema,
+	}),
+])
+
+export type DeliveryEnvelope = z.infer<typeof deliveryEnvelopeSchema>
+export type DeliveryPayload = ParlayResultNotification | PropSettledNotification
+
+export type DeliveryState =
+	| 'queued'
+	| 'processing'
+	| 'delivered'
+	| 'retryable_failed'
+	| 'permanent_failed'
+
+export type DestinationState =
+	| 'queued'
+	| 'processing'
+	| 'delivered'
+	| 'retryable_failed'
+	| 'permanent_failed'
+
+export interface DeliveryDestination {
+	id: string
+	state: DestinationState
+	attempts: number
+	last_error?: string
+	classification?: 'transient' | 'permanent'
+	receipt?: unknown
+}
+
+export interface DeliveryRecord {
+	delivery_id: string
+	kind: DeliveryEnvelope['kind']
+	schema_version: 1
+	occurred_at: string
+	payload: DeliveryPayload
+	payload_hash: string
+	state: DeliveryState
+	attempts: number
+	destinations: DeliveryDestination[]
+	created_at: string
+	updated_at: string
+	delivered_at?: string
+}
+
+/** Stable JSON is used so retried requests can compare semantic payloads. */
+export function stableJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+	if (value && typeof value === 'object') {
+		return `{${Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(
+				([key, nested]) =>
+					`${JSON.stringify(key)}:${stableJson(nested)}`,
+			)
+			.join(',')}}`
+	}
+	return JSON.stringify(value)
+}
+
+export function deliveryPayloadHash(envelope: DeliveryEnvelope): string {
+	return createHash('sha256')
+		.update(
+			stableJson({
+				schema_version: envelope.schema_version,
+				kind: envelope.kind,
+				occurred_at: envelope.occurred_at,
+				payload: envelope.payload,
+			}),
+		)
+		.digest('hex')
+}
+
+export function destinationIds(envelope: DeliveryEnvelope): string[] {
+	if (envelope.kind === 'parlay_result') {
+		return [`dm:${envelope.payload.user_id}`]
+	}
+	return [
+		...new Set(
+			envelope.payload.messages.map(
+				(reference) =>
+					`prop:${reference.guild_id}:${reference.channel_id}:${reference.message_id}`,
+			),
+		),
+	]
+}
+
+export function classifyDeliveryError(error: unknown): {
+	classification: 'transient' | 'permanent'
+	message: string
+} {
+	const candidate = error as { code?: number | string; status?: number }
+	const code = String(candidate?.code ?? '')
+	const status = candidate?.status
+	const permanentCodes = new Set(['50007', '10003', '50001', '10004'])
+	const message = error instanceof Error ? error.message : String(error)
+	return {
+		classification:
+			permanentCodes.has(code) ||
+			(status !== undefined && status >= 400 && status < 500)
+				? 'permanent'
+				: 'transient',
+		message: message.slice(0, 500),
+	}
+}

--- a/src/utils/api/routes/notifications/delivery-queue.ts
+++ b/src/utils/api/routes/notifications/delivery-queue.ts
@@ -4,6 +4,8 @@ import {
 	type DeliveryEnvelope,
 	type DeliveryRecord,
 	type DestinationState,
+	deliveryReceipts,
+	hasExactPropPostReceipts,
 } from './delivery-contract.js'
 import {
 	type DeliveryStore,
@@ -28,6 +30,7 @@ export interface DeliveryDispatcher {
 
 class DiscordDeliveryDispatcher implements DeliveryDispatcher {
 	private service?: NotificationService
+	private propPostingHandler?: import('../../../props/PropPostingHandler.js').PropPostingHandler
 
 	private async getService(): Promise<NotificationService> {
 		if (!this.service) {
@@ -45,6 +48,52 @@ class DiscordDeliveryDispatcher implements DeliveryDispatcher {
 				envelope.payload,
 				envelope.delivery_id,
 			)
+		}
+
+		if (envelope.kind === 'prop_post') {
+			const destination = parsePropPostDestination(destinationId)
+			const prop = envelope.payload.props.find(
+				(candidate) =>
+					candidate.over.outcome_uuid ===
+						destination.over_outcome_uuid &&
+					candidate.under.outcome_uuid ===
+						destination.under_outcome_uuid,
+			)
+			if (!prop)
+				throw new Error(
+					`Unknown prop-post destination ${destinationId}`,
+				)
+			if (!this.propPostingHandler) {
+				const module = await import(
+					'../../../props/PropPostingHandler.js'
+				)
+				this.propPostingHandler = new module.PropPostingHandler()
+			}
+			const receipt = await this.propPostingHandler.postPropPair(
+				destination.guild_id,
+				destination.channel_id,
+				prop,
+				prop.sport_title.toLowerCase().includes('nfl') ? 'nfl' : 'nba',
+				envelope.delivery_id,
+				destinationId,
+			)
+			if (
+				receipt.length !== 2 ||
+				receipt.some(
+					(reference) =>
+						reference.guild_id !== destination.guild_id ||
+						reference.channel_id !== destination.channel_id ||
+						![
+							destination.over_outcome_uuid,
+							destination.under_outcome_uuid,
+						].includes(reference.outcome_uuid),
+				)
+			) {
+				throw new Error(
+					'Prop-post destination returned incomplete receipts',
+				)
+			}
+			return receipt
 		}
 
 		const reference = envelope.payload.messages.find(
@@ -129,6 +178,12 @@ export class NotificationDeliveryQueue {
 	}
 
 	async accept(envelope: DeliveryEnvelope): Promise<DeliveryRecord> {
+		return (await this.acceptDetailed(envelope)).record
+	}
+
+	async acceptDetailed(
+		envelope: DeliveryEnvelope,
+	): Promise<{ record: DeliveryRecord; duplicate: boolean }> {
 		const accepted = await this.store.accept(envelope)
 		if (accepted.kind === 'conflict') {
 			const error = new Error(
@@ -163,7 +218,10 @@ export class NotificationDeliveryQueue {
 				if (!isDuplicateQueueError(error)) throw error
 			}
 		}
-		return accepted.record
+		return {
+			record: accepted.record,
+			duplicate: accepted.kind === 'duplicate',
+		}
 	}
 
 	async get(deliveryId: string): Promise<DeliveryRecord | null> {
@@ -222,14 +280,30 @@ export class NotificationDeliveryQueue {
 			}
 		}
 
-		const final = await this.store.update(deliveryId, (current) => ({
-			...current,
-			state: deriveDeliveryState(current),
-			delivered_at:
-				deriveDeliveryState(current) === 'delivered'
-					? (current.delivered_at ?? new Date().toISOString())
-					: current.delivered_at,
-		}))
+		const final = await this.store.update(deliveryId, (current) => {
+			const derivedState = deriveDeliveryState(current)
+			const propPostComplete =
+				current.kind !== 'prop_post' ||
+				hasExactPropPostReceipts(
+					current.payload as Extract<
+						DeliveryEnvelope,
+						{ kind: 'prop_post' }
+					>['payload'],
+					deliveryReceipts(current),
+				)
+			const state =
+				derivedState === 'delivered' && !propPostComplete
+					? 'retryable_failed'
+					: derivedState
+			return {
+				...current,
+				state,
+				delivered_at:
+					state === 'delivered'
+						? (current.delivered_at ?? new Date().toISOString())
+						: current.delivered_at,
+			}
+		})
 		if (hasRetryableFailure || final.state === 'retryable_failed') {
 			throw new RetryableDeliveryError(
 				'One or more notification destinations require retry',
@@ -245,6 +319,38 @@ export class NotificationDeliveryQueue {
 	async close(): Promise<void> {
 		await this.worker?.close()
 		await this.queue.close()
+	}
+}
+
+interface PropPostDestination {
+	guild_id: string
+	channel_id: string
+	over_outcome_uuid: string
+	under_outcome_uuid: string
+}
+
+function parsePropPostDestination(destinationId: string): PropPostDestination {
+	const [
+		prefix,
+		guild_id,
+		channel_id,
+		over_outcome_uuid,
+		under_outcome_uuid,
+	] = destinationId.split(':')
+	if (
+		prefix !== 'prop-post' ||
+		!guild_id ||
+		!channel_id ||
+		!over_outcome_uuid ||
+		!under_outcome_uuid
+	) {
+		throw new Error(`Invalid prop-post destination ${destinationId}`)
+	}
+	return {
+		guild_id,
+		channel_id,
+		over_outcome_uuid,
+		under_outcome_uuid,
 	}
 }
 

--- a/src/utils/api/routes/notifications/delivery-queue.ts
+++ b/src/utils/api/routes/notifications/delivery-queue.ts
@@ -15,6 +15,7 @@ import {
 import type NotificationService from './notifications.service.js'
 
 export const NOTIFICATION_DELIVERY_QUEUE = 'notification-delivery-v1'
+export const SYSTEM_DISCORD_BASE_URL = 'http://fake-discord:8080'
 
 // Keep queue construction lazy and environment-only. Importing notification
 // routes in unit tests must not force Pluto's full startup env schema.
@@ -108,6 +109,109 @@ class DiscordDeliveryDispatcher implements DeliveryDispatcher {
 			reference,
 		)
 	}
+}
+
+export class SystemDiscordDeliveryDispatcher implements DeliveryDispatcher {
+	async deliver(envelope: DeliveryEnvelope, destinationId: string) {
+		if (envelope.kind === 'parlay_result') {
+			if (!destinationId.startsWith('dm:'))
+				throw new Error(`Invalid parlay destination ${destinationId}`)
+			return sendToFakeDiscord(
+				`/users/${encodeURIComponent(envelope.payload.user_id)}/messages`,
+				'POST',
+				{ destination_id: destinationId, envelope },
+			)
+		}
+
+		if (envelope.kind === 'prop_post') {
+			const destination = parsePropPostDestination(destinationId)
+			const prop = envelope.payload.props.find(
+				(candidate) =>
+					candidate.over.outcome_uuid ===
+						destination.over_outcome_uuid &&
+					candidate.under.outcome_uuid ===
+						destination.under_outcome_uuid,
+			)
+			if (!prop)
+				throw new Error(
+					`Unknown prop-post destination ${destinationId}`,
+				)
+			const response = await sendToFakeDiscord(
+				`/channels/${encodeURIComponent(destination.channel_id)}/messages`,
+				'POST',
+				{ destination_id: destinationId, envelope, prop },
+			)
+			const messageId =
+				fakeDiscordMessageId(response) ??
+				`fake-${envelope.delivery_id}-${destination.channel_id}`
+			return [
+				{
+					outcome_uuid: destination.over_outcome_uuid,
+					guild_id: destination.guild_id,
+					channel_id: destination.channel_id,
+					message_id: messageId,
+				},
+				{
+					outcome_uuid: destination.under_outcome_uuid,
+					guild_id: destination.guild_id,
+					channel_id: destination.channel_id,
+					message_id: messageId,
+				},
+			]
+		}
+
+		const reference = envelope.payload.messages.find(
+			(candidate) =>
+				`prop:${candidate.guild_id}:${candidate.channel_id}:${candidate.message_id}` ===
+				destinationId,
+		)
+		if (!reference)
+			throw new Error(`Unknown prop destination ${destinationId}`)
+		return sendToFakeDiscord(
+			`/channels/${encodeURIComponent(reference.channel_id)}/messages/${encodeURIComponent(reference.message_id)}`,
+			'PATCH',
+			{ destination_id: destinationId, envelope },
+		)
+	}
+}
+
+async function sendToFakeDiscord(
+	path: string,
+	method: 'POST' | 'PATCH',
+	body: unknown,
+): Promise<unknown> {
+	const response = await fetch(`${SYSTEM_DISCORD_BASE_URL}${path}`, {
+		method,
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+	const payload = await readJsonResponse(response)
+	if (!response.ok) {
+		const error = new Error(
+			`fake-discord returned ${response.status} for ${method} ${path}`,
+		)
+		Object.assign(error, { status: response.status, payload })
+		throw error
+	}
+	return payload
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+	const text = await response.text()
+	if (!text) return undefined
+	try {
+		return JSON.parse(text)
+	} catch {
+		return text
+	}
+}
+
+function fakeDiscordMessageId(response: unknown): string | undefined {
+	if (!response || typeof response !== 'object') return undefined
+	const candidate = response as Record<string, unknown>
+	if (typeof candidate.id === 'string') return candidate.id
+	if (typeof candidate.message_id === 'string') return candidate.message_id
+	return undefined
 }
 
 class RetryableDeliveryError extends Error {
@@ -395,6 +499,24 @@ function updateDestination(
 }
 
 let defaultQueue: NotificationDeliveryQueue | undefined
+
+export function setNotificationDeliveryQueue(
+	queue: NotificationDeliveryQueue,
+): void {
+	defaultQueue = queue
+}
+
+export function resetNotificationDeliveryQueue(): void {
+	defaultQueue = undefined
+}
+
+export function configureSystemNotificationDelivery(): NotificationDeliveryQueue {
+	const queue = new NotificationDeliveryQueue({
+		dispatcher: new SystemDiscordDeliveryDispatcher(),
+	})
+	setNotificationDeliveryQueue(queue)
+	return queue
+}
 
 export function getNotificationDeliveryQueue(): NotificationDeliveryQueue {
 	if (!defaultQueue) defaultQueue = new NotificationDeliveryQueue()

--- a/src/utils/api/routes/notifications/delivery-queue.ts
+++ b/src/utils/api/routes/notifications/delivery-queue.ts
@@ -1,0 +1,286 @@
+import { type Job, Queue, Worker } from 'bullmq'
+import {
+	classifyDeliveryError,
+	type DeliveryEnvelope,
+	type DeliveryRecord,
+	type DestinationState,
+} from './delivery-contract.js'
+import {
+	type DeliveryStore,
+	deriveDeliveryState,
+	RedisDeliveryStore,
+} from './delivery-store.js'
+import type NotificationService from './notifications.service.js'
+
+export const NOTIFICATION_DELIVERY_QUEUE = 'notification-delivery-v1'
+
+// Keep queue construction lazy and environment-only. Importing notification
+// routes in unit tests must not force Pluto's full startup env schema.
+const REDIS_CONFIG = {
+	host: process.env.R_HOST ?? '127.0.0.1',
+	port: Number(process.env.R_PORT ?? 6379),
+	password: process.env.R_PASS,
+}
+
+export interface DeliveryDispatcher {
+	deliver(envelope: DeliveryEnvelope, destinationId: string): Promise<unknown>
+}
+
+class DiscordDeliveryDispatcher implements DeliveryDispatcher {
+	private service?: NotificationService
+
+	private async getService(): Promise<NotificationService> {
+		if (!this.service) {
+			const module = await import('./notifications.service.js')
+			this.service = new module.default()
+		}
+		return this.service
+	}
+
+	async deliver(envelope: DeliveryEnvelope, destinationId: string) {
+		if (envelope.kind === 'parlay_result') {
+			if (!destinationId.startsWith('dm:'))
+				throw new Error(`Invalid parlay destination ${destinationId}`)
+			return (await this.getService()).deliverParlayResult(
+				envelope.payload,
+				envelope.delivery_id,
+			)
+		}
+
+		const reference = envelope.payload.messages.find(
+			(candidate) =>
+				`prop:${candidate.guild_id}:${candidate.channel_id}:${candidate.message_id}` ===
+				destinationId,
+		)
+		if (!reference)
+			throw new Error(`Unknown prop destination ${destinationId}`)
+		return (await this.getService()).deliverPropSettlementMessage(
+			envelope.payload,
+			reference,
+		)
+	}
+}
+
+class RetryableDeliveryError extends Error {
+	readonly retryable = true
+}
+
+type DeliveryJob = DeliveryEnvelope
+
+export interface NotificationDeliveryQueueOptions {
+	store?: DeliveryStore
+	dispatcher?: DeliveryDispatcher
+	queue?: DeliveryQueuePort
+	startWorker?: boolean
+}
+
+export interface DeliveryQueuePort {
+	add(
+		name: string,
+		data: DeliveryJob,
+		options: { jobId: string },
+	): Promise<unknown>
+	close(): Promise<void>
+}
+
+export class NotificationDeliveryQueue {
+	readonly queue: DeliveryQueuePort
+	private readonly worker?: Worker<DeliveryJob>
+	private readonly store: DeliveryStore
+	private readonly dispatcher: DeliveryDispatcher
+
+	constructor(options: NotificationDeliveryQueueOptions = {}) {
+		this.store = options.store ?? new RedisDeliveryStore()
+		this.dispatcher = options.dispatcher ?? new DiscordDeliveryDispatcher()
+		this.queue =
+			options.queue ??
+			(new Queue<DeliveryJob>(NOTIFICATION_DELIVERY_QUEUE, {
+				connection: REDIS_CONFIG,
+				defaultJobOptions: {
+					attempts: 8,
+					backoff: { type: 'exponential', delay: 60_000 },
+					removeOnComplete: { age: 180 * 24 * 60 * 60 },
+					removeOnFail: false,
+				},
+			}) as unknown as DeliveryQueuePort)
+		if (options.startWorker !== false) {
+			this.worker = new Worker<DeliveryJob>(
+				NOTIFICATION_DELIVERY_QUEUE,
+				async (job) => this.process(job),
+				{
+					connection: REDIS_CONFIG,
+					concurrency: 8,
+					lockDuration: 60_000,
+					stalledInterval: 30_000,
+				},
+			)
+			this.worker.on('failed', (job, error) => {
+				void import('../../../logging/WinstonLogger.js').then(
+					({ logger }) =>
+						logger.error({
+							method: 'NotificationDeliveryQueue',
+							event: 'notification.delivery.job_failed',
+							delivery_id: job?.data.delivery_id,
+							error: error.message.slice(0, 500),
+						}),
+				)
+			})
+		}
+	}
+
+	async accept(envelope: DeliveryEnvelope): Promise<DeliveryRecord> {
+		const accepted = await this.store.accept(envelope)
+		if (accepted.kind === 'conflict') {
+			const error = new Error(
+				'Delivery ID is already used for another payload',
+			)
+			Object.assign(error, { code: 'DELIVERY_PAYLOAD_MISMATCH' })
+			throw error
+		}
+		if (accepted.kind === 'accepted') {
+			try {
+				await this.queue.add('deliver', envelope, {
+					jobId: envelope.delivery_id,
+				})
+			} catch (error) {
+				await this.store.update(envelope.delivery_id, (record) => ({
+					...record,
+					state: 'retryable_failed',
+				}))
+				throw error
+			}
+		} else if (
+			accepted.record.state === 'queued' ||
+			accepted.record.state === 'retryable_failed'
+		) {
+			// Re-enqueue is safe after a worker restart or an ambiguous queue
+			// acknowledgement because delivery_id is BullMQ's stable job ID.
+			try {
+				await this.queue.add('deliver', envelope, {
+					jobId: envelope.delivery_id,
+				})
+			} catch (error) {
+				if (!isDuplicateQueueError(error)) throw error
+			}
+		}
+		return accepted.record
+	}
+
+	async get(deliveryId: string): Promise<DeliveryRecord | null> {
+		return this.store.get(deliveryId)
+	}
+
+	private async process(job: Job<DeliveryJob>): Promise<void> {
+		const { delivery_id: deliveryId } = job.data
+		const record = await this.store.get(deliveryId)
+		if (!record) return
+
+		await this.store.update(deliveryId, (current) => ({
+			...current,
+			state: 'processing',
+			attempts: current.attempts + 1,
+		}))
+		let hasRetryableFailure = false
+
+		for (const destination of record.destinations) {
+			if (
+				destination.state === 'delivered' ||
+				destination.state === 'permanent_failed'
+			)
+				continue
+
+			await this.store.update(deliveryId, (current) =>
+				updateDestination(current, destination.id, {
+					state: 'processing',
+				}),
+			)
+			try {
+				const receipt = await this.dispatcher.deliver(
+					job.data,
+					destination.id,
+				)
+				await this.store.update(deliveryId, (current) =>
+					updateDestination(current, destination.id, {
+						state: 'delivered',
+						receipt,
+					}),
+				)
+			} catch (error) {
+				const classified = classifyDeliveryError(error)
+				const state: DestinationState =
+					classified.classification === 'permanent'
+						? 'permanent_failed'
+						: 'retryable_failed'
+				await this.store.update(deliveryId, (current) =>
+					updateDestination(current, destination.id, {
+						state,
+						last_error: classified.message,
+						classification: classified.classification,
+					}),
+				)
+				if (state === 'retryable_failed') hasRetryableFailure = true
+			}
+		}
+
+		const final = await this.store.update(deliveryId, (current) => ({
+			...current,
+			state: deriveDeliveryState(current),
+			delivered_at:
+				deriveDeliveryState(current) === 'delivered'
+					? (current.delivered_at ?? new Date().toISOString())
+					: current.delivered_at,
+		}))
+		if (hasRetryableFailure || final.state === 'retryable_failed') {
+			throw new RetryableDeliveryError(
+				'One or more notification destinations require retry',
+			)
+		}
+	}
+
+	/** Focused seam for integration tests; BullMQ invokes the same handler. */
+	async processJob(job: Job<DeliveryJob>): Promise<void> {
+		return this.process(job)
+	}
+
+	async close(): Promise<void> {
+		await this.worker?.close()
+		await this.queue.close()
+	}
+}
+
+function isDuplicateQueueError(error: unknown): boolean {
+	const candidate = error as { code?: string; message?: string }
+	return (
+		candidate.code === 'ERR_JOB_EXISTS' ||
+		(candidate.message?.toLowerCase().includes('already exists') ?? false)
+	)
+}
+
+function updateDestination(
+	record: DeliveryRecord,
+	destinationId: string,
+	patch: Partial<DeliveryRecord['destinations'][number]>,
+): DeliveryRecord {
+	return {
+		...record,
+		destinations: record.destinations.map((destination) =>
+			destination.id === destinationId
+				? {
+						...destination,
+						...patch,
+						attempts:
+							patch.state === 'processing'
+								? destination.attempts + 1
+								: destination.attempts,
+					}
+				: destination,
+		),
+	}
+}
+
+let defaultQueue: NotificationDeliveryQueue | undefined
+
+export function getNotificationDeliveryQueue(): NotificationDeliveryQueue {
+	if (!defaultQueue) defaultQueue = new NotificationDeliveryQueue()
+	return defaultQueue
+}

--- a/src/utils/api/routes/notifications/delivery-queue.ts
+++ b/src/utils/api/routes/notifications/delivery-queue.ts
@@ -242,7 +242,9 @@ export class NotificationDeliveryQueue {
 
 		for (const destination of record.destinations) {
 			if (
-				destination.state === 'delivered' ||
+				(destination.state === 'delivered' &&
+					(record.kind !== 'prop_post' ||
+						hasPropPostReceiptPair(destination))) ||
 				destination.state === 'permanent_failed'
 			)
 				continue
@@ -352,6 +354,14 @@ function parsePropPostDestination(destinationId: string): PropPostDestination {
 		over_outcome_uuid,
 		under_outcome_uuid,
 	}
+}
+
+function hasPropPostReceiptPair(
+	destination: DeliveryRecord['destinations'][number],
+): boolean {
+	return (
+		Array.isArray(destination.receipt) && destination.receipt.length === 2
+	)
 }
 
 function isDuplicateQueueError(error: unknown): boolean {

--- a/src/utils/api/routes/notifications/delivery-store.ts
+++ b/src/utils/api/routes/notifications/delivery-store.ts
@@ -1,0 +1,148 @@
+import type { RedisCacheClient } from '../../../cache/redis-instance.js'
+import {
+	type DeliveryEnvelope,
+	type DeliveryRecord,
+	type DeliveryState,
+	deliveryPayloadHash,
+	destinationIds,
+} from './delivery-contract.js'
+
+const KEY_PREFIX = 'pluto:delivery:v1:'
+const RETENTION_SECONDS = 180 * 24 * 60 * 60
+
+export type AcceptDeliveryResult =
+	| { kind: 'accepted'; record: DeliveryRecord }
+	| { kind: 'duplicate'; record: DeliveryRecord }
+	| { kind: 'conflict'; record: DeliveryRecord }
+
+export interface DeliveryStore {
+	accept(envelope: DeliveryEnvelope): Promise<AcceptDeliveryResult>
+	get(deliveryId: string): Promise<DeliveryRecord | null>
+	update(
+		deliveryId: string,
+		update: (record: DeliveryRecord) => DeliveryRecord,
+	): Promise<DeliveryRecord>
+}
+
+function key(deliveryId: string): string {
+	return `${KEY_PREFIX}${deliveryId}`
+}
+
+function parseRecord(raw: string | null): DeliveryRecord | null {
+	if (!raw) return null
+	try {
+		const parsed = JSON.parse(raw) as DeliveryRecord
+		if (
+			typeof parsed.delivery_id !== 'string' ||
+			typeof parsed.payload_hash !== 'string' ||
+			!Array.isArray(parsed.destinations)
+		)
+			return null
+		return parsed
+	} catch {
+		return null
+	}
+}
+
+export class RedisDeliveryStore implements DeliveryStore {
+	private redis?: RedisCacheClient
+
+	constructor(redis?: RedisCacheClient) {
+		this.redis = redis
+	}
+
+	private async client(): Promise<RedisCacheClient> {
+		if (!this.redis) {
+			// Defer env validation/Redis connection until a delivery route is
+			// actually used. This keeps route and contract tests hermetic.
+			this.redis = (
+				await import('../../../cache/redis-instance.js')
+			).default
+		}
+		return this.redis
+	}
+
+	async accept(envelope: DeliveryEnvelope): Promise<AcceptDeliveryResult> {
+		const deliveryKey = key(envelope.delivery_id)
+		const payloadHash = deliveryPayloadHash(envelope)
+		const now = new Date().toISOString()
+		const record: DeliveryRecord = {
+			delivery_id: envelope.delivery_id,
+			kind: envelope.kind,
+			schema_version: 1,
+			occurred_at: envelope.occurred_at,
+			payload: envelope.payload,
+			payload_hash: payloadHash,
+			state: 'queued',
+			attempts: 0,
+			destinations: destinationIds(envelope).map((id) => ({
+				id,
+				state: 'queued',
+				attempts: 0,
+			})),
+			created_at: now,
+			updated_at: now,
+		}
+
+		const redis = await this.client()
+		const created = await redis.set(
+			deliveryKey,
+			JSON.stringify(record),
+			'NX',
+			'EX',
+			RETENTION_SECONDS,
+		)
+		if (created === 'OK') return { kind: 'accepted', record }
+
+		const existing = await this.get(envelope.delivery_id)
+		if (!existing) {
+			// A malformed record must never be overwritten by a callback. Treat it
+			// as a conflict so operators can inspect and repair it explicitly.
+			return { kind: 'conflict', record }
+		}
+		return existing.payload_hash === payloadHash
+			? { kind: 'duplicate', record: existing }
+			: { kind: 'conflict', record: existing }
+	}
+
+	async get(deliveryId: string): Promise<DeliveryRecord | null> {
+		return parseRecord(await (await this.client()).get(key(deliveryId)))
+	}
+
+	async update(
+		deliveryId: string,
+		mutate: (record: DeliveryRecord) => DeliveryRecord,
+	): Promise<DeliveryRecord> {
+		const existing = await this.get(deliveryId)
+		if (!existing) throw new Error(`Delivery ${deliveryId} not found`)
+		const next = mutate(existing)
+		next.updated_at = new Date().toISOString()
+		await (await this.client()).set(
+			key(deliveryId),
+			JSON.stringify(next),
+			'EX',
+			RETENTION_SECONDS,
+		)
+		return next
+	}
+}
+
+export function deriveDeliveryState(record: DeliveryRecord): DeliveryState {
+	const states = record.destinations.map((destination) => destination.state)
+	if (states.every((state) => state === 'delivered')) return 'delivered'
+	if (states.some((state) => state === 'processing')) return 'processing'
+	if (states.some((state) => state === 'retryable_failed')) {
+		return 'retryable_failed'
+	}
+	if (states.every((state) => state === 'permanent_failed')) {
+		return 'permanent_failed'
+	}
+	if (states.some((state) => state === 'permanent_failed')) {
+		return states.every(
+			(state) => state === 'delivered' || state === 'permanent_failed',
+		)
+			? 'permanent_failed'
+			: 'processing'
+	}
+	return 'queued'
+}

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -2,7 +2,10 @@ import Router from '@koa/router'
 import type { Context, Next } from 'koa'
 import { z } from 'zod'
 import { logger } from '../../../logging/WinstonLogger.js'
-import { deliveryEnvelopeSchema } from './delivery-contract.js'
+import {
+	deliveryEnvelopeSchema,
+	deliveryReceipts,
+} from './delivery-contract.js'
 import { getNotificationDeliveryQueue } from './delivery-queue.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
@@ -259,9 +262,13 @@ NotificationRouter.get(
 		ctx.status = 200
 		ctx.body = {
 			delivery_id: record.delivery_id,
+			kind: record.kind,
 			status: record.state,
 			attempts: record.attempts,
 			destinations: record.destinations,
+			...(record.kind === 'prop_post'
+				? { receipts: deliveryReceipts(record) }
+				: {}),
 			delivered_at: record.delivered_at,
 		}
 	},

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -1,6 +1,9 @@
 import Router from '@koa/router'
 import type { Context, Next } from 'koa'
+import { z } from 'zod'
 import { logger } from '../../../logging/WinstonLogger.js'
+import { deliveryEnvelopeSchema } from './delivery-contract.js'
+import { getNotificationDeliveryQueue } from './delivery-queue.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
 import { validateParlayResultNotification } from './parlay-notification-utils.js'
@@ -67,6 +70,53 @@ NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 
 NotificationRouter.post('/notifications/parlays/results', async (ctx) => {
 	const rawPayload = ctx.request.body || {}
+	const envelope = deliveryEnvelopeSchema.safeParse(rawPayload)
+	if (envelope.success && envelope.data.kind === 'parlay_result') {
+		try {
+			const record = await getNotificationDeliveryQueue().accept(
+				envelope.data,
+			)
+			ctx.status = 202
+			ctx.body = {
+				delivery_id: record.delivery_id,
+				status: record.state,
+			}
+			return
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				(error as Error & { code?: string }).code ===
+					'DELIVERY_PAYLOAD_MISMATCH'
+			) {
+				ctx.status = 409
+				ctx.body = {
+					success: false,
+					code: 'DELIVERY_PAYLOAD_MISMATCH',
+					error: 'delivery_id is already used for another payload',
+				}
+				return
+			}
+			logger.error({
+				method: 'NotificationRouter',
+				event: 'parlay.notification.queue_failed',
+				error: error instanceof Error ? error.message : String(error),
+			})
+			ctx.status = 503
+			ctx.body = {
+				success: false,
+				error: 'Notification queue unavailable',
+			}
+			return
+		}
+	}
+	if ('delivery_id' in (rawPayload as object)) {
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid delivery envelope. Failed Zod validation.',
+		}
+		return
+	}
 	const validatedData = validateParlayResultNotification(rawPayload)
 
 	if (!validatedData) {
@@ -107,6 +157,54 @@ NotificationRouter.post(
 	requireApiKeyAuthentication,
 	async (ctx) => {
 		const rawPayload = ctx.request.body || {}
+		const envelope = deliveryEnvelopeSchema.safeParse(rawPayload)
+		if (envelope.success && envelope.data.kind === 'prop_settled') {
+			try {
+				const record = await getNotificationDeliveryQueue().accept(
+					envelope.data,
+				)
+				ctx.status = 202
+				ctx.body = {
+					delivery_id: record.delivery_id,
+					status: record.state,
+				}
+				return
+			} catch (error) {
+				if (
+					error instanceof Error &&
+					(error as Error & { code?: string }).code ===
+						'DELIVERY_PAYLOAD_MISMATCH'
+				) {
+					ctx.status = 409
+					ctx.body = {
+						success: false,
+						code: 'DELIVERY_PAYLOAD_MISMATCH',
+						error: 'delivery_id is already used for another payload',
+					}
+					return
+				}
+				logger.error({
+					method: 'NotificationRouter',
+					event: 'prop.notification.queue_failed',
+					error:
+						error instanceof Error ? error.message : String(error),
+				})
+				ctx.status = 503
+				ctx.body = {
+					success: false,
+					error: 'Notification queue unavailable',
+				}
+				return
+			}
+		}
+		if ('delivery_id' in (rawPayload as object)) {
+			ctx.status = 422
+			ctx.body = {
+				success: false,
+				error: 'Invalid delivery envelope. Failed Zod validation.',
+			}
+			return
+		}
 		const validatedData = validatePropSettledNotification(rawPayload)
 
 		if (!validatedData) {
@@ -138,6 +236,33 @@ NotificationRouter.post(
 				error: 'Failed to process prop settlement notification',
 			}
 			ctx.status = 500
+		}
+	},
+)
+
+NotificationRouter.get(
+	'/deliveries/:delivery_id',
+	requireApiKeyAuthentication,
+	async (ctx) => {
+		const deliveryId = ctx.params.delivery_id
+		if (!z.string().uuid().safeParse(deliveryId).success) {
+			ctx.status = 422
+			ctx.body = { success: false, error: 'delivery_id is required' }
+			return
+		}
+		const record = await getNotificationDeliveryQueue().get(deliveryId)
+		if (!record) {
+			ctx.status = 404
+			ctx.body = { success: false, error: 'Delivery not found' }
+			return
+		}
+		ctx.status = 200
+		ctx.body = {
+			delivery_id: record.delivery_id,
+			status: record.state,
+			attempts: record.attempts,
+			destinations: record.destinations,
+			delivered_at: record.delivered_at,
 		}
 	},
 )

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 // Import interfaces and potentially the Discord client type
 import { container } from '@sapphire/framework'
 import { EmbedBuilder, type Message } from 'discord.js'
@@ -21,6 +22,16 @@ import type {
 	NotifyBetUsers,
 } from './notifications.interface.js'
 import type { ParlayResultNotification } from './parlay-notification-contract.js'
+
+function createDeliveryNonce(
+	deliveryId: string,
+	destinationIndex: number,
+): string {
+	return createHash('sha256')
+		.update(`${deliveryId}:${destinationIndex}`)
+		.digest('hex')
+		.slice(0, 25)
+}
 
 export default class NotificationService {
 	private bigWinAnnouncementService?: BigWinAnnouncementService
@@ -142,67 +153,47 @@ export default class NotificationService {
 	}
 
 	/**
+	 * Queue worker entrypoint. Unlike the legacy callback method, Discord
+	 * failures propagate so BullMQ can retain and retry the destination.
+	 */
+	async deliverParlayResult(
+		data: ParlayResultNotification,
+		deliveryId?: string,
+	): Promise<void> {
+		const embeds = this.buildParlayEmbeds(data)
+		await this.sendParlayEmbeds(
+			data.user_id,
+			data,
+			embeds,
+			true,
+			deliveryId,
+		)
+		try {
+			await this.announceParlayWin(data)
+		} catch (error) {
+			logger.warn({
+				method: this.deliverParlayResult.name,
+				event: 'parlay.notification.announcement_failed',
+				parlay_id: data.parlay_id,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	/**
 	 * Apply one Khronos prop settlement to every original Discord post in the
 	 * posting ledger. A missing/deleted message is a delivery warning, not a
 	 * failed settlement: Khronos has already committed the outcome and can
 	 * safely retry the callback later.
 	 */
 	async processPropSettled(data: PropSettledNotification): Promise<void> {
-		const client = container.client
-		if (!client) {
-			logger.error({
-				method: this.processPropSettled.name,
-				event: 'prop.notification.delivery_failed',
-				message:
-					'Discord client not available for prop settlement update',
-				critical: true,
-				outcome_uuid: data.outcome_uuid,
-			})
-			return
-		}
-
 		const processedMessages = new Set<string>()
 		for (const reference of data.messages) {
 			const messageKey = `${reference.guild_id}:${reference.channel_id}:${reference.message_id}`
 			if (processedMessages.has(messageKey)) continue
 			processedMessages.add(messageKey)
-
 			try {
-				const channel = await client.channels.fetch(
-					reference.channel_id,
-				)
-				if (
-					!channel ||
-					!channel.isTextBased() ||
-					!('guildId' in channel) ||
-					channel.guildId !== reference.guild_id
-				) {
-					throw new Error(
-						`Channel ${reference.channel_id} is missing, not text-based, or belongs to another guild`,
-					)
-				}
-
-				const message = await channel.messages.fetch(
-					reference.message_id,
-				)
-				const updatedEmbeds = message.embeds.map((embed, index) =>
-					index === 0
-						? this.buildPropSettlementEmbed(message, data)
-						: EmbedBuilder.from(embed),
-				)
-
-				if (updatedEmbeds.length === 0) {
-					throw new Error(
-						'Original prop message has no embed to update',
-					)
-				}
-
-				await message.edit({
-					embeds: updatedEmbeds,
-					// The settlement is terminal. Removing components prevents stale
-					// buttons from being clicked while keeping the edit idempotent.
-					components: [],
-				})
+				await this.deliverPropSettlementMessage(data, reference)
 			} catch (error) {
 				logger.warn({
 					method: this.processPropSettled.name,
@@ -218,6 +209,47 @@ export default class NotificationService {
 				})
 			}
 		}
+	}
+
+	/** Deliver exactly one prop message, allowing the durable worker to retry it. */
+	async deliverPropSettlementMessage(
+		data: PropSettledNotification,
+		reference: PropSettledNotification['messages'][number],
+	): Promise<void> {
+		const client = container.client
+		if (!client) {
+			throw new Error(
+				'Discord client not available for prop settlement update',
+			)
+		}
+		const channel = await client.channels.fetch(reference.channel_id)
+		if (
+			!channel ||
+			!channel.isTextBased() ||
+			!('guildId' in channel) ||
+			channel.guildId !== reference.guild_id
+		) {
+			const error = new Error(
+				`Channel ${reference.channel_id} is missing, not text-based, or belongs to another guild`,
+			)
+			Object.assign(error, { code: '10003' })
+			throw error
+		}
+
+		const message = await channel.messages.fetch(reference.message_id)
+		const updatedEmbeds = message.embeds.map((embed, index) =>
+			index === 0
+				? this.buildPropSettlementEmbed(message, data)
+				: EmbedBuilder.from(embed),
+		)
+		if (updatedEmbeds.length === 0) {
+			const error = new Error(
+				'Original prop message has no embed to update',
+			)
+			Object.assign(error, { code: '10003' })
+			throw error
+		}
+		await message.edit({ embeds: updatedEmbeds, components: [] })
 	}
 
 	private buildPropSettlementEmbed(
@@ -527,6 +559,8 @@ export default class NotificationService {
 		userId: string,
 		data: ParlayResultNotification,
 		embeds: EmbedBuilder[],
+		throwOnFailure = false,
+		deliveryId?: string,
 	): Promise<void> {
 		const client = container.client
 
@@ -540,13 +574,22 @@ export default class NotificationService {
 				parlay_id: data.parlay_id,
 				user_id: userId,
 			})
+			if (throwOnFailure) throw new Error('Discord client not available')
 			return
 		}
 
 		try {
 			const user = await client.users.fetch(userId)
-			for (const embed of embeds) {
-				await user.send({ embeds: [embed] })
+			for (const [index, embed] of embeds.entries()) {
+				await user.send({
+					embeds: [embed],
+					...(deliveryId
+						? {
+								nonce: createDeliveryNonce(deliveryId, index),
+								enforceNonce: true,
+							}
+						: {}),
+				})
 			}
 		} catch (error) {
 			logger.error({
@@ -560,6 +603,7 @@ export default class NotificationService {
 				error: error instanceof Error ? error.message : String(error),
 				stack: error instanceof Error ? error.stack : undefined,
 			})
+			if (throwOnFailure) throw error
 		}
 	}
 

--- a/src/utils/api/routes/props/__tests__/props-router.test.ts
+++ b/src/utils/api/routes/props/__tests__/props-router.test.ts
@@ -8,18 +8,12 @@ const logger = vi.hoisted(() => ({
 	warn: vi.fn(),
 	info: vi.fn(),
 }))
-const postPropsToChannel = vi.hoisted(() => vi.fn())
+const acceptDetailed = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
-vi.mock('../../../../props/PropPostingHandler.js', () => {
-	function MockPropPostingHandler(this: {
-		postPropsToChannel: typeof postPropsToChannel
-	}) {
-		this.postPropsToChannel = postPropsToChannel
-	}
-
-	return { PropPostingHandler: MockPropPostingHandler }
-})
+vi.mock('../../notifications/delivery-queue.js', () => ({
+	getNotificationDeliveryQueue: () => ({ acceptDetailed }),
+}))
 
 import PropsRouter from '../props-router.js'
 
@@ -50,33 +44,36 @@ const validPayload = {
 	guilds: [{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' }],
 }
 
-const refs = [
-	{
-		outcome_uuid: validPayload.props[0].over.outcome_uuid,
-		guild_id: 'guild-1',
-		channel_id: 'channel-1',
-		message_id: 'message-1',
-	},
-	{
-		outcome_uuid: validPayload.props[0].under.outcome_uuid,
-		guild_id: 'guild-1',
-		channel_id: 'channel-1',
-		message_id: 'message-1',
-	},
-]
+const validEnvelope = {
+	delivery_id: '550e8400-e29b-41d4-a716-446655440010',
+	schema_version: 1,
+	kind: 'prop_post',
+	occurred_at: '2026-07-14T20:00:00.000Z',
+	payload: validPayload,
+}
+
+const queuedRecord = {
+	delivery_id: validEnvelope.delivery_id,
+	kind: 'prop_post',
+	schema_version: 1,
+	occurred_at: validEnvelope.occurred_at,
+	payload: validPayload,
+	payload_hash: 'hash',
+	state: 'queued',
+	attempts: 0,
+	destinations: [],
+	created_at: validEnvelope.occurred_at,
+	updated_at: validEnvelope.occurred_at,
+} as const
 
 describe('POST /props/daily', () => {
 	let server: Server | undefined
 
 	beforeEach(() => {
 		vi.clearAllMocks()
-		postPropsToChannel.mockResolvedValue({
-			posted: 1,
-			filtered: 0,
-			failed: 0,
-			total: 1,
-			results: refs,
-			failures: [],
+		acceptDetailed.mockResolvedValue({
+			record: queuedRecord,
+			duplicate: false,
 		})
 	})
 
@@ -109,17 +106,18 @@ describe('POST /props/daily', () => {
 		})
 	}
 
-	it('passes validated compact props to the posting handler and returns outcome refs', async () => {
-		const response = await request(validPayload)
+	it('durably accepts a validated prop-post envelope before Discord delivery', async () => {
+		const response = await request(validEnvelope)
 
-		expect(response.status).toBe(200)
-		expect(await response.json()).toEqual(refs)
-		expect(postPropsToChannel).toHaveBeenCalledWith(
-			'guild-1',
-			validPayload.props,
-			'nba',
-			'channel-1',
-		)
+		expect(response.status).toBe(202)
+		expect(await response.json()).toMatchObject({
+			accepted: true,
+			duplicate: false,
+			delivery_id: validEnvelope.delivery_id,
+			kind: 'prop_post',
+			status: 'queued',
+		})
+		expect(acceptDetailed).toHaveBeenCalledWith(validEnvelope)
 	})
 
 	it('rejects malformed payloads with structured 422 errors', async () => {
@@ -129,22 +127,29 @@ describe('POST /props/daily', () => {
 		const body = await response.json()
 		expect(body).toMatchObject({
 			success: false,
-			error: 'Invalid props payload. Failed Zod validation.',
+			error: 'Invalid prop-post delivery envelope. Failed Zod validation.',
 		})
 		expect(body.issues).toEqual(expect.any(Array))
-		expect(postPropsToChannel).not.toHaveBeenCalled()
+		expect(acceptDetailed).not.toHaveBeenCalled()
 	})
 
 	it('rejects unsupported guild sports with 422', async () => {
 		const response = await request({
-			...validPayload,
-			guilds: [
-				{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'mlb' },
-			],
+			...validEnvelope,
+			payload: {
+				...validPayload,
+				guilds: [
+					{
+						guild_id: 'guild-1',
+						channel_id: 'channel-1',
+						sport: 'mlb',
+					},
+				],
+			},
 		})
 
 		expect(response.status).toBe(422)
-		expect(postPropsToChannel).not.toHaveBeenCalled()
+		expect(acceptDetailed).not.toHaveBeenCalled()
 		expect(logger.warn).toHaveBeenCalledWith(
 			expect.objectContaining({
 				event: 'push_payload_rejected',
@@ -153,81 +158,32 @@ describe('POST /props/daily', () => {
 		)
 	})
 
-	it('returns 500 when a guild cannot receive props', async () => {
-		postPropsToChannel.mockResolvedValue({
-			posted: 0,
-			filtered: 0,
-			failed: 1,
-			total: 1,
-			results: [],
-			failures: [
-				{
-					guild_id: 'guild-1',
-					channel_id: 'channel-1',
-					outcome_uuids: refs.map((ref) => ref.outcome_uuid),
-					error: 'Discord unavailable',
-				},
-			],
-		})
+	it('returns 503 when durable queue acceptance fails', async () => {
+		acceptDetailed.mockRejectedValueOnce(new Error('Redis unavailable'))
 
-		const response = await request(validPayload)
+		const response = await request(validEnvelope)
 
-		expect(response.status).toBe(500)
-		expect(response.headers.get('x-props-failed')).toBe('1')
+		expect(response.status).toBe(503)
 		expect(await response.json()).toEqual({
 			success: false,
-			error: 'Failed to deliver one or more daily props.',
-			posted: [],
-			failures: [
-				{
-					guild_id: 'guild-1',
-					channel_id: 'channel-1',
-					outcome_uuids: refs.map((ref) => ref.outcome_uuid),
-					error: 'Discord unavailable',
-				},
-			],
+			error: 'Prop-post delivery queue unavailable.',
 		})
 		expect(logger.error).toHaveBeenCalledWith(
-			expect.objectContaining({
-				event: 'props_daily_delivery_failed',
-				failed_count: 1,
-			}),
+			expect.objectContaining({ event: 'props_daily_queue_failed' }),
 		)
 	})
 
-	it('returns posted refs alongside failure details when delivery is partial', async () => {
-		postPropsToChannel.mockResolvedValue({
-			posted: 1,
-			filtered: 0,
-			failed: 1,
-			total: 2,
-			results: refs,
-			failures: [
-				{
-					guild_id: 'guild-1',
-					channel_id: 'channel-1',
-					outcome_uuids: ['550e8400-e29b-41d4-a716-446655440002'],
-					error: 'Discord unavailable',
-				},
-			],
+	it('returns 409 when delivery ID is reused with a different payload', async () => {
+		const error = Object.assign(new Error('mismatch'), {
+			code: 'DELIVERY_PAYLOAD_MISMATCH',
 		})
+		acceptDetailed.mockRejectedValueOnce(error)
 
-		const response = await request(validPayload)
+		const response = await request(validEnvelope)
 
-		expect(response.status).toBe(500)
-		expect(response.headers.get('x-props-failed')).toBe('1')
-		expect(await response.json()).toEqual({
-			success: false,
-			error: 'Failed to deliver one or more daily props.',
-			posted: refs,
-			failures: [
-				{
-					guild_id: 'guild-1',
-					channel_id: 'channel-1',
-					outcome_uuids: ['550e8400-e29b-41d4-a716-446655440002'],
-					error: 'Discord unavailable',
-				},
-			],
+		expect(response.status).toBe(409)
+		expect(await response.json()).toMatchObject({
+			code: 'DELIVERY_PAYLOAD_MISMATCH',
 		})
 	})
 })

--- a/src/utils/api/routes/props/props-router.ts
+++ b/src/utils/api/routes/props/props-router.ts
@@ -1,16 +1,40 @@
 import Router from '@koa/router'
 import { logger } from '../../../logging/WinstonLogger.js'
-import { PropPostingHandler } from '../../../props/PropPostingHandler.js'
+import {
+	deliveryEnvelopeSchema,
+	deliveryReceipts,
+} from '../notifications/delivery-contract.js'
+import { getNotificationDeliveryQueue } from '../notifications/delivery-queue.js'
 import { dailyPropsPayloadSchema } from '../shared-payload-schemas.js'
 
 const PropsRouter = new Router()
-const propPostingHandler = new PropPostingHandler()
 
 const supportedSports = new Set(['nba', 'nfl'])
 
 PropsRouter.post('/props/daily', async (ctx) => {
+	const envelope = deliveryEnvelopeSchema.safeParse(ctx.request.body ?? {})
+	if (!envelope.success || envelope.data.kind !== 'prop_post') {
+		logger.warn({
+			method: 'PropsRouter',
+			event: 'push_payload_rejected',
+			schema: 'deliveryEnvelope.prop_post',
+			issues: envelope.success
+				? [{ message: 'Expected prop_post delivery envelope' }]
+				: envelope.error.issues,
+		})
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid prop-post delivery envelope. Failed Zod validation.',
+			issues: envelope.success
+				? [{ message: 'Expected prop_post delivery envelope' }]
+				: envelope.error.issues,
+		}
+		return
+	}
+
 	const parsedPayload = dailyPropsPayloadSchema.safeParse(
-		ctx.request.body ?? {},
+		envelope.data.payload,
 	)
 
 	if (!parsedPayload.success) {
@@ -23,8 +47,19 @@ PropsRouter.post('/props/daily', async (ctx) => {
 		ctx.status = 422
 		ctx.body = {
 			success: false,
-			error: 'Invalid props payload. Failed Zod validation.',
+			error: 'Invalid prop-post delivery envelope. Failed Zod validation.',
 			issues: parsedPayload.error.issues,
+		}
+		return
+	}
+	if (
+		parsedPayload.data.props.length === 0 ||
+		parsedPayload.data.guilds.length === 0
+	) {
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Prop-post delivery must include at least one prop and guild.',
 		}
 		return
 	}
@@ -53,55 +88,42 @@ PropsRouter.post('/props/daily', async (ctx) => {
 	}
 
 	try {
-		const postingResults = await Promise.all(
-			parsedPayload.data.guilds.map((guild) =>
-				propPostingHandler.postPropsToChannel(
-					guild.guild_id,
-					parsedPayload.data.props,
-					guild.sport.toLowerCase() as 'nba' | 'nfl',
-					guild.channel_id,
-				),
-			),
-		)
-		const references = postingResults.flatMap((result) => result.results)
-		const failures = postingResults.flatMap((result) => result.failures)
-		const failed = postingResults.reduce(
-			(total, result) => total + result.failed,
-			0,
-		)
-
-		if (failed > 0) {
-			logger.error({
-				method: 'PropsRouter',
-				event: 'props_daily_delivery_failed',
-				posted_count: references.length,
-				failed_count: failed,
-				failures,
-				results: postingResults,
-			})
-			ctx.set('X-Props-Failed', String(failed))
-			ctx.status = 500
+		const { record, duplicate } =
+			await getNotificationDeliveryQueue().acceptDetailed(envelope.data)
+		ctx.status = 202
+		ctx.body = {
+			accepted: true,
+			duplicate,
+			delivery_id: record.delivery_id,
+			kind: record.kind,
+			status: record.state,
+			...(record.kind === 'prop_post'
+				? { receipts: deliveryReceipts(record) }
+				: {}),
+		}
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			(error as Error & { code?: string }).code ===
+				'DELIVERY_PAYLOAD_MISMATCH'
+		) {
+			ctx.status = 409
 			ctx.body = {
 				success: false,
-				error: 'Failed to deliver one or more daily props.',
-				posted: references,
-				failures,
+				code: 'DELIVERY_PAYLOAD_MISMATCH',
+				error: 'delivery_id is already used for another payload',
 			}
 			return
 		}
-
-		ctx.status = 200
-		ctx.body = references
-	} catch (error) {
 		logger.error({
 			method: 'PropsRouter',
-			event: 'props_daily_processing_failed',
+			event: 'props_daily_queue_failed',
 			error: error instanceof Error ? error.message : String(error),
 		})
-		ctx.status = 500
+		ctx.status = 503
 		ctx.body = {
 			success: false,
-			error: 'Failed to process daily props.',
+			error: 'Prop-post delivery queue unavailable.',
 		}
 	}
 })

--- a/src/utils/cache/__tests__/cache-manager.test.ts
+++ b/src/utils/cache/__tests__/cache-manager.test.ts
@@ -1,42 +1,62 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const evalRedis = vi.fn()
+const atomicRedis = {
+	compareAndRemove: vi.fn(),
+	refreshIfOwned: vi.fn(),
+	transitionIfValue: vi.fn(),
+}
 
 vi.mock('../redis-instance.js', () => ({
-	default: { eval: evalRedis },
+	default: atomicRedis,
 }))
 
 const { CacheManager } = await import('../cache-manager.js')
 
 describe('CacheManager lock ownership', () => {
 	it('compares the serialized token written by setIfAbsent', async () => {
-		evalRedis.mockResolvedValueOnce(1)
+		atomicRedis.compareAndRemove.mockResolvedValueOnce(true)
 		const cache = new CacheManager()
 
 		await expect(
 			cache.compareAndRemove('lock-key', 'owner-token'),
 		).resolves.toBe(true)
-		expect(evalRedis).toHaveBeenCalledWith(
-			expect.stringContaining("redis.call('get', KEYS[1])"),
-			1,
+		expect(atomicRedis.compareAndRemove).toHaveBeenCalledWith(
 			'lock-key',
 			JSON.stringify('owner-token'),
 		)
 	})
 
 	it('refreshes a reservation only while the serialized owner token matches', async () => {
-		evalRedis.mockResolvedValueOnce(1)
+		atomicRedis.refreshIfOwned.mockResolvedValueOnce(true)
 		const cache = new CacheManager()
 
 		await expect(
 			cache.refreshIfOwned('placement-key', 'owner-token', 120),
 		).resolves.toBe(true)
-		expect(evalRedis).toHaveBeenCalledWith(
-			expect.stringContaining("redis.call('expire', KEYS[1], ARGV[2])"),
-			1,
+		expect(atomicRedis.refreshIfOwned).toHaveBeenCalledWith(
 			'placement-key',
 			JSON.stringify('owner-token'),
 			120,
+		)
+	})
+
+	it('transitions serialized values through the typed atomic port', async () => {
+		atomicRedis.transitionIfValue.mockResolvedValueOnce(true)
+		const cache = new CacheManager()
+
+		await expect(
+			cache.transitionIfValue(
+				'delivery-key',
+				{ status: 'pending' },
+				{ status: 'processing' },
+				60,
+			),
+		).resolves.toBe(true)
+		expect(atomicRedis.transitionIfValue).toHaveBeenCalledWith(
+			'delivery-key',
+			JSON.stringify({ status: 'pending' }),
+			JSON.stringify({ status: 'processing' }),
+			60,
 		)
 	})
 })

--- a/src/utils/cache/__tests__/redis-atomic-contract.ts
+++ b/src/utils/cache/__tests__/redis-atomic-contract.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AtomicCacheOperations } from '../redis-instance.js'
+
+export interface AtomicContractClient extends AtomicCacheOperations {
+	set(
+		key: string,
+		value: string,
+		...args: Array<string | number>
+	): Promise<unknown>
+	get(key: string): Promise<string | null>
+	del(...keys: string[]): Promise<unknown>
+	ttl(key: string): Promise<number>
+}
+
+export function runAtomicCacheContract(
+	name: string,
+	getClient: () => AtomicContractClient,
+	namespace: string,
+): void {
+	describe(name, () => {
+		const keys = ['lock', 'lease', 'delivery'].map(
+			(key) => `${namespace}:${key}`,
+		)
+		const [lockKey, leaseKey, deliveryKey] = keys as [
+			string,
+			string,
+			string,
+		]
+
+		beforeEach(async () => {
+			await getClient().del(...keys)
+		})
+
+		afterEach(async () => {
+			await getClient().del(...keys)
+		})
+
+		it('removes a value only for its current owner', async () => {
+			const client = getClient()
+			await client.set(lockKey, 'owner-a')
+
+			await expect(
+				client.compareAndRemove(lockKey, 'owner-b'),
+			).resolves.toBe(false)
+			await expect(client.get(lockKey)).resolves.toBe('owner-a')
+			await expect(
+				client.compareAndRemove(lockKey, 'owner-a'),
+			).resolves.toBe(true)
+			await expect(client.get(lockKey)).resolves.toBeNull()
+		})
+
+		it('refreshes and replaces expiry only for the current owner', async () => {
+			const client = getClient()
+			await client.set(leaseKey, 'owner-a', 'EX', 2)
+
+			await expect(
+				client.refreshIfOwned(leaseKey, 'owner-b', 30),
+			).resolves.toBe(false)
+			const unchangedTtl = await client.ttl(leaseKey)
+			expect(unchangedTtl).toBeGreaterThan(0)
+			expect(unchangedTtl).toBeLessThanOrEqual(2)
+			await expect(
+				client.refreshIfOwned(leaseKey, 'owner-a', 30),
+			).resolves.toBe(true)
+			await expect(client.ttl(leaseKey)).resolves.toBeGreaterThan(20)
+		})
+
+		it('transitions values while preserving or explicitly replacing TTL', async () => {
+			const client = getClient()
+			await client.set(deliveryKey, 'pending', 'EX', 20)
+			const originalTtl = await client.ttl(deliveryKey)
+
+			await expect(
+				client.transitionIfValue(
+					deliveryKey,
+					'processing',
+					'delivered',
+				),
+			).resolves.toBe(false)
+			await expect(
+				client.transitionIfValue(deliveryKey, 'pending', 'processing'),
+			).resolves.toBe(true)
+			const preservedTtl = await client.ttl(deliveryKey)
+			expect(preservedTtl).toBeGreaterThan(0)
+			expect(preservedTtl).toBeLessThanOrEqual(originalTtl)
+			await expect(
+				client.transitionIfValue(
+					deliveryKey,
+					'processing',
+					'delivered',
+					30,
+				),
+			).resolves.toBe(true)
+			await expect(client.ttl(deliveryKey)).resolves.toBeGreaterThan(20)
+			await expect(client.get(deliveryKey)).resolves.toBe('delivered')
+		})
+	})
+}

--- a/src/utils/cache/__tests__/redis-atomic.integration.test.ts
+++ b/src/utils/cache/__tests__/redis-atomic.integration.test.ts
@@ -1,0 +1,43 @@
+import Redis, { type Redis as RedisClient } from 'ioredis'
+import { afterAll, beforeAll, describe, vi } from 'vitest'
+import type { RedisCacheClient } from '../redis-instance.js'
+import { runAtomicCacheContract } from './redis-atomic-contract.js'
+
+vi.mock('../../../lib/startup/env.js', () => ({
+	default: { USE_MOCK_DATA: true },
+}))
+
+vi.mock('../../logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const { createAtomicRedisClient } = await import('../redis-instance.js')
+const RedisConstructor = Redis as unknown as {
+	new (url: string): RedisClient
+}
+
+const redisUrl = process.env.PLUTO_TEST_REDIS_URL
+if (process.env.PLUTO_REQUIRE_REDIS_TESTS === '1' && !redisUrl) {
+	throw new Error(
+		'PLUTO_TEST_REDIS_URL is required when PLUTO_REQUIRE_REDIS_TESTS=1.',
+	)
+}
+const describeWithRedis = redisUrl ? describe : describe.skip
+
+describeWithRedis('real Redis atomic adapter', () => {
+	let redis: RedisCacheClient
+
+	beforeAll(() => {
+		redis = createAtomicRedisClient(new RedisConstructor(redisUrl!))
+	})
+
+	afterAll(async () => {
+		await redis.quit()
+	})
+
+	runAtomicCacheContract(
+		'shared behavior',
+		() => redis,
+		`pluto:test:atomic:${process.pid}:${Date.now()}`,
+	)
+})

--- a/src/utils/cache/__tests__/redis-instance.test.ts
+++ b/src/utils/cache/__tests__/redis-instance.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runAtomicCacheContract } from './redis-atomic-contract.js'
+
+vi.mock('../../../lib/startup/env.js', () => ({
+	default: { USE_MOCK_DATA: true },
+}))
+
+vi.mock('../../logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const { InMemoryRedis } = await import('../redis-instance.js')
+
+let now = 0
+let redis: InstanceType<typeof InMemoryRedis>
+
+beforeEach(() => {
+	now = 0
+	redis = new InMemoryRedis(() => now)
+})
+
+runAtomicCacheContract(
+	'InMemoryRedis atomic contract',
+	() => redis,
+	'pluto:test:atomic:memory',
+)
+
+describe('InMemoryRedis expiry parity', () => {
+	it('expires EX values at the exact boundary for get and exists', async () => {
+		await redis.set('builder', 'value', 'EX', 15)
+
+		now = 14_999
+		await expect(redis.get('builder')).resolves.toBe('value')
+		await expect(redis.exists('builder')).resolves.toBe(1)
+		now = 15_000
+		await expect(redis.get('builder')).resolves.toBeNull()
+		await expect(redis.exists('builder')).resolves.toBe(0)
+	})
+
+	it('allows NX after expiration but not before it', async () => {
+		await expect(redis.set('lock', 'owner-a', 'EX', 5, 'NX')).resolves.toBe(
+			'OK',
+		)
+		await expect(
+			redis.set('lock', 'owner-b', 'EX', 5, 'NX'),
+		).resolves.toBeNull()
+
+		now = 5_000
+		await expect(redis.set('lock', 'owner-b', 'EX', 5, 'NX')).resolves.toBe(
+			'OK',
+		)
+	})
+
+	it('implements setex and expire with the injected clock', async () => {
+		await redis.setex('one', 10, 'value')
+		now = 4_000
+		await expect(redis.expire('one', 2)).resolves.toBe(1)
+		now = 5_999
+		await expect(redis.get('one')).resolves.toBe('value')
+		now = 6_000
+		await expect(redis.get('one')).resolves.toBeNull()
+		await expect(redis.expire('missing', 2)).resolves.toBe(0)
+	})
+
+	it('reports Redis-compatible TTL states and boundaries', async () => {
+		await expect(redis.ttl('missing')).resolves.toBe(-2)
+		await redis.set('persistent', 'value')
+		await expect(redis.ttl('persistent')).resolves.toBe(-1)
+		await redis.set('expiring', 'value', 'EX', 15)
+		await expect(redis.ttl('expiring')).resolves.toBe(15)
+
+		now = 14_001
+		await expect(redis.ttl('expiring')).resolves.toBe(1)
+		now = 14_501
+		await expect(redis.ttl('expiring')).resolves.toBe(0)
+		now = 15_000
+		await expect(redis.ttl('expiring')).resolves.toBe(-2)
+	})
+
+	it('rejects fractional expiry arguments', async () => {
+		await expect(
+			redis.set('fractional', 'value', 'EX', 1.5),
+		).rejects.toThrow('positive integer')
+		await redis.set('existing', 'value')
+		await expect(redis.expire('existing', 1.5)).rejects.toThrow('integer')
+		await expect(redis.expire('missing', 1.5)).rejects.toThrow('integer')
+	})
+
+	it('fails visibly when raw Lua bypasses the typed operation port', async () => {
+		await expect(redis.eval('return 1', 0)).rejects.toThrow(
+			'Raw Redis eval is unsupported',
+		)
+	})
+})

--- a/src/utils/cache/cache-manager.ts
+++ b/src/utils/cache/cache-manager.ts
@@ -1,12 +1,12 @@
 import { format } from 'date-fns'
-import type { ChainableCommander, Redis } from 'ioredis'
-import redisCache from './redis-instance.js'
+import type { ChainableCommander } from 'ioredis'
+import redisCache, { type RedisCacheClient } from './redis-instance.js'
 
 export class CacheManager {
-	cache: Redis
+	cache: RedisCacheClient
 
-	constructor() {
-		this.cache = redisCache
+	constructor(cache: RedisCacheClient = redisCache) {
+		this.cache = cache
 	}
 
 	async set(key: string, data: unknown, TTL?: number) {
@@ -40,13 +40,7 @@ export class CacheManager {
 
 	/** Remove a lock only when it is still owned by the caller. */
 	async compareAndRemove(key: string, value: string): Promise<boolean> {
-		const result = await this.cache.eval(
-			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end`,
-			1,
-			key,
-			JSON.stringify(value),
-		)
-		return result === 1
+		return this.cache.compareAndRemove(key, JSON.stringify(value))
 	}
 
 	/** Extend a lock or reservation only while the caller still owns it. */
@@ -55,14 +49,21 @@ export class CacheManager {
 		value: string,
 		seconds: number,
 	): Promise<boolean> {
-		const result = await this.cache.eval(
-			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end`,
-			1,
+		return this.cache.refreshIfOwned(key, JSON.stringify(value), seconds)
+	}
+
+	async transitionIfValue(
+		key: string,
+		expectedValue: unknown,
+		nextValue: unknown,
+		seconds?: number,
+	): Promise<boolean> {
+		return this.cache.transitionIfValue(
 			key,
-			JSON.stringify(value),
+			JSON.stringify(expectedValue),
+			JSON.stringify(nextValue),
 			seconds,
 		)
-		return result === 1
 	}
 
 	async get(key: string) {

--- a/src/utils/cache/redis-instance.ts
+++ b/src/utils/cache/redis-instance.ts
@@ -1,79 +1,256 @@
-import { default as Redis, type Redis as RedisClient } from 'ioredis' // Issue from https://github.com/redis/ioredis/issues/1624
+import {
+	type ChainableCommander,
+	default as Redis,
+	type Redis as RedisClient,
+	type RedisOptions,
+} from 'ioredis' // Issue from https://github.com/redis/ioredis/issues/1624
 import env from '../../lib/startup/env.js'
 import { logger } from '../logging/WinstonLogger.js'
 
 const { R_HOST, R_PORT, R_PASS, R_DB } = process.env
 
-// InMemoryRedis is a mock Redis client for testing. Note: expire() is a stub
-// that always returns 1 and does not enforce TTL on keys.
-class InMemoryRedis {
+const RedisConstructor = Redis as unknown as {
+	new (options: RedisOptions): RedisClient
+}
+
+export interface AtomicCacheOperations {
+	compareAndRemove(key: string, expectedValue: string): Promise<boolean>
+	refreshIfOwned(
+		key: string,
+		expectedValue: string,
+		seconds: number,
+	): Promise<boolean>
+	transitionIfValue(
+		key: string,
+		expectedValue: string,
+		nextValue: string,
+		seconds?: number,
+	): Promise<boolean>
+}
+
+export interface RedisCacheClient extends AtomicCacheOperations {
+	set(
+		key: string,
+		value: string,
+		...args: Array<string | number>
+	): Promise<'OK' | null>
+	get(key: string): Promise<string | null>
+	del(...keys: string[]): Promise<number>
+	flushall(): Promise<'OK'>
+	exists(key: string): Promise<number>
+	incr(key: string): Promise<number>
+	decr(key: string): Promise<number>
+	expire(key: string, seconds: number): Promise<number>
+	setex(key: string, seconds: number, value: string): Promise<'OK'>
+	ttl(key: string): Promise<number>
+	hset(key: string, field: string, value: string): Promise<number>
+	hgetall(key: string): Promise<Record<string, string>>
+	sadd(key: string, ...members: string[]): Promise<number>
+	smembers(key: string): Promise<string[]>
+	pipeline(): ChainableCommander
+	on(event: 'error', listener: (error: Error) => void): RedisCacheClient
+	quit(): Promise<string>
+}
+
+const COMPARE_AND_REMOVE_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('del', KEYS[1])
+end
+return 0`
+
+const REFRESH_IF_OWNED_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('expire', KEYS[1], ARGV[2])
+end
+return 0`
+
+const TRANSITION_IF_VALUE_SCRIPT = `
+if redis.call('get', KEYS[1]) ~= ARGV[1] then
+  return 0
+end
+if ARGV[3] == '' then
+  redis.call('set', KEYS[1], ARGV[2], 'KEEPTTL')
+else
+  redis.call('set', KEYS[1], ARGV[2], 'EX', ARGV[3])
+end
+return 1`
+
+const requirePositiveSeconds = (seconds: number): void => {
+	if (!Number.isSafeInteger(seconds) || seconds <= 0) {
+		throw new RangeError('Redis expiry must be a positive integer.')
+	}
+}
+
+export function createAtomicRedisClient(client: RedisClient): RedisCacheClient {
+	return Object.assign(client, {
+		async compareAndRemove(key: string, expectedValue: string) {
+			const result = await client.eval(
+				COMPARE_AND_REMOVE_SCRIPT,
+				1,
+				key,
+				expectedValue,
+			)
+			return Number(result) === 1
+		},
+		async refreshIfOwned(
+			key: string,
+			expectedValue: string,
+			seconds: number,
+		) {
+			requirePositiveSeconds(seconds)
+			const result = await client.eval(
+				REFRESH_IF_OWNED_SCRIPT,
+				1,
+				key,
+				expectedValue,
+				seconds,
+			)
+			return Number(result) === 1
+		},
+		async transitionIfValue(
+			key: string,
+			expectedValue: string,
+			nextValue: string,
+			seconds?: number,
+		) {
+			if (seconds !== undefined) requirePositiveSeconds(seconds)
+			const result = await client.eval(
+				TRANSITION_IF_VALUE_SCRIPT,
+				1,
+				key,
+				expectedValue,
+				nextValue,
+				seconds ?? '',
+			)
+			return Number(result) === 1
+		},
+	}) as unknown as RedisCacheClient
+}
+
+type Clock = () => number
+
+export class InMemoryRedis implements RedisCacheClient {
 	private readonly values = new Map<string, string>()
 	private readonly hashes = new Map<string, Map<string, string>>()
 	private readonly sets = new Map<string, Set<string>>()
+	private readonly expiresAt = new Map<string, number>()
 
-	async set(key: string, value: string, ...rest: unknown[]) {
-		if (
-			rest.includes('NX') &&
-			(this.values.has(key) || this.hashes.has(key) || this.sets.has(key))
-		) {
-			return null
+	constructor(private readonly now: Clock = Date.now) {}
+
+	async set(
+		key: string,
+		value: string,
+		...rest: Array<string | number>
+	): Promise<'OK' | null> {
+		let ttlMs: number | undefined
+		let onlyIfAbsent = false
+		let keepTtl = false
+		for (let index = 0; index < rest.length; index++) {
+			const option = String(rest[index]).toUpperCase()
+			if (option === 'NX') {
+				onlyIfAbsent = true
+				continue
+			}
+			if (option === 'KEEPTTL') {
+				keepTtl = true
+				continue
+			}
+			if (option === 'EX' || option === 'PX') {
+				const amount = Number(rest[++index])
+				if (!Number.isSafeInteger(amount) || amount <= 0) {
+					throw new RangeError(
+						'Redis expiry must be a positive integer.',
+					)
+				}
+				ttlMs = option === 'EX' ? amount * 1000 : amount
+				continue
+			}
+			throw new Error(`Unsupported in-memory Redis SET option: ${option}`)
 		}
+		this.purgeExpired(key)
+		if (onlyIfAbsent && this.hasKey(key)) return null
+		const previousExpiry = this.expiresAt.get(key)
+		this.hashes.delete(key)
+		this.sets.delete(key)
 		this.values.set(key, value)
+		if (ttlMs !== undefined) {
+			this.expiresAt.set(key, this.now() + ttlMs)
+		} else if (keepTtl && previousExpiry !== undefined) {
+			this.expiresAt.set(key, previousExpiry)
+		} else {
+			this.expiresAt.delete(key)
+		}
 		return 'OK'
 	}
 
 	async get(key: string) {
+		this.purgeExpired(key)
 		return this.values.get(key) ?? null
 	}
 
 	async del(...keys: string[]) {
 		let deleted = 0
 		for (const key of keys) {
-			if (this.values.delete(key)) deleted++
-			if (this.hashes.delete(key)) deleted++
-			if (this.sets.delete(key)) deleted++
+			this.purgeExpired(key)
+			if (this.removeKey(key)) deleted++
 		}
 		return deleted
 	}
 
-	async flushall() {
+	async flushall(): Promise<'OK'> {
 		this.values.clear()
 		this.hashes.clear()
 		this.sets.clear()
+		this.expiresAt.clear()
 		return 'OK'
 	}
 
 	async exists(key: string) {
-		return this.values.has(key) ||
-			this.hashes.has(key) ||
-			this.sets.has(key)
-			? 1
-			: 0
+		return this.hasKey(key) ? 1 : 0
 	}
 
 	async incr(key: string) {
+		this.purgeExpired(key)
 		const next = Number(this.values.get(key) ?? 0) + 1
 		this.values.set(key, String(next))
 		return next
 	}
 
 	async decr(key: string) {
+		this.purgeExpired(key)
 		const next = Number(this.values.get(key) ?? 0) - 1
 		this.values.set(key, String(next))
 		return next
 	}
 
-	async expire(_key: string, _seconds: number) {
-		// Stub for testing: always returns 1, does not actually expire keys
+	async expire(key: string, seconds: number) {
+		if (!Number.isSafeInteger(seconds)) {
+			throw new RangeError('Redis expiry must be an integer.')
+		}
+		if (!this.hasKey(key)) return 0
+		if (seconds <= 0) {
+			this.removeKey(key)
+			return 1
+		}
+		this.expiresAt.set(key, this.now() + seconds * 1000)
 		return 1
 	}
 
-	async setex(key: string, _seconds: number, value: string) {
-		this.values.set(key, value)
+	async setex(key: string, seconds: number, value: string): Promise<'OK'> {
+		await this.set(key, value, 'EX', seconds)
 		return 'OK'
 	}
 
+	async ttl(key: string): Promise<number> {
+		this.purgeExpired(key)
+		if (!this.hasKey(key)) return -2
+		const expiresAt = this.expiresAt.get(key)
+		if (expiresAt === undefined) return -1
+		return Math.round((expiresAt - this.now()) / 1000)
+	}
+
 	async hset(key: string, field: string, value: string) {
+		this.purgeExpired(key)
 		const hash = this.hashes.get(key) ?? new Map<string, string>()
 		const isNew = hash.has(field) ? 0 : 1
 		hash.set(field, value)
@@ -82,10 +259,12 @@ class InMemoryRedis {
 	}
 
 	async hgetall(key: string) {
+		this.purgeExpired(key)
 		return Object.fromEntries(this.hashes.get(key) ?? [])
 	}
 
 	async sadd(key: string, ...members: string[]) {
+		this.purgeExpired(key)
 		const set = this.sets.get(key) ?? new Set<string>()
 		let added = 0
 		for (const member of members) {
@@ -97,10 +276,55 @@ class InMemoryRedis {
 	}
 
 	async smembers(key: string) {
+		this.purgeExpired(key)
 		return [...(this.sets.get(key) ?? [])]
 	}
 
-	pipeline() {
+	async compareAndRemove(
+		key: string,
+		expectedValue: string,
+	): Promise<boolean> {
+		this.purgeExpired(key)
+		if (this.values.get(key) !== expectedValue) return false
+		this.removeKey(key)
+		return true
+	}
+
+	async refreshIfOwned(
+		key: string,
+		expectedValue: string,
+		seconds: number,
+	): Promise<boolean> {
+		requirePositiveSeconds(seconds)
+		this.purgeExpired(key)
+		if (this.values.get(key) !== expectedValue) return false
+		this.expiresAt.set(key, this.now() + seconds * 1000)
+		return true
+	}
+
+	async transitionIfValue(
+		key: string,
+		expectedValue: string,
+		nextValue: string,
+		seconds?: number,
+	): Promise<boolean> {
+		if (seconds !== undefined) requirePositiveSeconds(seconds)
+		this.purgeExpired(key)
+		if (this.values.get(key) !== expectedValue) return false
+		this.values.set(key, nextValue)
+		if (seconds !== undefined) {
+			this.expiresAt.set(key, this.now() + seconds * 1000)
+		}
+		return true
+	}
+
+	async eval(..._args: unknown[]): Promise<never> {
+		throw new Error(
+			'Raw Redis eval is unsupported in mock mode; use typed atomic operations.',
+		)
+	}
+
+	pipeline(): ChainableCommander {
 		const commands: Array<() => Promise<unknown>> = []
 		const pipeline = {
 			set: (key: string, value: string) => {
@@ -131,27 +355,60 @@ class InMemoryRedis {
 					}),
 				),
 		}
-		return pipeline
+		return pipeline as unknown as ChainableCommander
+	}
+
+	on(_event: 'error', _listener: (error: Error) => void): RedisCacheClient {
+		return this
+	}
+
+	async quit(): Promise<string> {
+		return 'OK'
+	}
+
+	private hasKey(key: string): boolean {
+		this.purgeExpired(key)
+		return (
+			this.values.has(key) || this.hashes.has(key) || this.sets.has(key)
+		)
+	}
+
+	private purgeExpired(key: string): void {
+		const expiresAt = this.expiresAt.get(key)
+		if (expiresAt !== undefined && expiresAt <= this.now()) {
+			this.removeKey(key)
+		}
+	}
+
+	private removeKey(key: string): boolean {
+		const existed =
+			this.values.has(key) || this.hashes.has(key) || this.sets.has(key)
+		this.values.delete(key)
+		this.hashes.delete(key)
+		this.sets.delete(key)
+		this.expiresAt.delete(key)
+		return existed
 	}
 }
 
-const redisCache = env.USE_MOCK_DATA
-	? (new InMemoryRedis() as unknown as RedisClient)
-	: // @ts-ignore - ioredis default export is constructable at runtime.
-		new Redis({
-			host: R_HOST,
-			port: Number(R_PORT),
-			password: R_PASS,
-			connectTimeout: 10000,
-			retryStrategy: (times) => {
-				const MAX_RETRY_ATTEMPTS = 3
-				if (times >= MAX_RETRY_ATTEMPTS) {
-					throw new Error('Max retry attempts reached')
-				}
-				return Math.min(2 ** times * 1000, 60000)
-			},
-			db: Number(R_DB),
-		})
+const redisCache: RedisCacheClient = env.USE_MOCK_DATA
+	? new InMemoryRedis()
+	: createAtomicRedisClient(
+			new RedisConstructor({
+				host: R_HOST,
+				port: Number(R_PORT),
+				password: R_PASS,
+				connectTimeout: 10000,
+				retryStrategy: (times) => {
+					const MAX_RETRY_ATTEMPTS = 3
+					if (times >= MAX_RETRY_ATTEMPTS) {
+						throw new Error('Max retry attempts reached')
+					}
+					return Math.min(2 ** times * 1000, 60000)
+				},
+				db: Number(R_DB),
+			}),
+		)
 
 if (env.USE_MOCK_DATA) {
 	logger.info({

--- a/src/utils/dev/__tests__/mock-backend-parlays.test.ts
+++ b/src/utils/dev/__tests__/mock-backend-parlays.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { InitParlayRequest } from '../../api/Khronos/parlays/ParlayApiWrapper.js'
 
 vi.mock('../../../lib/startup/env.js', () => ({
 	default: {
@@ -12,11 +13,30 @@ vi.mock('../../../lib/startup/env.js', () => ({
 const { MockBackend } = await import('../mock-backend.js')
 
 describe('MockBackend parlay lifecycle', () => {
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	function request(overrides: Partial<InitParlayRequest> = {}) {
+		return {
+			legs: [
+				{ event_id: 'event-1', outcome_uuid: 'event-1-home' },
+				{ event_id: 'event-2', outcome_uuid: 'event-2-away' },
+			],
+			stake: 10,
+			guild_id: 'guild-1',
+			user_id: 'user-1',
+			...overrides,
+		}
+	}
+
 	it('preserves spread and totals market metadata in mock parlays', () => {
 		const backend = MockBackend.instance()
 		backend.reset()
-		const game = backend.seedGames('nba', 1).matches[0]
-		if (!game?.id) throw new Error('mock game did not have an id')
+		const games = backend.seedGames('nba', 2).matches
+		const game = games[0]
+		const secondGame = games[1]
+		if (!game?.id || !secondGame?.id) throw new Error('mock games missing')
 
 		const preview = backend.initParlay({
 			legs: [
@@ -25,8 +45,8 @@ describe('MockBackend parlay lifecycle', () => {
 					outcome_uuid: `${game.id}-spread-home`,
 				},
 				{
-					event_id: game.id,
-					outcome_uuid: `${game.id}-total-over`,
+					event_id: secondGame.id,
+					outcome_uuid: `${secondGame.id}-total-over`,
 				},
 			],
 			stake: 10,
@@ -45,4 +65,163 @@ describe('MockBackend parlay lifecycle', () => {
 			]),
 		)
 	})
+
+	it('rejects same-event legs, unsupported markets, and out-of-range requests', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+
+		expect(() =>
+			backend.initParlay(
+				request({
+					legs: [
+						{ event_id: 'event-1', outcome_uuid: 'event-1-home' },
+						{ event_id: 'event-1', outcome_uuid: 'event-1-away' },
+					],
+				}),
+			),
+		).toThrow('distinct events')
+		expect(() =>
+			backend.initParlay({
+				...request(),
+				legs: [
+					...request().legs,
+					{
+						event_id: 'event-3',
+						outcome_uuid: 'event-3-player-points',
+					},
+				],
+			}),
+		).toThrow('supported')
+		expect(() => backend.initParlay({ ...request(), legs: [] })).toThrow(
+			'between 2 and 6',
+		)
+		expect(() =>
+			backend.initParlay({
+				...request(),
+				legs: Array.from({ length: 7 }, (_, index) => ({
+					event_id: `event-${index + 1}`,
+					outcome_uuid: `event-${index + 1}-home`,
+				})),
+			}),
+		).toThrow('between 2 and 6')
+		expect(() => backend.initParlay({ ...request(), stake: 0 })).toThrow(
+			'between 1 and 10000',
+		)
+		expect(() =>
+			backend.initParlay({ ...request(), stake: 10_001 }),
+		).toThrow('between 1 and 10000')
+	})
+
+	it('uses a 15-minute one-time token and rejects it at the expiry boundary', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		const now = new Date('2026-07-15T12:00:00.000Z')
+		vi.useFakeTimers({ now })
+
+		const preview = backend.initParlay(request())
+		expect(preview.expires_at).toBe('2026-07-15T12:15:00.000Z')
+		vi.advanceTimersByTime(15 * 60 * 1000 - 1)
+		const placed = backend.placeParlay(preview.init_token)
+		expect(placed.status).toBe('pending')
+		vi.setSystemTime(now)
+		const expired = backend.initParlay(request({ user_id: 'user-2' }))
+		vi.advanceTimersByTime(15 * 60 * 1000)
+		expect(() => backend.placeParlay(expired.init_token)).toThrow('expired')
+	})
+
+	it('debits once for a token and does not debit on replay', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		backend.setBalance('user-1', 100)
+		const preview = backend.initParlay(request({ stake: 80 }))
+
+		backend.placeParlay(preview.init_token)
+		expect(backend.getAccountBalance('user-1').balance).toBe(20)
+		expect(() => backend.placeParlay(preview.init_token)).toThrow('expired')
+		expect(backend.getAccountBalance('user-1').balance).toBe(20)
+	})
+
+	it('refunds cancellation once and closes cancellation at first commence time', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		backend.setBalance('user-1', 100)
+		const preview = backend.initParlay(request({ stake: 25 }))
+		const placed = backend.placeParlay(preview.init_token)
+
+		const cancelled = backend.cancelParlay(placed.id, 'user-1')
+		expect(cancelled.status).toBe('cancelled')
+		expect(cancelled.actual_payout).toBe(25)
+		expect(backend.getAccountBalance('user-1').balance).toBe(100)
+		expect(() => backend.cancelParlay(placed.id, 'user-1')).toThrow(
+			'no longer cancellable',
+		)
+		expect(backend.getAccountBalance('user-1').balance).toBe(100)
+
+		const future = backend.placeParlay(
+			backend.initParlay(request()).init_token,
+		)
+		vi.setSystemTime(new Date(future.legs[0]?.commence_time ?? now()))
+		expect(() => backend.cancelParlay(future.id, 'user-1')).toThrow(
+			'cancellation window has closed',
+		)
+	})
+
+	it('settles terminal states, credits winnings, and notifies exactly once', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		backend.setBalance('user-1', 100)
+		const notifications: string[] = []
+		const unsubscribe = backend.onParlayTerminal((parlay) => {
+			notifications.push(`${parlay.id}:${parlay.status}`)
+		})
+		const preview = backend.initParlay(request({ stake: 10 }))
+		const placed = backend.placeParlay(preview.init_token)
+
+		const pending = backend.settleParlayLeg(
+			placed.id,
+			'event-1-home',
+			'won',
+		)
+		expect(pending.status).toBe('pending')
+		const settled = backend.settleParlayLeg(
+			placed.id,
+			'event-2-away',
+			'won',
+		)
+		expect(settled.status).toBe('won')
+		expect(settled.actual_payout).toBe(preview.potential_payout)
+		expect(backend.getAccountBalance('user-1').balance).toBe(
+			100 - 10 + preview.potential_payout,
+		)
+		expect(notifications).toEqual([`${placed.id}:won`])
+		expect(() =>
+			backend.settleParlayLeg(placed.id, 'event-2-away', 'lost'),
+		).toThrow('terminal')
+		unsubscribe()
+	})
+
+	it('refunds all-push/void parlays and rejects illegal leg transitions', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		backend.setBalance('user-1', 100)
+		const preview = backend.initParlay(request({ stake: 10 }))
+		const placed = backend.placeParlay(preview.init_token)
+
+		backend.settleParlayLeg(placed.id, 'event-1-home', 'push')
+		const refunded = backend.settleParlayLeg(
+			placed.id,
+			'event-2-away',
+			'void',
+		)
+		expect(refunded.status).toBe('push_refunded')
+		expect(refunded.actual_payout).toBe(10)
+		expect(backend.getAccountBalance('user-1').balance).toBe(100)
+		expect(() =>
+			backend.settleParlayLeg(placed.id, 'event-1-home', 'won'),
+		).toThrow('terminal')
+	})
 })
+
+function now(): string {
+	return new Date().toISOString()
+}

--- a/src/utils/dev/mock-backend.ts
+++ b/src/utils/dev/mock-backend.ts
@@ -32,6 +32,7 @@ import type {
 	InitParlayRequest,
 	InitParlayResponse,
 	ParlayResponse,
+	PlacedParlayLeg,
 	UserParlaysResponse,
 } from '../api/Khronos/parlays/ParlayApiWrapper.js'
 import {
@@ -42,6 +43,28 @@ import { makeMatchesForSport, makeUpcomingGame } from './factories/games.js'
 import { asMockSport, MOCK_SPORTS, type MockSport } from './factories/teams.js'
 import { MockStore } from './mock-store.js'
 
+const PARLAY_INIT_TTL_MS = 15 * 60 * 1000
+const PARLAY_MIN_LEGS = 2
+const PARLAY_MAX_LEGS = 6
+const PARLAY_MIN_STAKE = 1
+const PARLAY_MAX_STAKE = 10_000
+const PARLAY_MAX_PAYOUT = 1_000_000
+
+type PendingParlay = {
+	request: InitParlayRequest
+	preview: InitParlayResponse
+	expiresAt: number
+}
+
+type TerminalParlayResult = Exclude<PlacedParlayLeg['result'], 'pending'>
+const TERMINAL_RESULTS = new Set<TerminalParlayResult>([
+	'won',
+	'lost',
+	'push',
+	'void',
+])
+export type MockParlayTerminalListener = (parlay: ParlayResponse) => void
+
 export class MockBackend {
 	private static backend: MockBackend | undefined
 	private readonly store = new MockStore()
@@ -51,11 +74,9 @@ export class MockBackend {
 	>()
 	private nextBetId = 10_000
 	private nextParlayId = 20_000
-	private readonly pendingParlays = new Map<
-		string,
-		{ request: InitParlayRequest; preview: InitParlayResponse }
-	>()
+	private readonly pendingParlays = new Map<string, PendingParlay>()
 	private readonly parlays = new Map<string, ParlayResponse>()
+	private readonly terminalListeners = new Set<MockParlayTerminalListener>()
 
 	private constructor() {
 		if (env.NODE_ENV === 'production') {
@@ -193,12 +214,9 @@ export class MockBackend {
 	}
 
 	initParlay(request: InitParlayRequest): InitParlayResponse {
+		this.validateParlayRequest(request)
 		const legs = request.legs.map((leg) => {
-			const market_key = leg.outcome_uuid.includes('-spread-')
-				? ('spreads' as const)
-				: leg.outcome_uuid.includes('-total-')
-					? ('totals' as const)
-					: ('h2h' as const)
+			const market_key = this.marketKeyForOutcome(leg.outcome_uuid)
 			const isHome = leg.outcome_uuid.endsWith('-home')
 			const isOver = leg.outcome_uuid.endsWith('-over')
 			return {
@@ -225,23 +243,40 @@ export class MockBackend {
 				).toISOString(),
 			}
 		})
-		const decimal = Math.pow(210 / 110, legs.length)
+		const decimal = legs.reduce(
+			(product, leg) => product * this.decimalOdds(leg.odds_american),
+			1,
+		)
+		const expiresAt = Date.now() + PARLAY_INIT_TTL_MS
 		const preview: InitParlayResponse = {
 			init_token: randomUUID(),
 			combined_odds_american: Math.round((decimal - 1) * 100),
 			potential_payout: Math.round(request.stake * decimal * 100) / 100,
 			legs,
-			expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+			expires_at: new Date(expiresAt).toISOString(),
 		}
-		this.pendingParlays.set(preview.init_token, { request, preview })
+		if (preview.potential_payout > PARLAY_MAX_PAYOUT) {
+			throw new Error(
+				`Parlay potential payout cannot exceed ${PARLAY_MAX_PAYOUT}.`,
+			)
+		}
+		this.pendingParlays.set(preview.init_token, {
+			request,
+			preview,
+			expiresAt,
+		})
 		return preview
 	}
 
 	placeParlay(initToken: string): ParlayResponse {
 		const pending = this.pendingParlays.get(initToken)
-		if (!pending) throw new Error('Mock parlay initialization expired.')
+		if (!pending || pending.expiresAt <= Date.now()) {
+			this.pendingParlays.delete(initToken)
+			throw new Error('Mock parlay initialization expired.')
+		}
 		this.pendingParlays.delete(initToken)
 		const { request, preview } = pending
+		this.store.debit(request.user_id, request.stake)
 		const id = `mock-parlay-${this.nextParlayId++}`
 		const parlay: ParlayResponse = {
 			id,
@@ -295,9 +330,97 @@ export class MockBackend {
 		if (parlay.status !== 'pending') {
 			throw new Error('Mock parlay is no longer cancellable.')
 		}
-		const cancelled = { ...parlay, status: 'cancelled' as const }
+		const earliestCommence = parlay.legs.reduce(
+			(earliest, leg) =>
+				new Date(leg.commence_time).getTime() < earliest
+					? new Date(leg.commence_time).getTime()
+					: earliest,
+			Number.POSITIVE_INFINITY,
+		)
+		if (earliestCommence <= Date.now()) {
+			throw new Error('Mock parlay cancellation window has closed.')
+		}
+		const cancelled = {
+			...parlay,
+			status: 'cancelled' as const,
+			actual_payout: parlay.stake,
+			settled_at: new Date().toISOString(),
+		}
+		this.store.credit(userId, parlay.stake)
 		this.parlays.set(parlayId, cancelled)
+		this.notifyTerminal(cancelled)
 		return cancelled
+	}
+
+	/** Register the in-process sink used by hermetic notification tests. */
+	onParlayTerminal(listener: MockParlayTerminalListener): () => void {
+		this.terminalListeners.add(listener)
+		return () => this.terminalListeners.delete(listener)
+	}
+
+	/** Apply one immutable outcome result and resolve the parlay when terminal. */
+	settleParlayLeg(
+		parlayId: string,
+		outcomeUuid: string,
+		result: TerminalParlayResult,
+	): ParlayResponse {
+		const parlay = this.parlays.get(parlayId)
+		if (!parlay) throw new Error('Mock parlay was not found.')
+		if (parlay.status !== 'pending') {
+			throw new Error('Mock parlay is already terminal.')
+		}
+		if (!TERMINAL_RESULTS.has(result)) {
+			throw new Error(`Unsupported mock parlay result: ${result}.`)
+		}
+		const leg = parlay.legs.find(
+			(candidate) => candidate.outcome_uuid === outcomeUuid,
+		)
+		if (!leg) throw new Error('Mock parlay leg was not found.')
+		if (leg.result !== 'pending') {
+			throw new Error('Mock parlay leg is already settled.')
+		}
+
+		const legs = parlay.legs.map((candidate) =>
+			candidate.outcome_uuid === outcomeUuid
+				? { ...candidate, result, settled_at: new Date().toISOString() }
+				: candidate,
+		)
+		const next: ParlayResponse = { ...parlay, legs }
+		if (legs.some((candidate) => candidate.result === 'lost')) {
+			next.status = 'lost'
+			next.actual_payout = 0
+			next.settled_at = new Date().toISOString()
+		} else if (legs.some((candidate) => candidate.result === 'pending')) {
+			this.parlays.set(parlayId, next)
+			return next
+		} else {
+			const winningLegs = legs.filter(
+				(candidate) => candidate.result === 'won',
+			)
+			next.status = winningLegs.length > 0 ? 'won' : 'push_refunded'
+			next.actual_payout =
+				winningLegs.length > 0
+					? this.roundCurrency(
+							parlay.stake *
+								winningLegs.reduce(
+									(product, candidate) =>
+										product *
+										this.decimalOdds(
+											candidate.odds_american,
+										),
+									1,
+								),
+						)
+					: parlay.stake
+			next.settled_at = new Date().toISOString()
+		}
+
+		if ((next.actual_payout ?? 0) > 0) {
+			this.store.credit(parlay.user_id, next.actual_payout ?? 0)
+		}
+		this.parlays.set(parlayId, next)
+		this.notifyTerminal(next)
+		return next
 	}
 
 	getEventOutcomes(sport: string, eventId: string): EventOutcome[] {
@@ -473,6 +596,62 @@ export class MockBackend {
 		this.nextParlayId = 20_000
 		this.pendingParlays.clear()
 		this.parlays.clear()
+		this.terminalListeners.clear()
+	}
+
+	private validateParlayRequest(request: InitParlayRequest): void {
+		if (
+			!Array.isArray(request.legs) ||
+			request.legs.length < PARLAY_MIN_LEGS ||
+			request.legs.length > PARLAY_MAX_LEGS
+		) {
+			throw new Error(
+				`Parlays must contain between ${PARLAY_MIN_LEGS} and ${PARLAY_MAX_LEGS} legs.`,
+			)
+		}
+		if (
+			!Number.isFinite(request.stake) ||
+			request.stake < PARLAY_MIN_STAKE ||
+			request.stake > PARLAY_MAX_STAKE
+		) {
+			throw new Error(
+				`Parlay stake must be between ${PARLAY_MIN_STAKE} and ${PARLAY_MAX_STAKE}.`,
+			)
+		}
+		if (
+			new Set(request.legs.map((leg) => leg.event_id)).size !==
+			request.legs.length
+		) {
+			throw new Error('Parlay legs must reference distinct events.')
+		}
+	}
+
+	private marketKeyForOutcome(
+		outcomeUuid: string,
+	): 'h2h' | 'spreads' | 'totals' {
+		if (outcomeUuid.includes('-spread-')) return 'spreads'
+		if (outcomeUuid.includes('-total-')) return 'totals'
+		if (outcomeUuid.endsWith('-home') || outcomeUuid.endsWith('-away')) {
+			return 'h2h'
+		}
+		throw new Error(`Market in outcome ${outcomeUuid} is not supported.`)
+	}
+
+	private decimalOdds(american: number): number {
+		return american >= 0 ? 1 + american / 100 : 1 + 100 / Math.abs(american)
+	}
+
+	private roundCurrency(value: number): number {
+		return Math.round((value + Number.EPSILON) * 100) / 100
+	}
+
+	private notifyTerminal(parlay: ParlayResponse): void {
+		for (const listener of this.terminalListeners) {
+			listener({
+				...parlay,
+				legs: parlay.legs.map((leg) => ({ ...leg })),
+			})
+		}
 	}
 
 	private findGameForBet(

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import type { ProcessedPropDto } from '@pluto-khronos/api-client'
 import { format } from 'date-fns'
 import {
@@ -152,6 +153,19 @@ export class PropPostingHandler {
 				})
 				continue
 			}
+			if (deliveryState.status === 'unknown') {
+				result.failed++
+				result.failures.push({
+					guild_id: guildId,
+					channel_id: channelId,
+					outcome_uuids: [
+						prop.over.outcome_uuid,
+						prop.under.outcome_uuid,
+					],
+					error: 'Unknown legacy delivery marker; manual reconciliation required',
+				})
+				continue
+			}
 
 			try {
 				const embed = await this.createPropEmbed(prop, sport)
@@ -227,6 +241,42 @@ export class PropPostingHandler {
 		return result
 	}
 
+	/**
+	 * Posts one prop pair for the durable prop-post worker. The queue has
+	 * already persisted the delivery envelope before this method is called.
+	 * Discord's nonce makes a retry after an ambiguous send return the original
+	 * message instead of creating a second one.
+	 */
+	async postPropPair(
+		guildId: string,
+		channelId: string,
+		prop: ProcessedPropDto,
+		sport: 'nba' | 'nfl',
+		deliveryId: string,
+		destinationId: string,
+	): Promise<PostedPropReference[]> {
+		const embed = await this.createPropEmbed(prop, sport)
+		const buttons = this.createPropButtons(prop)
+		const message = await this.guildWrapper.sendToChannel(
+			channelId,
+			{
+				embeds: [embed],
+				components: [buttons],
+				nonce: createDeliveryNonce(deliveryId, destinationId),
+				enforceNonce: true,
+			},
+			guildId,
+		)
+		return [prop.over.outcome_uuid, prop.under.outcome_uuid].map(
+			(outcome_uuid) => ({
+				outcome_uuid,
+				guild_id: guildId,
+				channel_id: channelId,
+				message_id: message.id,
+			}),
+		)
+	}
+
 	private getDeliveryKey(
 		guildId: string,
 		channelId: string | undefined,
@@ -248,6 +298,7 @@ export class PropPostingHandler {
 		| { status: 'sent'; results: PostedPropReference[] }
 		| { status: 'claimed' }
 		| { status: 'unavailable' }
+		| { status: 'unknown' }
 	> {
 		try {
 			const existing = await redisCache.get(deliveryKey)
@@ -273,14 +324,15 @@ export class PropPostingHandler {
 					const marker = JSON.parse(existing) as DeliveredMarker
 					if (
 						marker.status === 'sent' &&
-						Array.isArray(marker.results)
+						Array.isArray(marker.results) &&
+						marker.results.every(isPostedPropReference)
 					) {
 						return { status: 'sent', results: marker.results }
 					}
 				} catch {
-					// An unknown marker is treated as available for compatibility
-					// with older deployments that stored a plain status value.
+					return { status: 'unknown' }
 				}
+				return { status: 'unknown' }
 			}
 
 			const lock = await redisCache.set(
@@ -488,4 +540,25 @@ export class PropPostingHandler {
 			underButton,
 		)
 	}
+}
+
+function isPostedPropReference(value: unknown): value is PostedPropReference {
+	if (!value || typeof value !== 'object') return false
+	const candidate = value as Record<string, unknown>
+	return (
+		typeof candidate.outcome_uuid === 'string' &&
+		typeof candidate.guild_id === 'string' &&
+		typeof candidate.channel_id === 'string' &&
+		typeof candidate.message_id === 'string'
+	)
+}
+
+function createDeliveryNonce(
+	deliveryId: string,
+	destinationId: string,
+): string {
+	return createHash('sha256')
+		.update(`${deliveryId}:${destinationId}`)
+		.digest('hex')
+		.slice(0, 25)
 }

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -197,8 +197,7 @@ export class PropPostingHandler {
 						outcome_uuids: references.map(
 							(reference) => reference.outcome_uuid,
 						),
-						error:
-							'Discord message posted but durable delivery marker was unavailable',
+						error: 'Discord message posted but durable delivery marker was unavailable',
 					})
 				}
 			} catch (error) {
@@ -256,22 +255,13 @@ export class PropPostingHandler {
 			if (existing === 'processing') return { status: 'claimed' }
 			if (existing === 'retry') {
 				try {
-					const redis = redisCache as unknown as {
-						eval?: (
-							script: string,
-							numKeys: number,
-							...args: Array<string | number>
-						) => Promise<unknown>
-					}
-					if (!redis.eval) return { status: 'claimed' }
-					const reclaimed = await redis.eval(
-						"if redis.call('get', KEYS[1]) == 'retry' then return redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2]) else return nil end",
-						1,
+					const reclaimed = await redisCache.transitionIfValue(
 						deliveryKey,
+						'retry',
 						'processing',
 						PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
 					)
-					return reclaimed === 'OK'
+					return reclaimed
 						? { status: 'available' }
 						: { status: 'claimed' }
 				} catch {

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
 	set: vi.fn(),
 	setex: vi.fn(),
 	del: vi.fn(),
-	eval: vi.fn(),
+	transitionIfValue: vi.fn(),
 	sendToChannel: vi.fn(),
 	sendToPredictionChannel: vi.fn(),
 	getTeamInfo: vi.fn(),
@@ -34,7 +34,7 @@ vi.mock('../../cache/redis-instance.js', () => ({
 		set: mocks.set,
 		setex: mocks.setex,
 		del: mocks.del,
-		eval: mocks.eval,
+		transitionIfValue: mocks.transitionIfValue,
 	},
 }))
 
@@ -88,7 +88,7 @@ describe('PropPostingHandler message references and idempotency', () => {
 		mocks.get.mockResolvedValue(null)
 		mocks.set.mockResolvedValue('OK')
 		mocks.setex.mockResolvedValue('OK')
-		mocks.eval.mockResolvedValue('OK')
+		mocks.transitionIfValue.mockResolvedValue(true)
 		mocks.del.mockResolvedValue(1)
 		mocks.sendToChannel.mockResolvedValue(sentMessage)
 		mocks.sendToPredictionChannel.mockResolvedValue(sentMessage)
@@ -214,10 +214,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 
 		expect(result.posted).toBe(1)
 		expect(result.results).toEqual(references)
-		expect(mocks.eval).toHaveBeenCalledWith(
-			expect.stringContaining("redis.call('get', KEYS[1]) == 'retry'"),
-			1,
+		expect(mocks.transitionIfValue).toHaveBeenCalledWith(
 			deliveryKey,
+			'retry',
 			'processing',
 			7 * 24 * 60 * 60,
 		)
@@ -241,7 +240,12 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'channel-1',
 		)
 
-		expect(result).toMatchObject({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(result).toMatchObject({
+			posted: 0,
+			filtered: 0,
+			failed: 1,
+			total: 1,
+		})
 		expect(retry.posted).toBe(1)
 		expect(retry.results).toEqual(references)
 		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
@@ -253,7 +257,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 	})
 
 	it('keeps partial failures explicit and releases failed claims', async () => {
-		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
 
 		const result = await new PropPostingHandler().postPropsToChannel(
 			'guild-1',
@@ -267,7 +273,10 @@ describe('PropPostingHandler message references and idempotency', () => {
 			expect.objectContaining({
 				guild_id: 'guild-1',
 				channel_id: 'channel-1',
-				outcome_uuids: [prop.over.outcome_uuid, prop.under.outcome_uuid],
+				outcome_uuids: [
+					prop.over.outcome_uuid,
+					prop.under.outcome_uuid,
+				],
 				error: 'Discord unavailable',
 			}),
 		])
@@ -275,7 +284,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 	})
 
 	it('shortens a failed claim when Redis release fails', async () => {
-		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
 		mocks.del.mockRejectedValueOnce(new Error('Redis unavailable'))
 
 		await new PropPostingHandler().postPropsToChannel(
@@ -285,13 +296,19 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'channel-1',
 		)
 
-		expect(mocks.setex).toHaveBeenLastCalledWith(deliveryKey, 5, 'processing')
+		expect(mocks.setex).toHaveBeenLastCalledWith(
+			deliveryKey,
+			5,
+			'processing',
+		)
 	})
 
 	it('persists a sent ledger with plain SET when SETEX fails', async () => {
 		mocks.set.mockReset()
 		mocks.set.mockResolvedValueOnce('OK').mockResolvedValueOnce('OK')
-		mocks.setex.mockRejectedValueOnce(new Error('Redis command unavailable'))
+		mocks.setex.mockRejectedValueOnce(
+			new Error('Redis command unavailable'),
+		)
 
 		await new PropPostingHandler().postPropsToChannel(
 			'guild-1',
@@ -307,7 +324,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 	})
 
 	it('leaves a retry marker when claim release commands fail', async () => {
-		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
 		mocks.del.mockRejectedValueOnce(new Error('Redis unavailable'))
 		mocks.setex.mockRejectedValueOnce(new Error('Redis unavailable'))
 
@@ -323,7 +342,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 
 	it('reports a marker persistence failure after Discord accepts the message', async () => {
 		mocks.set.mockReset()
-		mocks.set.mockResolvedValueOnce('OK').mockRejectedValueOnce(new Error('Redis unavailable'))
+		mocks.set
+			.mockResolvedValueOnce('OK')
+			.mockRejectedValueOnce(new Error('Redis unavailable'))
 		mocks.setex.mockRejectedValueOnce(new Error('Redis unavailable'))
 
 		const result = await new PropPostingHandler().postPropsToChannel(
@@ -333,15 +354,22 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'channel-1',
 		)
 
-		expect(result).toMatchObject({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(result).toMatchObject({
+			posted: 0,
+			filtered: 0,
+			failed: 1,
+			total: 1,
+		})
 		expect(result.results).toEqual([])
 		expect(result.failures).toEqual([
 			expect.objectContaining({
 				guild_id: 'guild-1',
 				channel_id: 'channel-1',
-				outcome_uuids: [prop.over.outcome_uuid, prop.under.outcome_uuid],
-				error:
-					'Discord message posted but durable delivery marker was unavailable',
+				outcome_uuids: [
+					prop.over.outcome_uuid,
+					prop.under.outcome_uuid,
+				],
+				error: 'Discord message posted but durable delivery marker was unavailable',
 			}),
 		])
 		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -120,6 +120,36 @@ describe('PropPostingHandler message references and idempotency', () => {
 		)
 	})
 
+	it('uses a deterministic Discord nonce for durable prop-post retries', async () => {
+		const result = await new PropPostingHandler().postPropPair(
+			'guild-1',
+			'channel-1',
+			prop,
+			'nba',
+			'550e8400-e29b-41d4-a716-446655440010',
+			'prop-post:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+		)
+
+		expect(result).toEqual(references)
+		const firstOptions = mocks.sendToChannel.mock.calls[0][1]
+		expect(firstOptions).toMatchObject({
+			enforceNonce: true,
+			nonce: expect.stringMatching(/^[0-9a-f]{25}$/),
+		})
+		mocks.sendToChannel.mockClear()
+		await new PropPostingHandler().postPropPair(
+			'guild-1',
+			'channel-1',
+			prop,
+			'nba',
+			'550e8400-e29b-41d4-a716-446655440010',
+			'prop-post:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+		)
+		expect(mocks.sendToChannel.mock.calls[0][1].nonce).toBe(
+			firstOptions.nonce,
+		)
+	})
+
 	it('does not repost a prop already delivered to the same destination', async () => {
 		const handler = new PropPostingHandler()
 
@@ -163,6 +193,23 @@ describe('PropPostingHandler message references and idempotency', () => {
 
 		expect(result).toMatchObject({ posted: 1, filtered: 0, failed: 0 })
 		expect(result.results).toEqual(references)
+		expect(mocks.sendToChannel).not.toHaveBeenCalled()
+	})
+
+	it('fails closed on an unknown legacy marker instead of reposting', async () => {
+		mocks.get.mockResolvedValue(JSON.stringify({ status: 'complete' }))
+
+		const result = await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toMatchObject({ posted: 0, failed: 1, filtered: 0 })
+		expect(result.failures[0]?.error).toMatch(
+			/unknown legacy delivery marker/i,
+		)
 		expect(mocks.sendToChannel).not.toHaveBeenCalled()
 	})
 


### PR DESCRIPTION
## Parlays & Predictions audit remediation — Pluto foundations

Draft integration PR targeting `dev/parlays-props`. This PR contains the Pluto builder/cache foundations, idempotent placement reconciliation, and durable notification receiver; it does not merge, deploy, publish packages, or enable the durable worker outside the test seam.

### Implemented slices

- [TF-1056](https://linear.app/zelusforge/issue/TF-1056): versioned parlay builder session/control identities to reject stale UI interactions.
- [TF-1060](https://linear.app/zelusforge/issue/TF-1060): typed cache atomic-operation port with Redis/in-memory semantic parity.
- [TF-1058](https://linear.app/zelusforge/issue/TF-1058): stable `placement_id` lifecycle, timeout/lease-loss reconciliation, and cancellation fencing through Khronos.
- [TF-1059](https://linear.app/zelusforge/issue/TF-1059): durable versioned notification receiver, Redis/BullMQ delivery state, per-destination retry/permanent classification, and delivery status lookup.

### Cross-repository links

- Program parent: [TF-1036](https://linear.app/zelusforge/issue/TF-1036)
- Khronos placement, shared schemas, and lease-backed outbox: [Khronos PR #692](https://github.com/fearandesire/khronos/pull/692) — TF-1039, TF-1041, and [TF-1064](https://linear.app/zelusforge/issue/TF-1064).
- Goracle durable outcome outbox and independent processor: [Goracle PR #50](https://github.com/fearandesire/goracle/pull/50) — TF-1052, TF-1053, TF-1054.
- Remaining Pluto prop-post/mock/formatting slices: TF-1061, TF-1062, TF-1063. Paired Khronos producer slices KH-06/KH-07/KH-08 will enqueue the envelopes consumed here.

### Compatibility/rollout note

XR-01 and KH-05 are additive and currently unpublished. PLU-03 accepts the v1 envelope and preserves legacy raw payloads during rollout; it intentionally does not use yalc, commit generated clients, publish packages, migrate shared databases, or enable new workers. The notification queue uses `notification-delivery-v1`, BullMQ `jobId = delivery_id`, 180-day status retention, 60-second locks, 30-second stalled scans, deterministic 25-character Discord nonce, and `enforceNonce: true`.

Placement compatibility requires Khronos PR #692 to land its `placement_id` migration/controller contract before the Pluto placement path is enabled.

### Evidence

Focused notification suites: 6 files / 21 tests passed, including queue/store regressions; `pnpm typecheck`, changed-file Biome, and `git diff --check` passed. PLU-02 focused suites remain 32/32 with typecheck/Biome/diff checks green.

### Review focus

Please prioritize stale-control and placement reconciliation, durable-before-202 semantics, delivery-id hash conflicts, per-destination retry isolation, Discord nonce/idempotency behavior, and compatibility with Khronos PR #692.