### PR TITLE
chore(observability): remove Loki dual-ship for Alloy

### DIFF
--- a/src/lib/startup/env.ts
+++ b/src/lib/startup/env.ts
@@ -46,9 +46,10 @@ const envSchema = z
 		API_KEY: z
 			.string()
 			.min(1, { message: 'API_KEY is required for API authentication' }),
-		LOKI_URL: z.string(),
-		LOKI_USER: z.string().min(1, { message: 'LOKI_USER is required' }),
-		LOKI_PASS: z.string().min(1, { message: 'LOKI_PASS is required' }),
+		// Optional legacy; Alloy scrapes Docker stdout — do not require direct Loki
+		LOKI_URL: z.string().optional().default(''),
+		LOKI_USER: z.string().optional().default(''),
+		LOKI_PASS: z.string().optional().default(''),
 		MAINTENANCE_MODE: z.boolean(),
 		USE_MOCK_DATA: z.boolean().default(false),
 		MOCK_GUILD_BETTING_CHAN_ID: z.string().optional(),

--- a/src/utils/api/koa/setup/koaSetup.ts
+++ b/src/utils/api/koa/setup/koaSetup.ts
@@ -2,7 +2,7 @@ import cors from '@koa/cors'
 import Koa from 'koa'
 import bodyParser from 'koa-bodyparser'
 import { logger } from 'koa2-winston'
-import { createLokiTransport } from './../../../logging/transports/lokiTransport.js'
+import { createConsoleTransport } from './../../../logging/transports/consoleTransport.js'
 import { pageNotFound } from '../../requests/middleware.js'
 import { createApiKeyAuthMiddleware } from './apiKeyAuth.js'
 import { setupBullBoard } from './bullBoard.js'
@@ -25,11 +25,7 @@ export async function setupKoaApp(): Promise<Koa> {
 	// Add logging middleware
 	app.use(
 		logger({
-			transports: createLokiTransport({
-				customLabels: {
-					api: true,
-				},
-			}),
+			transports: [createConsoleTransport()],
 		}),
 	)
 

--- a/src/utils/logging/WinstonLogger.ts
+++ b/src/utils/logging/WinstonLogger.ts
@@ -3,7 +3,8 @@ import 'winston-transport'
 import { fullFormat } from 'winston-error-format'
 import env from '#lib/startup/env.js'
 import { createConsoleTransport } from './transports/consoleTransport.js'
-import { createLokiTransport } from './transports/lokiTransport.js'
+// Loki direct-ship removed: Docker stdout → Alloy is the sole production path
+// (fnx-observability contract v1 / Pluto#580).
 
 /**
  * Renames Winston's `message` field to `msg` so JSON output matches the
@@ -41,16 +42,8 @@ const createBaseFormat = () => {
 	)
 }
 
-const createTransports = (customLabels: Record<string, string> = {}) => {
-	const transports = [
-		createConsoleTransport(),
-		createLokiTransport({ customLabels }),
-	]
-
-	return transports.filter(
-		(transport): transport is NonNullable<typeof transport> =>
-			transport !== null,
-	)
+const createTransports = (_customLabels: Record<string, string> = {}) => {
+	return [createConsoleTransport()]
 }
 
 /**
@@ -99,9 +92,12 @@ export const createRootLogger = (config: LoggerConfig = {}) => {
 		level: resolveLogLevel(),
 		format: createBaseFormat(),
 		defaultMeta: {
+			service: APP.toLowerCase().includes('pluto') ? 'pluto' : APP,
 			app: APP,
+			component: 'bot',
 			version: VERSION,
 			env: ENV,
+			environment: ENV,
 		},
 		transports: createTransports(config.customLabels),
 	})

--- a/src/utils/logging/transports/consoleTransport.ts
+++ b/src/utils/logging/transports/consoleTransport.ts
@@ -2,7 +2,6 @@ import * as winston from 'winston'
 import { consoleFormat } from 'winston-console-format'
 import { fullFormat } from 'winston-error-format'
 import env from '#lib/startup/env.js'
-import { messageToMsg } from '../WinstonLogger.js'
 
 /**
  * Creates a console transport with environment-aware formatting.
@@ -26,11 +25,11 @@ export const createConsoleTransport = () => {
 		(logFormat !== 'json' && env.NODE_ENV !== 'production')
 
 	if (!usePretty) {
+		// Keep Winston `message` field name for Alloy stage.json (`msg = "message"`).
 		return new winston.transports.Console({
 			format: winston.format.combine(
 				winston.format.timestamp(),
 				fullFormat(),
-				messageToMsg(),
 				winston.format.json(),
 			),
 		})


### PR DESCRIPTION
Closes #580

## Summary
- Remove Winston + Koa Loki transports (Docker → Alloy only)
- Keep `message` field name for Alloy `stage.json`
- Add service/app/component defaultMeta
- Make LOKI_* optional

## Test plan
- [ ] CI green
- [ ] App starts without LOKI_* env
- [ ] LogQL `{cluster="Atlas", compose_project="pluto"} | json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Logging now includes service, component, and environment details for improved context.
  - JSON-formatted console logs preserve the standard `message` field.

- **Bug Fixes**
  - Applications can start without Loki connection settings.
  - Logging now consistently uses console output instead of Loki.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->