### PR TITLE
chore: promote parlays-props remediation to main

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
   pull_request:
-    branches: [main]
+    branches: [main, dev/parlays-props]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -51,6 +51,17 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:7.4-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,6 +81,15 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test with required Redis contract
+        run: pnpm test:run
+        env:
+          PLUTO_REQUIRE_REDIS_TESTS: "1"
+          PLUTO_TEST_REDIS_URL: redis://localhost:6379/15
 
       - name: Build
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"@koa/cors": "^5.0.0",
 		"@koa/router": "^15.5.0",
 		"@pluto-khronos/api-client": "3.4.3",
-		"@pluto-khronos/types": "3.4.3",
+		"@pluto-khronos/types": "3.5.1",
 		"@sapphire/decorators": "^6.1.1",
 		"@sapphire/discord-utilities": "^4.0.0",
 		"@sapphire/discord.js-utilities": "^7.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 3.4.3
         version: 3.4.3
       '@pluto-khronos/types':
-        specifier: 3.4.3
-        version: 3.4.3(discord.js@14.26.3)
+        specifier: 3.5.1
+        version: 3.5.1(discord.js@14.26.3)
       '@sapphire/decorators':
         specifier: ^6.1.1
         version: 6.2.0
@@ -1842,8 +1842,8 @@ packages:
   '@pluto-khronos/api-client@3.4.3':
     resolution: {integrity: sha512-5r387yyxvpmJpbq+3K+OGHrEEo7VrYftTm94TCFz0AdypLIU5YxMpW2B8wVXcfCQwS+WFNtYRPtkr+bacx45dg==}
 
-  '@pluto-khronos/types@3.4.3':
-    resolution: {integrity: sha512-nbpTwpFuInMAqs+3aswc7kD0Gwpumrr1jjpdPwO0Or+pyi3dvRh5Wusd4c4W5HYRhKc7L6Mln9VlmYCfVaaLLg==}
+  '@pluto-khronos/types@3.5.1':
+    resolution: {integrity: sha512-yRV2ckWCVAGlOcb42ugy6/77LNSlnFvwBWS17jA3i9Jup1j6ruLUeFvKwfe7qEcc5XMUognWwhcp0ZpjdqwXAg==}
     peerDependencies:
       discord.js: ^14.0.0
 
@@ -8705,7 +8705,7 @@ snapshots:
 
   '@pluto-khronos/api-client@3.4.3': {}
 
-  '@pluto-khronos/types@3.4.3(discord.js@14.26.3)':
+  '@pluto-khronos/types@3.5.1(discord.js@14.26.3)':
     dependencies:
       discord.js: 14.26.3
       resolve-team: 2.0.4

--- a/src/commands/betting/mybets.ts
+++ b/src/commands/betting/mybets.ts
@@ -36,6 +36,7 @@ export class UserCommand extends Command {
 			const historyPage = this.paginationService.getHistoryPage(
 				betsData.historyBets,
 				1,
+				betsData.historyParlays,
 			)
 			const groupedBets = this.paginationService.groupBetsByDate(
 				historyPage.bets,
@@ -44,6 +45,8 @@ export class UserCommand extends Command {
 			const displayData: MyBetsDisplayData = {
 				userId,
 				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
 				historyPage,
 				groupedBets,
 			}

--- a/src/commands/betting/mybets.ts
+++ b/src/commands/betting/mybets.ts
@@ -49,6 +49,7 @@ export class UserCommand extends Command {
 				historyParlays: betsData.historyParlays,
 				historyPage,
 				groupedBets,
+				parlayFetchWarning: betsData.parlayFetchWarning,
 			}
 
 			const response = await this.formatterService.buildEmbedResponse(

--- a/src/commands/betting/parlay.ts
+++ b/src/commands/betting/parlay.ts
@@ -29,7 +29,10 @@ export class UserCommand extends Command {
 		await interaction.deferReply({ flags: MessageFlags.Ephemeral })
 		try {
 			const service = this.getService()
-			const session = await service.start(interaction.user.id)
+			const session = await service.start(
+				interaction.user.id,
+				interaction.guildId!,
+			)
 			return interaction.editReply(service.render(session))
 		} catch (error) {
 			this.container.logger.error({

--- a/src/commands/betting/parlay.ts
+++ b/src/commands/betting/parlay.ts
@@ -1,0 +1,52 @@
+import { ApplyOptions } from '@sapphire/decorators'
+import { Command } from '@sapphire/framework'
+import { InteractionContextType, MessageFlags } from 'discord.js'
+import { ParlayBuilderService } from '../../services/ParlayBuilderService.js'
+import { ErrorEmbeds } from '../../utils/common/errors/global.js'
+
+@ApplyOptions<Command.Options>({
+	description: '🎲 Build a multi-game parlay',
+})
+export class UserCommand extends Command {
+	private builderService?: ParlayBuilderService
+
+	private getService(): ParlayBuilderService {
+		return (this.builderService ??= new ParlayBuilderService())
+	}
+
+	public override registerApplicationCommands(registry: Command.Registry) {
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName(this.name)
+				.setDescription(this.description)
+				.setContexts(InteractionContextType.Guild),
+		)
+	}
+
+	public override async chatInputRun(
+		interaction: Command.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral })
+		try {
+			const service = this.getService()
+			const session = await service.start(interaction.user.id)
+			return interaction.editReply(service.render(session))
+		} catch (error) {
+			this.container.logger.error({
+				message: 'Failed to start parlay builder',
+				metadata: {
+					userId: interaction.user.id,
+					error:
+						error instanceof Error ? error.message : String(error),
+				},
+			})
+			return interaction.editReply({
+				embeds: [
+					await ErrorEmbeds.internalErr(
+						'Unable to start your parlay. Please try again.',
+					),
+				],
+			})
+		}
+	}
+}

--- a/src/commands/predictions/__tests__/predictions.test.ts
+++ b/src/commands/predictions/__tests__/predictions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetLeaderboard = vi.fn()
 const mockGetActivePredictionsForUser = vi.fn()
+const mockGetPredictionStats = vi.fn()
 
 vi.mock(
 	'../../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js',
@@ -22,6 +23,12 @@ vi.mock(
 		}),
 	}),
 )
+
+vi.mock('../../../utils/api/Khronos/stats/stats-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getPredictionStats: mockGetPredictionStats }
+	}),
+}))
 
 vi.mock('../../../utils/api/Khronos/props/props-api-wrapper.js', () => ({
 	default: vi.fn().mockImplementation(function () {
@@ -55,7 +62,10 @@ vi.mock('@sapphire/discord.js-utilities', () => ({
 }))
 
 const { SlashCommandBuilder } = await import('discord.js')
-const { UserCommand } = await import('../predictions.js')
+const { formatStreakBadge, UserCommand } = await import('../predictions.js')
+const { formatStreakLine } = await import(
+	'../../../utils/predictions/streak-display.js'
+)
 
 function makeInteraction() {
 	return {
@@ -122,6 +132,9 @@ describe('/predictions', () => {
 					correct_predictions: 9,
 					incorrect_predictions: 3,
 					success_rate: 75,
+					current_streak: 0,
+					best_streak: 0,
+					badge_tier: null,
 				},
 			],
 			total_users: 1,
@@ -158,6 +171,149 @@ describe('/predictions', () => {
 				expect.objectContaining({ name: '⏳ Pending', value: '`2`' }),
 			]),
 		)
+	})
+
+	it('renders current and best streak from the Khronos stats contract', async () => {
+		mockGetLeaderboard.mockResolvedValue({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+					current_streak: 4,
+					best_streak: 7,
+					badge_tier: 3,
+				},
+			],
+			total_users: 1,
+		})
+		mockGetActivePredictionsForUser.mockResolvedValue([])
+		mockGetPredictionStats.mockResolvedValue({
+			user_id: 'user-1',
+			correct_predictions: 9,
+			incorrect_predictions: 3,
+			total_predictions: 12,
+			success_rate: 75,
+			current_streak: 4,
+			best_streak: 7,
+			badge_tier: 3,
+		})
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(mockGetPredictionStats).toHaveBeenCalledWith({
+			userId: 'user-1',
+			guildId: 'guild-1',
+		})
+		const [{ embeds }] = interaction.editReply.mock.calls.find(
+			([payload]) => payload.embeds,
+		) as [{ embeds: Array<{ toJSON: () => unknown }> }]
+		const embed = embeds[0].toJSON() as {
+			fields?: Array<{ name: string; value: string }>
+		}
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🔥 Current Streak',
+					value: '`4`',
+				}),
+				expect.objectContaining({
+					name: '🏆 Best Streak',
+					value: '`7`',
+				}),
+				expect.objectContaining({
+					name: '🏅 Streak Badge',
+					value: '`🔥3`',
+				}),
+			]),
+		)
+	})
+
+	it.each([
+		[0, ''],
+		[2, ''],
+		[3, ' 🔥3'],
+		[5, ' 🔥5'],
+		[10, ' 🔥10'],
+	] as const)('formats streak marker at threshold %i', (streak, expected) => {
+		expect(formatStreakBadge(streak)).toBe(expected)
+	})
+
+	it('does not present unavailable stats as a broken zero streak', async () => {
+		mockGetLeaderboard.mockResolvedValue({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+					current_streak: 4,
+					best_streak: 7,
+					badge_tier: 3,
+				},
+			],
+			total_users: 1,
+		})
+		mockGetActivePredictionsForUser.mockResolvedValue([])
+		mockGetPredictionStats.mockRejectedValue(
+			new Error('stats endpoint unavailable'),
+		)
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		const [{ embeds }] = interaction.editReply.mock.calls.find(
+			([payload]) => payload.embeds,
+		) as [{ embeds: Array<{ toJSON: () => unknown }> }]
+		const embed = embeds[0].toJSON() as {
+			description?: string
+			fields?: Array<{ name: string; value: string }>
+		}
+		expect(embed.description).toContain(formatStreakLine(null, null))
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🔥 Current Streak',
+					value: '`Unavailable`',
+				}),
+				expect.objectContaining({
+					name: '🏅 Streak Badge',
+					value: '`Unavailable`',
+				}),
+			]),
+		)
+	})
+
+	it('renders a fire marker in leaderboard rows at the reported tier', async () => {
+		const createLeaderboardEmbed = (
+			command as unknown as {
+				createLeaderboardEmbed: (
+					entries: unknown[],
+					page: number,
+				) => Promise<{ toJSON: () => { description?: string } }>
+			}
+		).createLeaderboardEmbed.bind(command)
+		const embed = await createLeaderboardEmbed(
+			[
+				{
+					position: 1,
+					userId: 'user-1',
+					score: 88,
+					correctPredictions: 10,
+					incorrectPredictions: 2,
+					currentStreak: 5,
+					bestStreak: 6,
+					badgeTier: 5,
+				},
+			],
+			1,
+		)
+
+		expect(embed.toJSON().description).toContain('user-1 🔥5')
 	})
 
 	it('returns friendly empty copy when server stats and pending data are empty', async () => {

--- a/src/commands/predictions/__tests__/predictions.test.ts
+++ b/src/commands/predictions/__tests__/predictions.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetLeaderboard = vi.fn()
+const mockGetActivePredictionsForUser = vi.fn()
+
+vi.mock(
+	'../../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js',
+	() => ({
+		default: vi.fn().mockImplementation(function () {
+			return { getLeaderboard: mockGetLeaderboard }
+		}),
+	}),
+)
+
+vi.mock(
+	'../../../utils/api/Khronos/prediction/predictionApiWrapper.js',
+	() => ({
+		default: vi.fn().mockImplementation(function () {
+			return {
+				getActivePredictionsForUser: mockGetActivePredictionsForUser,
+			}
+		}),
+	}),
+)
+
+vi.mock('../../../utils/api/Khronos/props/props-api-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getPropByUuid: vi.fn() }
+	}),
+}))
+
+vi.mock('../../../utils/common/TeamInfo.js', () => ({
+	default: {
+		resolveTeamIdentifier: vi.fn().mockResolvedValue({
+			away_team: 'AWY',
+			home_team: 'HME',
+		}),
+	},
+}))
+
+vi.mock('../../../utils/bot_res/ClientTools.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { resolveMember: vi.fn() }
+	}),
+}))
+
+vi.mock('@sapphire/discord.js-utilities', () => ({
+	PaginatedMessageEmbedFields: vi.fn().mockImplementation(function () {
+		return {
+			setItems: vi.fn().mockReturnThis(),
+			setItemsPerPage: vi.fn().mockReturnThis(),
+			make: vi.fn().mockReturnValue({ run: vi.fn() }),
+		}
+	}),
+}))
+
+const { SlashCommandBuilder } = await import('discord.js')
+const { UserCommand } = await import('../predictions.js')
+
+function makeInteraction() {
+	return {
+		guildId: 'guild-1',
+		user: { id: 'user-1', username: 'Fenix' },
+		deferReply: vi.fn().mockResolvedValue(undefined),
+		editReply: vi.fn().mockResolvedValue(undefined),
+		options: {
+			getUser: vi.fn().mockReturnValue(null),
+			getString: vi.fn().mockReturnValue(null),
+		},
+	}
+}
+
+describe('/predictions', () => {
+	let command: InstanceType<typeof UserCommand>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		command = Object.create(UserCommand.prototype) as InstanceType<
+			typeof UserCommand
+		>
+		Object.defineProperty(command, 'container', {
+			configurable: true,
+			value: { logger: { error: vi.fn(), warn: vi.fn() } },
+		})
+	})
+
+	it('registers guild-only history, stats, and leaderboard subcommands', () => {
+		const registry = {
+			registerChatInputCommand: vi.fn(),
+		}
+		Object.defineProperties(command, {
+			name: { configurable: true, value: 'predictions' },
+			description: {
+				configurable: true,
+				value: 'View prediction history, stats, and leaderboard',
+			},
+		})
+
+		command.registerApplicationCommands(registry as never)
+
+		expect(registry.registerChatInputCommand).toHaveBeenCalledTimes(1)
+		const [builder, options] =
+			registry.registerChatInputCommand.mock.calls[0]
+		const json = builder(new SlashCommandBuilder()).toJSON()
+
+		expect(json.name).toBe('predictions')
+		expect(json.contexts).toEqual([0])
+		expect(json.options?.map((option) => option.name)).toEqual([
+			'history',
+			'stats',
+			'leaderboard',
+		])
+		expect(options.idHints).toEqual(['1298280482123026537'])
+	})
+
+	it('renders server-calculated stats and pending count', async () => {
+		mockGetLeaderboard.mockResolvedValue({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+				},
+			],
+			total_users: 1,
+		})
+		mockGetActivePredictionsForUser.mockResolvedValue([
+			{ id: 'pending-1', guild_id: 'guild-1' },
+			{ id: 'pending-2', guild_id: 'guild-1' },
+		])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(mockGetLeaderboard).toHaveBeenCalledWith({ guildId: 'guild-1' })
+		expect(mockGetActivePredictionsForUser).toHaveBeenCalledWith({
+			userId: 'user-1',
+		})
+		const [{ embeds }] = interaction.editReply.mock.calls.find(
+			([payload]) => payload.embeds,
+		) as [{ embeds: Array<{ toJSON: () => unknown }> }]
+		const embed = embeds[0].toJSON() as {
+			title?: string
+			description?: string
+			fields?: unknown[]
+		}
+		expect(embed.title).toBe('📊 Prediction Statistics')
+		expect(embed.description).toContain('Server stats')
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'Total Predictions',
+					value: '`12`',
+				}),
+				expect.objectContaining({ name: 'Win Rate', value: '`75.0%`' }),
+				expect.objectContaining({ name: '⏳ Pending', value: '`2`' }),
+			]),
+		)
+	})
+
+	it('returns friendly empty copy when server stats and pending data are empty', async () => {
+		mockGetLeaderboard.mockResolvedValue({ entries: [], total_users: 0 })
+		mockGetActivePredictionsForUser.mockResolvedValue([])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			content: "You haven't made any predictions yet.",
+		})
+	})
+
+	it('does not count pending predictions from another guild', async () => {
+		mockGetLeaderboard.mockResolvedValue({ entries: [], total_users: 0 })
+		mockGetActivePredictionsForUser.mockResolvedValue([
+			{ id: 'pending-other-guild', guild_id: 'guild-2' },
+		])
+
+		const interaction = makeInteraction()
+		await command.handleStats(interaction as never)
+
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			content: "You haven't made any predictions yet.",
+		})
+	})
+})

--- a/src/commands/predictions/history.ts
+++ b/src/commands/predictions/history.ts
@@ -1,233 +1,31 @@
-import {
-	type AllUserPredictionsDto,
-	GetAllPredictionsFilteredStatusEnum,
-} from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
-import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
 import { Command } from '@sapphire/framework'
-import type { User } from 'discord.js'
-import { EmbedBuilder, InteractionContextType } from 'discord.js'
-import _ from 'lodash'
-import embedColors from '../../lib/colorsConfig.js'
-import { MarketKeyAbbreviations } from '../../utils/api/common/interfaces/market-abbreviations.js'
-import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
-import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
-import { DateManager } from '../../utils/common/DateManager.js'
-import TeamInfo from '../../utils/common/TeamInfo.js'
+import { InteractionContextType } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
+/**
+ * @deprecated Use /predictions history. Kept for one release as a pointer.
+ */
 @ApplyOptions<Command.Options>({
-	description: 'View your prediction history',
+	description: 'View your prediction history (legacy alias)',
 })
 export class UserCommand extends Command {
-	private readonly dateManager = new DateManager()
-
-	public constructor(context: Command.Context, options: Command.Options) {
-		super(context, {
-			...options,
-			description: 'View your prediction history.',
-		})
-	}
-
 	public override registerApplicationCommands(registry: Command.Registry) {
-		registry.registerChatInputCommand(
-			(builder) =>
-				builder //
-					.setName(this.name)
-					.setDescription(this.description)
-					.setContexts(InteractionContextType.Guild)
-					.addUserOption((option) =>
-						option
-							.setName('user')
-							.setDescription(
-								'[Optional] The user to view history for (default: yourself)',
-							)
-							.setRequired(false),
-					)
-					.addStringOption((option) =>
-						option
-							.setName('status')
-							.setDescription(
-								'[Optional] Filter predictions by status',
-							)
-							.setRequired(false)
-							.addChoices(
-								{
-									name: 'Pending',
-									value: GetAllPredictionsFilteredStatusEnum.Pending,
-								},
-								{
-									name: 'Completed',
-									value: GetAllPredictionsFilteredStatusEnum.Completed,
-								},
-							),
-					),
-			{ idHints: ['1298280482123026536'] },
+		// No id hint: the former history hint was shared with /prediction.
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName(this.name)
+				.setDescription(this.description)
+				.setContexts(InteractionContextType.Guild),
 		)
 	}
 
 	public override async chatInputRun(
 		interaction: Command.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const user = interaction.options.getUser('user') || interaction.user
-		const status = interaction.options.getString(
-			'status',
-		) as GetAllPredictionsFilteredStatusEnum | null
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions = await (status
-				? predictionApiWrapper.getPredictionsFiltered({
-						userId: user.id,
-						status,
-					})
-				: predictionApiWrapper.getPredictionsForUser({
-						userId: user.id,
-					}))
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: 'No predictions found for the specified criteria.',
-				})
-			}
-			const descStr = status ? `Filtered by: \`${status}\`` : null
-			const templateEmbed = new EmbedBuilder()
-				.setTitle(`Prediction History | ${user.username}`)
-				.setDescription(descStr)
-				.setColor(embedColors.PlutoBlue)
-
-			const propsApiWrapper = new PropsApiWrapper()
-			let hadFormattingFailures = false
-			const formattedPredictions = (
-				await Promise.allSettled(
-					usersPredictions.map((prediction) =>
-						this.createPredictionField(prediction, propsApiWrapper),
-					),
-				)
-			).flatMap((result, index) => {
-				if (result.status === 'fulfilled') {
-					return result.value ? [result.value] : []
-				}
-				hadFormattingFailures = true
-				const prediction = usersPredictions[index]
-				this.container.logger.error(
-					`Failed to create prediction field for prediction ${prediction?.id || 'unknown'} (user: ${user.id})`,
-					result.reason,
-				)
-				return []
-			})
-
-			if (formattedPredictions.length === 0) {
-				const baseDescription = descStr ? `${descStr}\n\n` : ''
-				const message = hadFormattingFailures
-					? 'We were unable to load details for your predictions. Please try again later.'
-					: 'No prediction history found. Your predictions will appear here once you make them.'
-
-				templateEmbed.setDescription(baseDescription + message)
-				return interaction.editReply({ embeds: [templateEmbed] })
-			}
-
-			const paginatedMsg = new PaginatedMessageEmbedFields({
-				template: { embeds: [templateEmbed] },
-			})
-				.setItems(formattedPredictions)
-				.setItemsPerPage(10)
-				.make()
-
-			await paginatedMsg.run(interaction)
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content:
-					'An error occurred while fetching the prediction history.',
-			})
-		}
-	}
-
-	private async createPredictionField(
-		prediction: AllUserPredictionsDto,
-		propsApiWrapper: PropsApiWrapper,
-	): Promise<{ name: string; value: string; inline: boolean } | null> {
-		const outcomeEmoji = this.getOutcomeEmoji(prediction)
-		const parsedMatchString = await this.parseMatchString(
-			prediction.match_string,
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions history',
 		)
-		const parsedChoice = this.parseChoice(prediction.choice)
-		const prop = await propsApiWrapper.getPropByUuid(
-			prediction.outcome_uuid,
-		)
-		const outcome = prop.outcomes.find(
-			(o) => o.outcome_uuid === prediction.outcome_uuid,
-		)
-		if (!outcome) {
-			this.container.logger.warn(
-				`Missing outcome for prediction ${prediction.id} (market_key: ${prop.market_key}, outcome_uuid: ${prediction.outcome_uuid})`,
-			)
-			return null
-		}
-		const { market_key } = prop
-		const point = outcome.point ?? null
-		let parsedMarketKey = MarketKeyAbbreviations[market_key] || market_key
-		parsedMarketKey = _.startCase(parsedMarketKey)
-		const outcomeStr = (emoji: string) => {
-			if (emoji === '⏳') {
-				return 'Pending ⏳'
-			}
-			if (emoji === '✅') {
-				return 'Correct ✅'
-			}
-			if (emoji === '❌') {
-				return 'Incorrect ❌'
-			}
-			return emoji
-		}
-		const date = this.dateManager.toMMDDYYYY(
-			prop.event_context.commence_time,
-		)
-		const pointText = point ?? ''
-		const formattedChoice =
-			pointText === ''
-				? `\`${parsedChoice}\``
-				: `\`${parsedChoice} ${pointText}\``
-		let value = `**Date**: ${date}\n**Status**: ${outcomeStr(outcomeEmoji)}\n**Choice**: ${formattedChoice}\n**Market**: ${parsedMarketKey} `
-
-		if (prediction.description && prediction.description.trim() !== '') {
-			value += `\n**Player:** ${prediction.description}`
-		}
-
-		return {
-			name: `${parsedMatchString}`,
-			value: value,
-			inline: false,
-		}
-	}
-
-	private getOutcomeEmoji(prediction: AllUserPredictionsDto): string {
-		if (
-			prediction.status !== GetAllPredictionsFilteredStatusEnum.Completed
-		) {
-			return '⏳'
-		}
-		if (prediction.is_correct === null) {
-			return '⏳'
-		}
-		return prediction?.is_correct ? '✅' : '❌'
-	}
-
-	private async parseMatchString(matchString: string) {
-		const [awayTeam, homeTeam] = matchString.split(' vs. ')
-		if (!awayTeam || !homeTeam) {
-			return matchString
-		}
-		const result = await TeamInfo.resolveTeamIdentifier({
-			away_team: awayTeam,
-			home_team: homeTeam,
-		})
-
-		return `${result.away_team} vs. ${result.home_team}`
-	}
-	private parseChoice(choice: string) {
-		return choice.charAt(0).toUpperCase() + choice.slice(1).toLowerCase()
 	}
 }

--- a/src/commands/predictions/prediction-leaderboard.ts
+++ b/src/commands/predictions/prediction-leaderboard.ts
@@ -1,16 +1,13 @@
-import type { SimpleLeaderboardResponseDto } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
 import { Command } from '@sapphire/framework'
-import { EmbedBuilder, InteractionContextType, type Message } from 'discord.js'
-import _ from 'lodash'
-import embedColors from '../../lib/colorsConfig.js'
-import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
-import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
-import ClientTools from '../../utils/bot_res/ClientTools.js'
-import Pagination from '../../utils/embeds/pagination.js'
+import { InteractionContextType } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
+/**
+ * @deprecated Use /predictions leaderboard. Kept for one release as a pointer.
+ */
 @ApplyOptions<Command.Options>({
-	description: 'View the leaderboard for accuracy challenge',
+	description: 'View the prediction leaderboard (legacy alias)',
 })
 export class UserCommand extends Command {
 	public override registerApplicationCommands(registry: Command.Registry) {
@@ -20,255 +17,16 @@ export class UserCommand extends Command {
 					.setName('accuracy_leaderboard')
 					.setDescription(this.description)
 					.setContexts([InteractionContextType.Guild]),
-			{
-				idHints: ['1297933995123933225'],
-			},
+			{ idHints: ['1297933995123933225'] },
 		)
 	}
 
 	public override async chatInputRun(
 		interaction: Command.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply()
-
-		try {
-			const guildId = interaction.guildId
-
-			await interaction.editReply({
-				content: 'Fetching leaderboard data...',
-			})
-
-			const leaderboardWrapper = new LeaderboardWrapper()
-			const leaderboard = await leaderboardWrapper.getLeaderboard({
-				guildId,
-			})
-
-			if (!leaderboard || _.isEmpty(leaderboard.entries)) {
-				return interaction.editReply({
-					content: 'No leaderboard data found.',
-				})
-			}
-
-			await this.container.logger.info({
-				leaderboardEntries: leaderboard.entries.length,
-			})
-
-			await interaction.editReply({
-				content: 'Processing leaderboard data...',
-			})
-
-			const thumbnail = interaction.guild?.iconURL({ extension: 'png' })
-			const parsedLeaderboard = this.parseLeaderboardData(leaderboard)
-
-			const embed = await this.createLeaderboardEmbed({
-				leaderboardData: parsedLeaderboard,
-				currentPage: 1,
-				metadata: { thumbnail },
-			})
-
-			const pagination = new Pagination()
-			const components = pagination.createPaginationButtons(
-				1,
-				Math.ceil(parsedLeaderboard.length / 20),
-			)
-
-			const reply = await interaction.editReply({
-				content: null,
-				embeds: [embed],
-				components,
-			})
-
-			await this.handlePagination(interaction, reply, parsedLeaderboard)
-		} catch (error) {
-			if (error instanceof EmptyDataException) {
-				return interaction.editReply({
-					content: error.message,
-				})
-			}
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching the leaderboard.',
-			})
-		}
-	}
-
-	private parseLeaderboardData(
-		leaderboardData: SimpleLeaderboardResponseDto,
-	): ParsedLeaderboardEntry[] {
-		if (!leaderboardData.entries || leaderboardData.entries.length === 0) {
-			return []
-		}
-
-		// Entries are already aggregated and sorted by the backend
-		// Calculate score using the formula: (correct * 10) + (incorrect * -2)
-		// Default values from ScoringService as per predictions/prediction-system.md
-		return leaderboardData.entries.map((entry, index) => {
-			const score =
-				entry.correct_predictions * LEADERBOARD_SCORING.CORRECT_POINTS +
-				entry.incorrect_predictions *
-					LEADERBOARD_SCORING.INCORRECT_PENALTY
-
-			return {
-				userId: entry.user_id,
-				score,
-				correctPredictions: entry.correct_predictions,
-				incorrectPredictions: entry.incorrect_predictions,
-				position: index + 1,
-			}
-		})
-	}
-
-	async createLeaderboardEmbed(
-		params: CreateLeaderboardEmbedParams,
-	): Promise<EmbedBuilder> {
-		if (
-			!params.leaderboardData ||
-			params.leaderboardData.length === 0 ||
-			_.isEmpty(params.leaderboardData)
-		) {
-			throw new EmptyDataException('the leaderboard')
-		}
-
-		const currentPage = params.currentPage || 1
-		const startIndex = (currentPage - 1) * 20
-		const endIndex = startIndex + 20
-		const pageEntries = params.leaderboardData.slice(startIndex, endIndex)
-		const totalPages = Math.ceil(params.leaderboardData.length / 20)
-
-		// Process user data in parallel with proper error handling
-		const descriptionLines = await Promise.all(
-			pageEntries.map(async (entry) => {
-				try {
-					const member = await this.getMember(entry.userId)
-					const username = member ? member.username : entry.userId
-					const total =
-						entry.correctPredictions + entry.incorrectPredictions
-					return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
-				} catch (error) {
-					this.container.logger.error(
-						`Error processing user ${entry.userId}:`,
-						error,
-					)
-					return `${entry.position}. Unknown User - **\`${entry.score}\`** *(${entry.correctPredictions}/${entry.correctPredictions + entry.incorrectPredictions})*`
-				}
-			}),
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions leaderboard',
 		)
-
-		const embed = new EmbedBuilder()
-			.setTitle(
-				`Accuracy Leaderboard${params.title ? ` | ${params.title}` : ''}`,
-			)
-			.setColor(embedColors.PlutoBlue)
-			.setDescription(descriptionLines.join('\n'))
-			.setFooter({
-				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${params.leaderboardData.length}`,
-			})
-
-		if (params.metadata?.thumbnail) {
-			embed.setThumbnail(params.metadata.thumbnail)
-		}
-
-		return embed
-	}
-
-	private async getMember(userId: string) {
-		try {
-			return await new ClientTools(this.container).resolveMember(userId)
-		} catch (error) {
-			this.container.logger.error(
-				`Failed to resolve member ${userId}:`,
-				error,
-			)
-			return null
-		}
-	}
-
-	private async handlePagination(
-		interaction: Command.ChatInputCommandInteraction,
-		reply: Message,
-		leaderboard: ParsedLeaderboardEntry[],
-	) {
-		const totalPages = Math.ceil(leaderboard.length / 20)
-		let currentPage = 1
-
-		const collector = reply.createMessageComponentCollector({ time: 60000 })
-
-		collector.on('collect', async (i) => {
-			if (i.user.id !== interaction.user.id) {
-				await i.followUp({
-					content:
-						'Only the original user can interact with these buttons.',
-					ephemeral: true,
-				})
-				return
-			}
-
-			switch (i.customId) {
-				case 'first':
-					currentPage = 1
-					break
-				case 'previous':
-					currentPage = Math.max(1, currentPage - 1)
-					break
-				case 'next':
-					currentPage = Math.min(totalPages, currentPage + 1)
-					break
-				case 'last':
-					currentPage = totalPages
-					break
-			}
-
-			const newEmbed = await this.createLeaderboardEmbed({
-				leaderboardData: leaderboard,
-				currentPage,
-			})
-			const pagination = new Pagination()
-			const newComponents = pagination.createPaginationButtons(
-				currentPage,
-				totalPages,
-			)
-
-			await i.update({ embeds: [newEmbed], components: newComponents })
-		})
-
-		collector.on('end', async () => {
-			const pagination = new Pagination()
-			const disabledComponents = pagination
-				.createPaginationButtons(currentPage, totalPages)
-				.map((row) => {
-					for (const button of row.components) {
-						button.setDisabled(true)
-					}
-					return row
-				})
-
-			await reply.edit({ components: disabledComponents })
-		})
-	}
-	private validateOptions(interaction: Command.ChatInputCommandInteraction) {}
-}
-
-interface ParsedLeaderboardEntry {
-	position: number
-	userId: string
-	score: number
-	correctPredictions: number
-	incorrectPredictions: number
-}
-
-class CreateLeaderboardEmbedParams {
-	leaderboardData: ParsedLeaderboardEntry[]
-	currentPage?: number = 1
-	title?: string
-	metadata?: {
-		thumbnail?: string
-	}
-}
-
-class EmptyDataException extends Error {
-	constructor(message: string) {
-		super(message)
-		this.name = 'EmptyDataException'
-		this.message = `No data found for ${message}.`
 	}
 }

--- a/src/commands/predictions/prediction.ts
+++ b/src/commands/predictions/prediction.ts
@@ -1,26 +1,15 @@
-import type { AllUserPredictionsDto } from '@pluto-khronos/api-client'
-import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
-import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities'
 import { Subcommand } from '@sapphire/plugin-subcommands'
-import {
-	EmbedBuilder,
-	InteractionContextType,
-	PermissionFlagsBits,
-} from 'discord.js'
-import _ from 'lodash'
-import { teamResolver } from 'resolve-team'
-import embedColors from '../../lib/colorsConfig.js'
-import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
-import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
-import TeamInfo from '../../utils/common/TeamInfo.js'
+import { InteractionContextType, PermissionFlagsBits } from 'discord.js'
+import { sendPredictionCommandDeprecation } from '../../utils/commands/prediction-deprecation.js'
 
 /**
- * User-facing prediction command for viewing personal prediction history and stats
+ * @deprecated Use /predictions history or /predictions stats. Kept for one
+ * release so existing command registrations have a clear migration path.
  */
 @ApplyOptions<Subcommand.Options>({
 	name: 'prediction',
-	description: 'View your predictions',
+	description: 'View your predictions (legacy alias)',
 	requiredClientPermissions: [
 		PermissionFlagsBits.SendMessages,
 		PermissionFlagsBits.EmbedLinks,
@@ -41,452 +30,36 @@ export class UserCommand extends Subcommand {
 					.addSubcommand((subcommand) =>
 						subcommand
 							.setName('history')
-							.setDescription('View your prediction history')
-							.addStringOption((option) =>
-								option
-									.setName('view')
-									.setDescription('Which predictions to view')
-									.setRequired(true)
-									.addChoices(
-										{
-											name: '⏳ Pending',
-											value: 'pending',
-										},
-										{
-											name: '✅ Completed',
-											value: 'completed',
-										},
-									),
+							.setDescription(
+								'Legacy alias for /predictions history',
 							),
 					)
 					.addSubcommand((subcommand) =>
 						subcommand
 							.setName('stats')
-							.setDescription('View your prediction statistics'),
+							.setDescription(
+								'Legacy alias for /predictions stats',
+							),
 					),
 			{ idHints: ['1298280482123026536'] },
 		)
 	}
 
-	/**
-	 * Handle /predictions history subcommand
-	 */
 	public async handleHistory(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const view = interaction.options.getString('view', true) as
-			| 'pending'
-			| 'completed'
-		const user = interaction.user
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions =
-				await predictionApiWrapper.getPredictionsForUser({
-					userId: user.id,
-				})
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: "You haven't made any predictions yet.",
-				})
-			}
-
-			switch (view) {
-				case 'pending':
-					return this.showPendingView(interaction, usersPredictions)
-				case 'completed':
-					return this.showCompletedView(interaction, usersPredictions)
-			}
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching your predictions.',
-			})
-		}
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions history',
+		)
 	}
 
-	/**
-	 * Handle /predictions stats subcommand
-	 */
 	public async handleStats(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({ ephemeral: true })
-
-		const user = interaction.user
-
-		try {
-			const predictionApiWrapper = new PredictionApiWrapper()
-			const usersPredictions =
-				await predictionApiWrapper.getPredictionsForUser({
-					userId: user.id,
-				})
-
-			if (!usersPredictions || usersPredictions.length === 0) {
-				return interaction.editReply({
-					content: "You haven't made any predictions yet.",
-				})
-			}
-
-			// Calculate statistics
-			const totalPredictions = usersPredictions.length
-			const completedPredictions = usersPredictions.filter(
-				(p) =>
-					p.status === GetAllPredictionsFilteredStatusEnum.Completed,
-			)
-			const pendingPredictions = usersPredictions.filter(
-				(p) => p.status === GetAllPredictionsFilteredStatusEnum.Pending,
-			)
-
-			const correctPredictions = completedPredictions.filter(
-				(p) => p.is_correct === true,
-			)
-			const incorrectPredictions = completedPredictions.filter(
-				(p) => p.is_correct === false,
-			)
-
-			const winRate =
-				completedPredictions.length > 0
-					? (
-							(correctPredictions.length /
-								completedPredictions.length) *
-							100
-						).toFixed(1)
-					: '0.0'
-
-			const embed = new EmbedBuilder()
-				.setTitle('📊 Prediction Statistics')
-				.setColor(embedColors.PlutoBlue)
-				.setDescription(`Stats for ${user.username}`)
-				.addFields(
-					{
-						name: 'Total Predictions',
-						value: `\`${totalPredictions}\``,
-						inline: true,
-					},
-					{
-						name: 'Win Rate',
-						value: `\`${winRate}%\``,
-						inline: true,
-					},
-					{ name: '\u200B', value: '\u200B', inline: true },
-					{
-						name: '✅ Correct',
-						value: `\`${correctPredictions.length}\``,
-						inline: true,
-					},
-					{
-						name: '❌ Incorrect',
-						value: `\`${incorrectPredictions.length}\``,
-						inline: true,
-					},
-					{
-						name: '⏳ Pending',
-						value: `\`${pendingPredictions.length}\``,
-						inline: true,
-					},
-				)
-				.setTimestamp()
-
-			return interaction.editReply({ embeds: [embed] })
-		} catch (error) {
-			this.container.logger.error(error)
-			return interaction.editReply({
-				content: 'An error occurred while fetching your statistics.',
-			})
-		}
-	}
-
-	/**
-	 * Show pending predictions view with detailed format
-	 */
-	private async showPendingView(
-		interaction: Subcommand.ChatInputCommandInteraction,
-		predictions: AllUserPredictionsDto[],
-	) {
-		const pending = predictions.filter(
-			(p) => p.status === GetAllPredictionsFilteredStatusEnum.Pending,
+		return sendPredictionCommandDeprecation(
+			interaction,
+			'/predictions stats',
 		)
-
-		if (pending.length === 0) {
-			return interaction.editReply({
-				content: 'You have no pending predictions.',
-			})
-		}
-
-		type FormattedPrediction = {
-			formattedText: string
-		}
-
-		const formattedPredictions = await Promise.all(
-			pending.map(async (p): Promise<FormattedPrediction> => {
-				const outcome = await this.getOutcomeDetails(p.outcome_uuid)
-				const formattedText = await this.formatPredictionCompact(
-					p,
-					outcome,
-					null,
-				)
-
-				return {
-					formattedText,
-				}
-			}),
-		)
-
-		const templateEmbed = new EmbedBuilder()
-			.setTitle('⏳ Your Pending Predictions')
-			.setDescription(
-				`You have ${pending.length} active prediction${
-					pending.length !== 1 ? 's' : ''
-				}`,
-			)
-			.setColor(embedColors.PlutoYellow)
-
-		const paginatedMsg =
-			new PaginatedFieldMessageEmbed<FormattedPrediction>()
-				.setTitleField('\u200B')
-				.setTemplate(templateEmbed)
-				.setItems(formattedPredictions)
-				.setItemsPerPage(5)
-				.formatItems((item) => item.formattedText)
-				.make()
-
-		return paginatedMsg.run(interaction)
-	}
-
-	/**
-	 * Show completed predictions view with compact format
-	 */
-	private async showCompletedView(
-		interaction: Subcommand.ChatInputCommandInteraction,
-		predictions: AllUserPredictionsDto[],
-	) {
-		const completed = predictions.filter(
-			(p) => p.status !== GetAllPredictionsFilteredStatusEnum.Pending,
-		)
-
-		if (completed.length === 0) {
-			return interaction.editReply({
-				content: 'You have no completed predictions yet.',
-			})
-		}
-
-		const correct = completed.filter(
-			(p) =>
-				p.status === GetAllPredictionsFilteredStatusEnum.Completed &&
-				p.is_correct === true,
-		).length
-		const incorrect = completed.length - correct
-
-		type FormattedCompletedPrediction = {
-			formattedText: string
-		}
-
-		const formattedPredictions = await Promise.all(
-			completed.map(async (p): Promise<FormattedCompletedPrediction> => {
-				// Determine if prediction is correct (only for Completed status)
-				let isCorrect: boolean | null = null
-				if (
-					p.status === GetAllPredictionsFilteredStatusEnum.Completed
-				) {
-					isCorrect = p.is_correct === true
-				}
-				const outcome = await this.getOutcomeDetails(p.outcome_uuid)
-				const formattedText = await this.formatPredictionCompact(
-					p,
-					outcome,
-					isCorrect,
-				)
-
-				return {
-					formattedText,
-				}
-			}),
-		)
-
-		const templateEmbed = new EmbedBuilder()
-			.setTitle('📊 Your Completed Predictions')
-			.setDescription(`${correct} correct • ${incorrect} incorrect`)
-			.setColor(embedColors.PlutoBlue)
-
-		const paginatedMsg =
-			new PaginatedFieldMessageEmbed<FormattedCompletedPrediction>()
-				.setTitleField('\u200B')
-				.setTemplate(templateEmbed)
-				.setItems(formattedPredictions)
-				.setItemsPerPage(8)
-				.formatItems((item) => item.formattedText)
-				.make()
-
-		return paginatedMsg.run(interaction)
-	}
-
-	/**
-	 * Get outcome details from prop API
-	 */
-	private async getOutcomeDetails(outcomeUuid: string): Promise<{
-		name: string
-		description?: string
-		point: number
-		market_key: string
-		event_context: {
-			home_team: string
-			away_team: string
-		}
-	} | null> {
-		try {
-			const propApiWrapper = new PropsApiWrapper()
-			const prop = await propApiWrapper.getPropByUuid(outcomeUuid)
-
-			const outcome = prop.outcomes.find(
-				(o) => o.outcome_uuid === outcomeUuid,
-			)
-
-			if (!outcome) return null
-
-			return {
-				name: outcome.name,
-				description: outcome.description,
-				point: outcome.point,
-				market_key: prop.market_key,
-				event_context: prop.event_context,
-			}
-		} catch (error) {
-			this.container.logger.error(
-				'Failed to fetch outcome details:',
-				error,
-			)
-			return null
-		}
-	}
-
-	/**
-	 * Formats a prediction choice with point and market information
-	 */
-	private formatPredictionChoice(
-		choice: string,
-		point: number | undefined,
-		marketKey: string,
-	): string {
-		const upperChoice = choice.toUpperCase()
-		const marketName = _.startCase(marketKey.replace('player_', ''))
-
-		if (point !== null && point !== undefined) {
-			return `${upperChoice} ${point} ${marketName}`
-		}
-
-		return `${upperChoice} ${marketName}`
-	}
-
-	/**
-	 * Format prediction in compact view format
-	 * Player format: **✅ Player Name** (ABBREV vs. ABBREV)\nProp Type • **PICK Line**\n*<t:TIMESTAMP:d>*
-	 * Team format: **✅ Team Name**\nProp Type • **PICK Line**\n*<t:TIMESTAMP:d>*
-	 */
-	private async formatPredictionCompact(
-		prediction: AllUserPredictionsDto,
-		outcome: {
-			name: string
-			description?: string
-			point: number
-			market_key: string
-			event_context: {
-				home_team: string
-				away_team: string
-			}
-		} | null,
-		isCorrect: boolean | null,
-	): Promise<string> {
-		if (!outcome) {
-			return 'Unknown prediction'
-		}
-
-		const result =
-			isCorrect === true ? '✅' : isCorrect === false ? '❌' : '⏳'
-		const isPlayerPrediction =
-			outcome.description && outcome.description.trim() !== ''
-
-		let entityLine: string
-		if (isPlayerPrediction) {
-			const playerName = outcome.description!
-			let matchupString: string
-			if (prediction.match_string) {
-				const [awayTeam, homeTeam] =
-					prediction.match_string.split(' vs. ')
-				const awayTeamData = await teamResolver.resolve(
-					awayTeam || outcome.event_context.away_team,
-					{ full: true },
-				)
-				const homeTeamData = await teamResolver.resolve(
-					homeTeam || outcome.event_context.home_team,
-					{ full: true },
-				)
-				const awayAbbrev =
-					awayTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(
-						awayTeam || outcome.event_context.away_team,
-					)
-				const homeAbbrev =
-					homeTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(
-						homeTeam || outcome.event_context.home_team,
-					)
-				matchupString = `${awayAbbrev} vs. ${homeAbbrev}`
-			} else {
-				const awayTeamData = await teamResolver.resolve(
-					outcome.event_context.away_team,
-					{ full: true },
-				)
-				const homeTeamData = await teamResolver.resolve(
-					outcome.event_context.home_team,
-					{ full: true },
-				)
-				const awayAbbrev =
-					awayTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(outcome.event_context.away_team)
-				const homeAbbrev =
-					homeTeamData?.abbrev ||
-					TeamInfo.getTeamShortName(outcome.event_context.home_team)
-				matchupString = `${awayAbbrev} vs. ${homeAbbrev}`
-			}
-			entityLine = `**${result} ${playerName}** (${matchupString})`
-		} else {
-			const teamName = TeamInfo.getTeamShortName(outcome.name)
-			entityLine = `**${result} ${teamName}**`
-		}
-
-		const propType = _.startCase(
-			outcome.market_key.replace('player_', '').replace('_', ' '),
-		)
-
-		const pick = prediction.choice.toUpperCase()
-		const line =
-			outcome.point !== null && outcome.point !== undefined
-				? outcome.point.toString()
-				: ''
-
-		const timestamp = Math.floor(
-			new Date(prediction.created_at).getTime() / 1000,
-		)
-		const formattedDate = `<t:${timestamp}:d>`
-
-		const propLine = line
-			? `${propType} • **${pick} ${line}**`
-			: `${propType} • **${pick}**`
-
-		return `${entityLine}\n${propLine}\n*${formattedDate}*`
-	}
-
-	private async parseMatchString(matchString: string) {
-		const [awayTeam, homeTeam] = matchString.split(' vs. ')
-		const result = await TeamInfo.resolveTeamIdentifier({
-			away_team: awayTeam,
-			home_team: homeTeam,
-		})
-
-		return `${result.away_team} vs. ${result.home_team}`
 	}
 }

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -1,7 +1,4 @@
-import type {
-	AllUserPredictionsDto,
-	SimpleLeaderboardResponseDto,
-} from '@pluto-khronos/api-client'
+import type { AllUserPredictionsDto } from '@pluto-khronos/api-client'
 import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
 import { ApplyOptions } from '@sapphire/decorators'
 import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
@@ -16,13 +13,23 @@ import _ from 'lodash'
 import { teamResolver } from 'resolve-team'
 import embedColors from '../../lib/colorsConfig.js'
 import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
-import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
+import LeaderboardWrapper, {
+	type LeaderboardResponseWithStreaks,
+} from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
 import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
 import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
+import StatsWrapper, {
+	type PredictionStats,
+} from '../../utils/api/Khronos/stats/stats-wrapper.js'
 import ClientTools from '../../utils/bot_res/ClientTools.js'
 import { DateManager } from '../../utils/common/DateManager.js'
 import TeamInfo from '../../utils/common/TeamInfo.js'
 import Pagination from '../../utils/embeds/pagination.js'
+import {
+	formatBadge,
+	formatStreakLine,
+	type StreakBadgeTier,
+} from '../../utils/predictions/streak-display.js'
 
 /**
  * Reserved command id for the consolidated group. Legacy aliases retain their
@@ -30,6 +37,28 @@ import Pagination from '../../utils/embeds/pagination.js'
  * the migration window.
  */
 const PREDICTIONS_COMMAND_ID_HINTS = ['1298280482123026537']
+
+/** Resolve display badge from the current streak when older API payloads omit it. */
+export function resolveStreakBadgeTier(
+	currentStreak: number | null,
+	reportedTier: StreakBadgeTier = null,
+): StreakBadgeTier {
+	if (currentStreak === null) return null
+	if (reportedTier !== null) return reportedTier
+	if (currentStreak >= 10) return 10
+	if (currentStreak >= 5) return 5
+	if (currentStreak >= 3) return 3
+	return null
+}
+
+/** Keep leaderboard marker copy consistent across pages and future clients. */
+export function formatStreakBadge(
+	currentStreak: number,
+	reportedTier: StreakBadgeTier = null,
+): string {
+	const tier = resolveStreakBadgeTier(currentStreak, reportedTier)
+	return formatBadge(tier)
+}
 
 @ApplyOptions<Subcommand.Options>({
 	name: 'predictions',
@@ -204,6 +233,20 @@ export class UserCommand extends Subcommand {
 					userId: interaction.user.id,
 				}),
 			])
+			let predictionStats: PredictionStats | null = null
+			try {
+				predictionStats = await new StatsWrapper().getPredictionStats({
+					userId: interaction.user.id,
+					guildId,
+				})
+			} catch (error) {
+				// Keep stats usable while a mixed-version Khronos deployment rolls
+				// out without presenting stale leaderboard streaks as personal stats.
+				this.container.logger.warn(
+					'Prediction streak stats unavailable; using leaderboard fallback.',
+					error,
+				)
+			}
 			const pending = allPending.filter(
 				(prediction) => prediction.guild_id === guildId,
 			)
@@ -221,10 +264,18 @@ export class UserCommand extends Subcommand {
 			const correctPredictions = entry?.correct_predictions ?? 0
 			const incorrectPredictions = entry?.incorrect_predictions ?? 0
 			const winRate = entry?.success_rate ?? 0
+			const currentStreak = predictionStats?.current_streak ?? null
+			const bestStreak = predictionStats?.best_streak ?? null
+			const badgeTier = resolveStreakBadgeTier(
+				currentStreak,
+				predictionStats?.badge_tier ?? null,
+			)
 			const embed = new EmbedBuilder()
 				.setTitle('📊 Prediction Statistics')
 				.setColor(embedColors.PlutoBlue)
-				.setDescription(`Server stats for ${interaction.user.username}`)
+				.setDescription(
+					`Server stats for ${interaction.user.username}\n\n${formatStreakLine(currentStreak, bestStreak)}`,
+				)
 				.addFields(
 					{
 						name: 'Total Predictions',
@@ -252,9 +303,35 @@ export class UserCommand extends Subcommand {
 						value: `\`${pending.length}\``,
 						inline: true,
 					},
+					{
+						name: '🔥 Current Streak',
+						value:
+							currentStreak === null
+								? '`Unavailable`'
+								: `\`${currentStreak}\``,
+						inline: true,
+					},
+					{
+						name: '🏆 Best Streak',
+						value:
+							bestStreak === null
+								? '`Unavailable`'
+								: `\`${bestStreak}\``,
+						inline: true,
+					},
+					{
+						name: '🏅 Streak Badge',
+						value:
+							predictionStats === null
+								? '`Unavailable`'
+								: badgeTier === null
+									? '`None yet`'
+									: `\`🔥${badgeTier}\``,
+						inline: true,
+					},
 				)
 				.setFooter({
-					text: 'Streaks will appear here after the engagement rollout.',
+					text: "Use /predictions leaderboard to compare your streak • voids/pushes don't break streaks.",
 				})
 				.setTimestamp()
 
@@ -362,7 +439,7 @@ export class UserCommand extends Subcommand {
 	}
 
 	private parseLeaderboardData(
-		leaderboard: SimpleLeaderboardResponseDto,
+		leaderboard: LeaderboardResponseWithStreaks,
 	): ParsedLeaderboardEntry[] {
 		return leaderboard.entries.map((entry, index) => ({
 			userId: entry.user_id,
@@ -373,6 +450,9 @@ export class UserCommand extends Subcommand {
 					LEADERBOARD_SCORING.INCORRECT_PENALTY,
 			correctPredictions: entry.correct_predictions,
 			incorrectPredictions: entry.incorrect_predictions,
+			currentStreak: entry.current_streak,
+			bestStreak: entry.best_streak,
+			badgeTier: entry.badge_tier,
 		}))
 	}
 
@@ -389,7 +469,11 @@ export class UserCommand extends Subcommand {
 				const username = member?.username ?? entry.userId
 				const total =
 					entry.correctPredictions + entry.incorrectPredictions
-				return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
+				const streakBadge = formatStreakBadge(
+					entry.currentStreak,
+					entry.badgeTier,
+				)
+				return `${entry.position}. ${username}${streakBadge} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
 			}),
 		)
 
@@ -398,7 +482,7 @@ export class UserCommand extends Subcommand {
 			.setColor(embedColors.PlutoBlue)
 			.setDescription(description.join('\n'))
 			.setFooter({
-				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length}`,
+				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length} | 🔥3/5/10 = streak badge`,
 			})
 	}
 
@@ -478,4 +562,7 @@ interface ParsedLeaderboardEntry {
 	score: number
 	correctPredictions: number
 	incorrectPredictions: number
+	currentStreak: number
+	bestStreak: number
+	badgeTier: StreakBadgeTier
 }

--- a/src/commands/predictions/predictions.ts
+++ b/src/commands/predictions/predictions.ts
@@ -1,0 +1,481 @@
+import type {
+	AllUserPredictionsDto,
+	SimpleLeaderboardResponseDto,
+} from '@pluto-khronos/api-client'
+import { GetAllPredictionsFilteredStatusEnum } from '@pluto-khronos/api-client'
+import { ApplyOptions } from '@sapphire/decorators'
+import { PaginatedMessageEmbedFields } from '@sapphire/discord.js-utilities'
+import { Subcommand } from '@sapphire/plugin-subcommands'
+import {
+	EmbedBuilder,
+	InteractionContextType,
+	type Message,
+	PermissionFlagsBits,
+} from 'discord.js'
+import _ from 'lodash'
+import { teamResolver } from 'resolve-team'
+import embedColors from '../../lib/colorsConfig.js'
+import { LEADERBOARD_SCORING } from '../../lib/scoring-constants.js'
+import LeaderboardWrapper from '../../utils/api/Khronos/leaderboard/leaderboard-wrapper.js'
+import PredictionApiWrapper from '../../utils/api/Khronos/prediction/predictionApiWrapper.js'
+import PropsApiWrapper from '../../utils/api/Khronos/props/props-api-wrapper.js'
+import ClientTools from '../../utils/bot_res/ClientTools.js'
+import { DateManager } from '../../utils/common/DateManager.js'
+import TeamInfo from '../../utils/common/TeamInfo.js'
+import Pagination from '../../utils/embeds/pagination.js'
+
+/**
+ * Reserved command id for the consolidated group. Legacy aliases retain their
+ * existing hints for one release and are removed with the alias pieces after
+ * the migration window.
+ */
+const PREDICTIONS_COMMAND_ID_HINTS = ['1298280482123026537']
+
+@ApplyOptions<Subcommand.Options>({
+	name: 'predictions',
+	description: 'View prediction history, stats, and leaderboard',
+	requiredClientPermissions: [
+		PermissionFlagsBits.SendMessages,
+		PermissionFlagsBits.EmbedLinks,
+	],
+	subcommands: [
+		{ name: 'history', chatInputRun: 'handleHistory' },
+		{ name: 'stats', chatInputRun: 'handleStats' },
+		{ name: 'leaderboard', chatInputRun: 'handleLeaderboard' },
+	],
+})
+export class UserCommand extends Subcommand {
+	private readonly dateManager = new DateManager()
+
+	public override registerApplicationCommands(registry: Subcommand.Registry) {
+		registry.registerChatInputCommand(
+			(builder) =>
+				builder
+					.setName(this.name)
+					.setDescription(this.description)
+					.setContexts(InteractionContextType.Guild)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('history')
+							.setDescription('View prediction history')
+							.addUserOption((option) =>
+								option
+									.setName('user')
+									.setDescription(
+										'[Optional] The user to view history for (default: yourself)',
+									)
+									.setRequired(false),
+							)
+							.addStringOption((option) =>
+								option
+									.setName('status')
+									.setDescription(
+										'Filter predictions by status',
+									)
+									.setRequired(false)
+									.addChoices(
+										{
+											name: 'Pending',
+											value: GetAllPredictionsFilteredStatusEnum.Pending,
+										},
+										{
+											name: 'Completed',
+											value: GetAllPredictionsFilteredStatusEnum.Completed,
+										},
+									),
+							),
+					)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('stats')
+							.setDescription(
+								'View server-calculated prediction statistics',
+							),
+					)
+					.addSubcommand((subcommand) =>
+						subcommand
+							.setName('leaderboard')
+							.setDescription(
+								'View the prediction accuracy leaderboard',
+							),
+					),
+			{ idHints: PREDICTIONS_COMMAND_ID_HINTS },
+		)
+	}
+
+	public async handleHistory(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ ephemeral: true })
+
+		const user = interaction.options.getUser('user') || interaction.user
+		const status = interaction.options.getString(
+			'status',
+		) as GetAllPredictionsFilteredStatusEnum | null
+
+		try {
+			const predictionApiWrapper = new PredictionApiWrapper()
+			const predictions = await (status
+				? predictionApiWrapper.getPredictionsFiltered({
+						userId: user.id,
+						status,
+					})
+				: predictionApiWrapper.getPredictionsForUser({
+						userId: user.id,
+					}))
+
+			if (!predictions || predictions.length === 0) {
+				return interaction.editReply({
+					content: 'No predictions found for the specified criteria.',
+				})
+			}
+
+			const description = status
+				? `Filtered by: \`${status}\``
+				: undefined
+			const templateEmbed = new EmbedBuilder()
+				.setTitle(`Prediction History | ${user.username}`)
+				.setColor(embedColors.PlutoBlue)
+			if (description) templateEmbed.setDescription(description)
+
+			const propsApiWrapper = new PropsApiWrapper()
+			let hadFormattingFailures = false
+			const formattedPredictions = (
+				await Promise.allSettled(
+					predictions.map((prediction) =>
+						this.createPredictionField(prediction, propsApiWrapper),
+					),
+				)
+			).flatMap((result, index) => {
+				if (result.status === 'fulfilled') {
+					return result.value ? [result.value] : []
+				}
+				hadFormattingFailures = true
+				this.container.logger.error(
+					`Failed to create prediction field for prediction ${predictions[index]?.id || 'unknown'} (user: ${user.id})`,
+					result.reason,
+				)
+				return []
+			})
+
+			if (formattedPredictions.length === 0) {
+				const message = hadFormattingFailures
+					? 'We were unable to load details for your predictions. Please try again later.'
+					: 'No prediction history found. Your predictions will appear here once you make them.'
+				templateEmbed.setDescription(
+					description ? `${description}\n\n${message}` : message,
+				)
+				return interaction.editReply({ embeds: [templateEmbed] })
+			}
+
+			const paginatedMessage = new PaginatedMessageEmbedFields({
+				template: { embeds: [templateEmbed] },
+			})
+				.setItems(formattedPredictions)
+				.setItemsPerPage(10)
+				.make()
+
+			return paginatedMessage.run(interaction)
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content:
+					'An error occurred while fetching the prediction history.',
+			})
+		}
+	}
+
+	public async handleStats(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply({ ephemeral: true })
+
+		const guildId = interaction.guildId
+		if (!guildId) {
+			return interaction.editReply({
+				content: 'This command can only be used in a guild.',
+			})
+		}
+
+		try {
+			const [leaderboard, allPending] = await Promise.all([
+				new LeaderboardWrapper().getLeaderboard({ guildId }),
+				new PredictionApiWrapper().getActivePredictionsForUser({
+					userId: interaction.user.id,
+				}),
+			])
+			const pending = allPending.filter(
+				(prediction) => prediction.guild_id === guildId,
+			)
+
+			const entry = leaderboard.entries.find(
+				(candidate) => candidate.user_id === interaction.user.id,
+			)
+			if (!entry && pending.length === 0) {
+				return interaction.editReply({
+					content: "You haven't made any predictions yet.",
+				})
+			}
+
+			const totalPredictions = entry?.total_predictions ?? 0
+			const correctPredictions = entry?.correct_predictions ?? 0
+			const incorrectPredictions = entry?.incorrect_predictions ?? 0
+			const winRate = entry?.success_rate ?? 0
+			const embed = new EmbedBuilder()
+				.setTitle('📊 Prediction Statistics')
+				.setColor(embedColors.PlutoBlue)
+				.setDescription(`Server stats for ${interaction.user.username}`)
+				.addFields(
+					{
+						name: 'Total Predictions',
+						value: `\`${totalPredictions}\``,
+						inline: true,
+					},
+					{
+						name: 'Win Rate',
+						value: `\`${winRate.toFixed(1)}%\``,
+						inline: true,
+					},
+					{ name: '\u200B', value: '\u200B', inline: true },
+					{
+						name: '✅ Correct',
+						value: `\`${correctPredictions}\``,
+						inline: true,
+					},
+					{
+						name: '❌ Incorrect',
+						value: `\`${incorrectPredictions}\``,
+						inline: true,
+					},
+					{
+						name: '⏳ Pending',
+						value: `\`${pending.length}\``,
+						inline: true,
+					},
+				)
+				.setFooter({
+					text: 'Streaks will appear here after the engagement rollout.',
+				})
+				.setTimestamp()
+
+			return interaction.editReply({ embeds: [embed] })
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content: 'An error occurred while fetching your statistics.',
+			})
+		}
+	}
+
+	public async handleLeaderboard(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply()
+		const guildId = interaction.guildId
+		if (!guildId) {
+			return interaction.editReply({
+				content: 'This command can only be used in a guild.',
+			})
+		}
+
+		try {
+			const leaderboard = await new LeaderboardWrapper().getLeaderboard({
+				guildId,
+			})
+			if (!leaderboard.entries.length) {
+				return interaction.editReply({
+					content: 'No leaderboard data found.',
+				})
+			}
+
+			const parsed = this.parseLeaderboardData(leaderboard)
+			const totalPages = Math.ceil(parsed.length / 20)
+			const embed = await this.createLeaderboardEmbed(parsed, 1)
+			const pagination = new Pagination()
+			const reply = await interaction.editReply({
+				content: null,
+				embeds: [embed],
+				components: pagination.createPaginationButtons(1, totalPages),
+			})
+
+			await this.handlePagination(interaction, reply, parsed)
+		} catch (error) {
+			this.container.logger.error(error)
+			return interaction.editReply({
+				content: 'An error occurred while fetching the leaderboard.',
+			})
+		}
+	}
+
+	private async createPredictionField(
+		prediction: AllUserPredictionsDto,
+		propsApiWrapper: PropsApiWrapper,
+	): Promise<{ name: string; value: string; inline: boolean } | null> {
+		const prop = await propsApiWrapper.getPropByUuid(
+			prediction.outcome_uuid,
+		)
+		const outcome = prop.outcomes.find(
+			(candidate) => candidate.outcome_uuid === prediction.outcome_uuid,
+		)
+		if (!outcome) return null
+
+		const parsedMatch = await this.parseMatchString(prediction.match_string)
+		const point = outcome.point ?? null
+		const choice =
+			prediction.choice.charAt(0).toUpperCase() +
+			prediction.choice.slice(1).toLowerCase()
+		const status =
+			prediction.status !== GetAllPredictionsFilteredStatusEnum.Completed
+				? 'Pending ⏳'
+				: prediction.is_correct === true
+					? 'Correct ✅'
+					: prediction.is_correct === false
+						? 'Incorrect ❌'
+						: 'Pending ⏳'
+		const market = _.startCase(prop.market_key.replace('player_', ''))
+		const date = this.dateManager.toMMDDYYYY(
+			prop.event_context.commence_time,
+		)
+		const value = [
+			`**Date**: ${date}`,
+			`**Status**: ${status}`,
+			`**Choice**: \`${choice}${point === null ? '' : ` ${point}`}\``,
+			`**Market**: ${market}`,
+			prediction.description?.trim()
+				? `**Player:** ${prediction.description}`
+				: null,
+		]
+			.filter((line): line is string => Boolean(line))
+			.join('\n')
+
+		return { name: parsedMatch, value, inline: false }
+	}
+
+	private async parseMatchString(matchString: string) {
+		const [awayTeam, homeTeam] = matchString.split(' vs. ')
+		if (!awayTeam || !homeTeam) return matchString
+		const result = await TeamInfo.resolveTeamIdentifier({
+			away_team: awayTeam,
+			home_team: homeTeam,
+		})
+		return `${result.away_team} vs. ${result.home_team}`
+	}
+
+	private parseLeaderboardData(
+		leaderboard: SimpleLeaderboardResponseDto,
+	): ParsedLeaderboardEntry[] {
+		return leaderboard.entries.map((entry, index) => ({
+			userId: entry.user_id,
+			position: index + 1,
+			score:
+				entry.correct_predictions * LEADERBOARD_SCORING.CORRECT_POINTS +
+				entry.incorrect_predictions *
+					LEADERBOARD_SCORING.INCORRECT_PENALTY,
+			correctPredictions: entry.correct_predictions,
+			incorrectPredictions: entry.incorrect_predictions,
+		}))
+	}
+
+	private async createLeaderboardEmbed(
+		leaderboard: ParsedLeaderboardEntry[],
+		currentPage: number,
+	): Promise<EmbedBuilder> {
+		const startIndex = (currentPage - 1) * 20
+		const pageEntries = leaderboard.slice(startIndex, startIndex + 20)
+		const totalPages = Math.ceil(leaderboard.length / 20)
+		const description = await Promise.all(
+			pageEntries.map(async (entry) => {
+				const member = await this.getMember(entry.userId)
+				const username = member?.username ?? entry.userId
+				const total =
+					entry.correctPredictions + entry.incorrectPredictions
+				return `${entry.position}. ${username} - **\`${entry.score}\`** *(${entry.correctPredictions}/${total})*`
+			}),
+		)
+
+		return new EmbedBuilder()
+			.setTitle('Prediction Accuracy Leaderboard')
+			.setColor(embedColors.PlutoBlue)
+			.setDescription(description.join('\n'))
+			.setFooter({
+				text: `Page ${currentPage} of ${totalPages} | Total Entries: ${leaderboard.length}`,
+			})
+	}
+
+	private async getMember(userId: string) {
+		try {
+			return await new ClientTools(this.container).resolveMember(userId)
+		} catch (error) {
+			this.container.logger.error(
+				`Failed to resolve member ${userId}:`,
+				error,
+			)
+			return null
+		}
+	}
+
+	private async handlePagination(
+		interaction: Subcommand.ChatInputCommandInteraction,
+		reply: Message,
+		leaderboard: ParsedLeaderboardEntry[],
+	) {
+		const totalPages = Math.ceil(leaderboard.length / 20)
+		let currentPage = 1
+		const collector = reply.createMessageComponentCollector({ time: 60000 })
+
+		collector.on('collect', async (buttonInteraction) => {
+			if (buttonInteraction.user.id !== interaction.user.id) {
+				await buttonInteraction.followUp({
+					content:
+						'Only the original user can interact with these buttons.',
+					ephemeral: true,
+				})
+				return
+			}
+			switch (buttonInteraction.customId) {
+				case 'first':
+					currentPage = 1
+					break
+				case 'previous':
+					currentPage = Math.max(1, currentPage - 1)
+					break
+				case 'next':
+					currentPage = Math.min(totalPages, currentPage + 1)
+					break
+				case 'last':
+					currentPage = totalPages
+					break
+			}
+			const embed = await this.createLeaderboardEmbed(
+				leaderboard,
+				currentPage,
+			)
+			await buttonInteraction.update({
+				embeds: [embed],
+				components: new Pagination().createPaginationButtons(
+					currentPage,
+					totalPages,
+				),
+			})
+		})
+
+		collector.on('end', async () => {
+			const disabled = new Pagination()
+				.createPaginationButtons(currentPage, totalPages)
+				.map((row) => {
+					for (const button of row.components)
+						button.setDisabled(true)
+					return row
+				})
+			await reply.edit({ components: disabled })
+		})
+	}
+}
+
+interface ParsedLeaderboardEntry {
+	position: number
+	userId: string
+	score: number
+	correctPredictions: number
+	incorrectPredictions: number
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@sapphire/framework'
 import '@sapphire/plugin-hmr/register'
 import { GatewayIntentBits, Partials } from 'discord.js'
-import env from './lib/startup/env.js'
+import { startPluto } from './lib/startup/pluto.js'
 import { logger } from './utils/logging/WinstonLogger.js'
 
 const SapDiscClient = new SapphireClient({
@@ -39,37 +39,6 @@ logger.info({
 	message: 'Pluto is starting up',
 })
 
-const initializeStartupServices = async () => {
-	if (env.USE_MOCK_DATA) {
-		logger.info({
-			message:
-				'Mock data mode enabled; skipping Redis-backed startup services',
-			source: 'startup:mock-data',
-		})
-		return
-	}
-
-	await import('./lib/startup/cache.js')
-	await import('./utils/api/Khronos/KhronosInstances.js')
-	await import('./utils/api/koa/index.js')
-	await import('./utils/cache/queue/ChannelCreationQueue.js')
-	await import('./utils/cron/index.js')
-}
-
-const login = async () => {
-	try {
-		await initializeStartupServices()
-		await SapDiscClient.login(process.env.TOKEN)
-		logger.info('Pluto is up and running!')
-	} catch (error) {
-		logger.error({
-			message: 'Failed to login',
-		})
-		SapDiscClient.logger.fatal(error)
-		SapDiscClient.destroy()
-		process.exit(1)
-	}
-}
-login()
+void startPluto({ client: SapDiscClient })
 
 export { SapDiscClient }

--- a/src/interaction-handlers/__tests__/parlay-button-handler.test.ts
+++ b/src/interaction-handlers/__tests__/parlay-button-handler.test.ts
@@ -1,0 +1,438 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { builderService, matchCache, parlayAnnouncement, parlayApi } =
+	vi.hoisted(() => ({
+		builderService: {
+			assertCurrent: vi.fn(),
+			clear: vi.fn(),
+			clearWithPlacementToken: vi.fn(),
+			removeLeg: vi.fn(),
+			reserveForPlacement: vi.fn(),
+			refreshPlacement: vi.fn(),
+			setPlacementState: vi.fn(),
+			validateForPlacement: vi.fn(),
+			releasePlacement: vi.fn(),
+			render: vi.fn(),
+			renderMessage: vi.fn(),
+		},
+		parlayApi: {
+			init: vi.fn(),
+			place: vi.fn(),
+			findByPlacement: vi.fn(),
+		},
+		parlayAnnouncement: { announceParlayPlaced: vi.fn() },
+		matchCache: { getMatches: vi.fn(), getMatch: vi.fn() },
+	}))
+
+vi.mock('../../utils/logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	InteractionHandler: class {
+		public none() {
+			return { kind: 'none' }
+		}
+		public some(value: unknown) {
+			return { kind: 'some', value }
+		}
+	},
+	InteractionHandlerTypes: { Button: 'button' },
+}))
+
+vi.mock('../../services/ParlayBuilderService.js', async (importOriginal) => {
+	const original =
+		await importOriginal<
+			typeof import('../../services/ParlayBuilderService.js')
+		>()
+	return {
+		...original,
+		ParlayBuilderService: class {
+			constructor() {
+				return builderService
+			}
+		},
+		logParlayBuilderError: vi.fn(),
+	}
+})
+
+vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
+	default: class {
+		constructor() {
+			return matchCache
+		}
+	},
+}))
+vi.mock('../../utils/api/Khronos/parlays/ParlayApiWrapper.js', () => ({
+	default: class {
+		constructor() {
+			return parlayApi
+		}
+	},
+}))
+vi.mock('../../utils/api/common/bets/BetsCacheService.js', () => ({
+	BetsCacheService: class {},
+}))
+vi.mock('../../utils/api/Khronos/bets/BetslipsManager.js', () => ({
+	BetslipManager: class {
+		constructor() {
+			return parlayAnnouncement
+		}
+	},
+}))
+vi.mock('../../utils/api/Khronos/bets/betslip-wrapper.js', () => ({
+	default: class {},
+}))
+vi.mock('../../utils/cache/cache-manager.js', () => ({
+	CacheManager: class {},
+}))
+
+const { STALE_PARLAY_BUILDER_MESSAGE } = await import(
+	'../../services/ParlayBuilderService.js'
+)
+const { ParlayButtonHandler } = await import('../parlay-button-handler.js')
+
+describe('ParlayButtonHandler', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		const session = {
+			sessionId: 'sessionA0001',
+			revision: 2,
+			legs: [
+				{ event_id: 'event-1', outcome_uuid: 'outcome-1' },
+				{ event_id: 'event-2', outcome_uuid: 'outcome-2' },
+			],
+			stake: 10,
+			placementId: '00000000-0000-4000-8000-000000000001',
+			placementPhase: 'editing',
+			lastPlacementResponse: null,
+		}
+		builderService.assertCurrent.mockResolvedValue(session)
+		builderService.reserveForPlacement.mockResolvedValue({
+			session: { ...session, placementPhase: 'placing' },
+			token: 'placement-token',
+		})
+		builderService.refreshPlacement.mockResolvedValue(true)
+		builderService.setPlacementState.mockImplementation(
+			async (
+				_userId,
+				_guildId,
+				_expected,
+				placementPhase,
+				response = null,
+			) => ({
+				...session,
+				placementPhase,
+				lastPlacementResponse: response,
+			}),
+		)
+		builderService.clear.mockResolvedValue(undefined)
+		builderService.clearWithPlacementToken.mockResolvedValue(undefined)
+		builderService.releasePlacement.mockResolvedValue(undefined)
+		builderService.validateForPlacement.mockReturnValue(undefined)
+		builderService.renderMessage.mockReturnValue({ components: [] })
+		parlayAnnouncement.announceParlayPlaced.mockResolvedValue(undefined)
+		matchCache.getMatches.mockResolvedValue([
+			{
+				id: 'event-1',
+				home_team: 'Home',
+				away_team: 'Away',
+				commence_time: '2099-01-01T00:00:00.000Z',
+			},
+		])
+	})
+
+	it('rejects a stale add control ephemerally without opening a modal', async () => {
+		builderService.assertCurrent.mockRejectedValueOnce(
+			new Error(STALE_PARLAY_BUILDER_MESSAGE),
+		)
+		const interaction = {
+			customId: 'parlay.btn.sessionA0001.2.add',
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			showModal: vi.fn(),
+			reply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.parse(interaction as never)
+
+		expect(builderService.assertCurrent).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 2 },
+		)
+		expect(interaction.showModal).not.toHaveBeenCalled()
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: STALE_PARLAY_BUILDER_MESSAGE,
+			flags: 64,
+		})
+	})
+
+	it('expires legacy buttons instead of binding them to the active builder', async () => {
+		const interaction = {
+			customId: 'parlay_btn_remove:0',
+			reply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.parse(interaction as never)
+
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: STALE_PARLAY_BUILDER_MESSAGE,
+			flags: 64,
+		})
+		expect(builderService.removeLeg).not.toHaveBeenCalled()
+	})
+
+	it('carries the builder identity into the add modal', async () => {
+		builderService.assertCurrent.mockResolvedValueOnce({})
+		const interaction = {
+			customId: 'parlay.btn.sessionA0001.2.add',
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			showModal: vi.fn(),
+			reply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.parse(interaction as never)
+
+		const modal = interaction.showModal.mock.calls[0]?.[0]
+		expect(modal.toJSON().custom_id).toBe(
+			'parlay.modal.sessionA0001.2.add-leg',
+		)
+	})
+
+	it('passes the rendered identity to remove mutations', async () => {
+		builderService.removeLeg.mockResolvedValueOnce({})
+		builderService.render.mockReturnValueOnce({ components: [] })
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'remove',
+			index: 0,
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(builderService.removeLeg).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 2 },
+			0,
+		)
+	})
+
+	it('rejects a stale cancel identity before it clears the builder', async () => {
+		builderService.assertCurrent.mockRejectedValueOnce(
+			new Error(STALE_PARLAY_BUILDER_MESSAGE),
+		)
+		builderService.renderMessage.mockReturnValueOnce({ components: [] })
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'cancel',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(builderService.clear).not.toHaveBeenCalled()
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			components: [],
+			flags: 32768,
+		})
+	})
+
+	it('rejects a stale confirm identity before it reserves placement', async () => {
+		builderService.assertCurrent.mockRejectedValueOnce(
+			new Error(STALE_PARLAY_BUILDER_MESSAGE),
+		)
+		builderService.renderMessage.mockReturnValueOnce({ components: [] })
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'confirm',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(builderService.reserveForPlacement).not.toHaveBeenCalled()
+		expect(builderService.releasePlacement).not.toHaveBeenCalled()
+	})
+
+	it('reconciles a timeout after Khronos committed and renders one placement', async () => {
+		parlayApi.init.mockResolvedValueOnce({ init_token: 'init-token' })
+		parlayApi.place.mockRejectedValueOnce(new Error('socket timeout'))
+		parlayApi.findByPlacement.mockResolvedValueOnce({
+			id: 'parlay-1',
+			leg_count: 2,
+			stake: 10,
+			potential_payout: 40,
+			combined_odds_american: 300,
+		})
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'confirm',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(parlayApi.place).toHaveBeenCalledWith(
+			'init-token',
+			'00000000-0000-4000-8000-000000000001',
+		)
+		expect(parlayApi.findByPlacement).toHaveBeenCalledWith(
+			'00000000-0000-4000-8000-000000000001',
+		)
+		expect(builderService.setPlacementState).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 2 },
+			'unknown',
+		)
+		expect(interaction.editReply).toHaveBeenCalledWith({ components: [] })
+	})
+
+	it('renders placement success even when lease cleanup fails after a response', async () => {
+		parlayApi.init.mockResolvedValueOnce({ init_token: 'init-token' })
+		parlayApi.place.mockResolvedValueOnce({
+			id: 'parlay-1',
+			leg_count: 2,
+			stake: 10,
+			potential_payout: 40,
+			combined_odds_american: 300,
+		})
+		builderService.clearWithPlacementToken.mockRejectedValueOnce(
+			new Error('lost lease'),
+		)
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'confirm',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(interaction.editReply).toHaveBeenCalledWith({ components: [] })
+		expect(builderService.releasePlacement).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			'placement-token',
+		)
+	})
+
+	it('prevents a second replica from placing while the first holds the reservation', async () => {
+		parlayApi.init.mockResolvedValue({ init_token: 'init-token' })
+		parlayApi.place.mockResolvedValue({
+			id: 'parlay-1',
+			leg_count: 2,
+			stake: 10,
+			potential_payout: 40,
+			combined_odds_american: 300,
+		})
+		builderService.reserveForPlacement
+			.mockResolvedValueOnce({
+				session: {
+					sessionId: 'sessionA0001',
+					revision: 2,
+					legs: [
+						{ event_id: 'event-1', outcome_uuid: 'outcome-1' },
+						{ event_id: 'event-2', outcome_uuid: 'outcome-2' },
+					],
+					stake: 10,
+					placementId: '00000000-0000-4000-8000-000000000001',
+					placementPhase: 'placing',
+					lastPlacementResponse: null,
+				},
+				token: 'placement-token',
+			})
+			.mockResolvedValueOnce(null)
+		const first = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const second = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+		const payload = {
+			action: 'confirm' as const,
+			sessionId: 'sessionA0001',
+			revision: 2,
+		}
+
+		await Promise.all([
+			handler.run(first as never, payload),
+			handler.run(second as never, payload),
+		])
+
+		expect(parlayApi.place).toHaveBeenCalledTimes(1)
+	})
+
+	it('reconciles an unknown placement before cancellation clears the builder', async () => {
+		builderService.assertCurrent.mockResolvedValueOnce({
+			sessionId: 'sessionA0001',
+			revision: 2,
+			placementId: '00000000-0000-4000-8000-000000000001',
+			placementPhase: 'unknown',
+			lastPlacementResponse: null,
+		})
+		parlayApi.findByPlacement.mockResolvedValueOnce(null)
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayButtonHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			action: 'cancel',
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+
+		expect(parlayApi.findByPlacement).toHaveBeenCalledWith(
+			'00000000-0000-4000-8000-000000000001',
+		)
+		expect(builderService.setPlacementState).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 2 },
+			'editing',
+		)
+		expect(builderService.clear).toHaveBeenCalledWith('user-1', 'guild-1', {
+			sessionId: 'sessionA0001',
+			revision: 2,
+		})
+	})
+})

--- a/src/interaction-handlers/__tests__/parlay-modal-handler.test.ts
+++ b/src/interaction-handlers/__tests__/parlay-modal-handler.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { builderService } = vi.hoisted(() => ({
+	builderService: {
+		render: vi.fn(),
+		renderMessage: vi.fn(),
+		setStake: vi.fn(),
+		addLeg: vi.fn(),
+	},
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	InteractionHandler: class {
+		public none() {
+			return { kind: 'none' }
+		}
+		public some(value: unknown) {
+			return { kind: 'some', value }
+		}
+	},
+	InteractionHandlerTypes: { ModalSubmit: 'modal-submit' },
+}))
+
+vi.mock('../../services/ParlayBuilderService.js', () => ({
+	ParlayBuilderService: class {
+		constructor() {
+			return builderService
+		}
+	},
+	getParlayErrorMessage: (error: unknown) =>
+		error instanceof Error ? error.message : 'Unable to process parlay.',
+	logParlayBuilderError: vi.fn(),
+}))
+
+vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
+	default: vi.fn(),
+}))
+
+vi.mock('../../utils/cache/cache-manager.js', () => ({
+	CacheManager: vi.fn(),
+}))
+
+const { ParlayModalHandler } = await import('../parlay-modal-handler.js')
+
+describe('ParlayModalHandler', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('reports modal validation errors ephemerally without overwriting the builder', async () => {
+		const message = { edit: vi.fn() }
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			fields: { getTextInputValue: vi.fn(() => 'not-a-number') },
+			isFromMessage: vi.fn(() => true),
+			message,
+			replied: false,
+			deferred: false,
+			reply: vi.fn(),
+			deferReply: vi.fn(),
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, { kind: 'stake' })
+
+		expect(message.edit).not.toHaveBeenCalled()
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: 'Stake must be a whole number. Try again.',
+			flags: 64,
+		})
+	})
+})

--- a/src/interaction-handlers/__tests__/parlay-modal-handler.test.ts
+++ b/src/interaction-handlers/__tests__/parlay-modal-handler.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { builderService } = vi.hoisted(() => ({
+const { builderService, matchCache } = vi.hoisted(() => ({
 	builderService: {
 		render: vi.fn(),
 		renderMessage: vi.fn(),
 		setStake: vi.fn(),
 		addLeg: vi.fn(),
 	},
+	matchCache: { getMatch: vi.fn() },
+}))
+
+vi.mock('../../utils/logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }))
 
 vi.mock('@sapphire/framework', () => ({
@@ -21,19 +26,32 @@ vi.mock('@sapphire/framework', () => ({
 	InteractionHandlerTypes: { ModalSubmit: 'modal-submit' },
 }))
 
-vi.mock('../../services/ParlayBuilderService.js', () => ({
-	ParlayBuilderService: class {
-		constructor() {
-			return builderService
-		}
-	},
-	getParlayErrorMessage: (error: unknown) =>
-		error instanceof Error ? error.message : 'Unable to process parlay.',
-	logParlayBuilderError: vi.fn(),
-}))
+vi.mock('../../services/ParlayBuilderService.js', async (importOriginal) => {
+	const original =
+		await importOriginal<
+			typeof import('../../services/ParlayBuilderService.js')
+		>()
+	return {
+		...original,
+		ParlayBuilderService: class {
+			constructor() {
+				return builderService
+			}
+		},
+		logParlayBuilderError: vi.fn(),
+	}
+})
 
 vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
-	default: vi.fn(),
+	default: class {
+		constructor() {
+			return matchCache
+		}
+	},
+}))
+
+vi.mock('../../utils/api/Khronos/parlays/ParlayApiWrapper.js', () => ({
+	default: class {},
 }))
 
 vi.mock('../../utils/cache/cache-manager.js', () => ({
@@ -41,9 +59,167 @@ vi.mock('../../utils/cache/cache-manager.js', () => ({
 }))
 
 const { ParlayModalHandler } = await import('../parlay-modal-handler.js')
+const { STALE_PARLAY_BUILDER_MESSAGE } = await import(
+	'../../services/ParlayBuilderService.js'
+)
 
 describe('ParlayModalHandler', () => {
 	beforeEach(() => vi.clearAllMocks())
+
+	it('parses the builder identity from a versioned modal', () => {
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		expect(
+			handler.parse({
+				customId: 'parlay.modal.sessionA0001.4.stake',
+			} as never),
+		).toEqual({
+			kind: 'some',
+			value: {
+				kind: 'stake',
+				sessionId: 'sessionA0001',
+				revision: 4,
+			},
+		})
+	})
+
+	it('rejects a legacy modal as stale', async () => {
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			reply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, { kind: 'legacy' })
+
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: STALE_PARLAY_BUILDER_MESSAGE,
+			flags: 64,
+		})
+		expect(builderService.setStake).not.toHaveBeenCalled()
+		expect(builderService.addLeg).not.toHaveBeenCalled()
+	})
+
+	it('passes the modal identity to the stake mutation', async () => {
+		const session = {
+			sessionId: 'sessionA0001',
+			revision: 5,
+			legs: [],
+			stake: 25,
+		}
+		builderService.setStake.mockResolvedValueOnce(session)
+		builderService.render.mockReturnValueOnce({ components: [] })
+		const message = { edit: vi.fn() }
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			fields: { getTextInputValue: vi.fn(() => '25') },
+			isFromMessage: vi.fn(() => true),
+			message,
+			replied: false,
+			deferred: false,
+			reply: vi.fn(),
+			deferReply: vi.fn(),
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			kind: 'stake',
+			sessionId: 'sessionA0001',
+			revision: 4,
+		})
+
+		expect(builderService.setStake).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 4 },
+			25,
+		)
+		expect(message.edit).toHaveBeenCalledWith({ components: [] })
+	})
+
+	it('reports a stale versioned modal without editing the builder message', async () => {
+		builderService.setStake.mockRejectedValueOnce(
+			new Error(STALE_PARLAY_BUILDER_MESSAGE),
+		)
+		const message = { edit: vi.fn() }
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			fields: { getTextInputValue: vi.fn(() => '25') },
+			isFromMessage: vi.fn(() => true),
+			message,
+			replied: false,
+			deferred: false,
+			reply: vi.fn(),
+			deferReply: vi.fn(),
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			kind: 'stake',
+			sessionId: 'sessionA0001',
+			revision: 4,
+		})
+
+		expect(message.edit).not.toHaveBeenCalled()
+		expect(interaction.reply).toHaveBeenCalledWith({
+			content: STALE_PARLAY_BUILDER_MESSAGE,
+			flags: 64,
+		})
+	})
+
+	it('passes the modal identity to the add-leg mutation', async () => {
+		const session = {
+			sessionId: 'sessionA0001',
+			revision: 5,
+			legs: [],
+			stake: null,
+		}
+		matchCache.getMatch.mockResolvedValueOnce({ id: 'event-1' })
+		builderService.addLeg.mockResolvedValueOnce(session)
+		builderService.render.mockReturnValueOnce({ components: [] })
+		const message = { edit: vi.fn() }
+		const values = {
+			parlay_game: ['event-1'],
+			parlay_market: ['totals'],
+			parlay_side: ['over'],
+		}
+		const interaction = {
+			user: { id: 'user-1' },
+			guildId: 'guild-1',
+			fields: {
+				getStringSelectValues: vi.fn(
+					(id: keyof typeof values) => values[id],
+				),
+			},
+			isFromMessage: vi.fn(() => true),
+			message,
+			replied: false,
+			deferred: false,
+			reply: vi.fn(),
+			deferReply: vi.fn(),
+			editReply: vi.fn(),
+		}
+		const handler = new ParlayModalHandler({} as never, {} as never)
+
+		await handler.run(interaction as never, {
+			kind: 'add-leg',
+			sessionId: 'sessionA0001',
+			revision: 4,
+		})
+
+		expect(builderService.addLeg).toHaveBeenCalledWith(
+			'user-1',
+			'guild-1',
+			{ sessionId: 'sessionA0001', revision: 4 },
+			{ matchId: 'event-1', marketKey: 'totals', side: 'over' },
+		)
+		expect(message.edit).toHaveBeenCalledWith({ components: [] })
+	})
 
 	it('reports modal validation errors ephemerally without overwriting the builder', async () => {
 		const message = { edit: vi.fn() }
@@ -61,7 +237,11 @@ describe('ParlayModalHandler', () => {
 		}
 		const handler = new ParlayModalHandler({} as never, {} as never)
 
-		await handler.run(interaction as never, { kind: 'stake' })
+		await handler.run(interaction as never, {
+			kind: 'stake',
+			sessionId: 'sessionA0001',
+			revision: 4,
+		})
 
 		expect(message.edit).not.toHaveBeenCalled()
 		expect(interaction.reply).toHaveBeenCalledWith({

--- a/src/interaction-handlers/my-bets-pagination-handler.ts
+++ b/src/interaction-handlers/my-bets-pagination-handler.ts
@@ -103,6 +103,7 @@ export class MyBetsPaginationHandler extends InteractionHandler {
 			const historyPage = this.paginationService.getHistoryPage(
 				betsData.historyBets,
 				targetPage,
+				betsData.historyParlays,
 			)
 			const groupedBets = this.paginationService.groupBetsByDate(
 				historyPage.bets,
@@ -111,6 +112,8 @@ export class MyBetsPaginationHandler extends InteractionHandler {
 			const displayData: MyBetsDisplayData = {
 				userId,
 				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
 				historyPage,
 				groupedBets,
 			}

--- a/src/interaction-handlers/my-bets-pagination-handler.ts
+++ b/src/interaction-handlers/my-bets-pagination-handler.ts
@@ -116,6 +116,7 @@ export class MyBetsPaginationHandler extends InteractionHandler {
 				historyParlays: betsData.historyParlays,
 				historyPage,
 				groupedBets,
+				parlayFetchWarning: betsData.parlayFetchWarning,
 			}
 
 			const response = await this.formatterService.buildEmbedResponse(

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -91,9 +91,13 @@ export class ParlayButtonHandler extends InteractionHandler {
 			| { action: 'confirm' },
 	) {
 		const userId = interaction.user.id
+		const guildId = interaction.guildId
 		try {
+			if (!guildId) {
+				throw new Error('Parlays can only be built inside a server.')
+			}
 			if (payload.action === 'cancel') {
-				await this.builderService.clear(userId)
+				await this.builderService.clear(userId, guildId)
 				return interaction.editReply(
 					this.builderService.renderMessage(
 						'Parlay builder cancelled.',
@@ -103,44 +107,98 @@ export class ParlayButtonHandler extends InteractionHandler {
 			if (payload.action === 'remove') {
 				const session = await this.builderService.removeLeg(
 					userId,
+					guildId,
 					payload.index,
 				)
 				return interaction.editReply(
 					this.builderService.render(session),
 				)
 			}
-			const session = await this.builderService.get(userId)
-			if (!session)
-				throw new Error(
-					'Your parlay builder expired. Run `/parlay` to start again.',
-				)
-			this.builderService.validateForPlacement(session)
-			const initialized = await this.parlayApi.init({
-				legs: session.legs.map(({ event_id, outcome_uuid }) => ({
-					event_id,
-					outcome_uuid,
-				})),
-				stake: session.stake!,
-				guild_id: interaction.guildId!,
-				user_id: userId,
-			})
-			const placed = await this.parlayApi.place(initialized.init_token)
-			await new BetslipManager(
-				new BetslipWrapper(),
-				new BetsCacheService(new CacheManager()),
-			).announceParlayPlaced(interaction, {
-				parlayId: placed.id,
-				legCount: placed.leg_count,
-				stake: Number(placed.stake),
-				potentialPayout: Number(placed.potential_payout),
-			})
-			await this.builderService.clear(userId)
-			return interaction.editReply(
-				this.builderService.renderMessage(
-					`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
-					0x57f287,
-				),
+			const reservation = await this.builderService.reserveForPlacement(
+				userId,
+				guildId,
 			)
+			if (!reservation) {
+				throw new Error(
+					'Your parlay is already being placed. Please wait for the result.',
+				)
+			}
+			const { session, token } = reservation
+			let leaseLost = false
+			const assertPlacementLease = async () => {
+				if (leaseLost) {
+					throw new Error(
+						'Parlay placement lost its reservation. Please try again.',
+					)
+				}
+				const refreshed = await this.builderService.refreshPlacement(
+					userId,
+					guildId,
+					token,
+				)
+				if (!refreshed) {
+					leaseLost = true
+					throw new Error(
+						'Parlay placement lost its reservation. Please try again.',
+					)
+				}
+			}
+			const leaseHeartbeat = setInterval(() => {
+				void assertPlacementLease().catch((error) =>
+					logParlayBuilderError(error, {
+						action: 'refresh_placement_reservation',
+						userId,
+					}),
+				)
+			}, 30_000)
+			leaseHeartbeat.unref?.()
+			try {
+				await assertPlacementLease()
+				this.builderService.validateForPlacement(session)
+				const initialized = await this.parlayApi.init({
+					legs: session.legs.map(({ event_id, outcome_uuid }) => ({
+						event_id,
+						outcome_uuid,
+					})),
+					stake: session.stake!,
+					guild_id: guildId,
+					user_id: userId,
+				})
+				await assertPlacementLease()
+				const placed = await this.parlayApi.place(
+					initialized.init_token,
+				)
+				await assertPlacementLease()
+				await new BetslipManager(
+					new BetslipWrapper(),
+					new BetsCacheService(new CacheManager()),
+				).announceParlayPlaced(interaction, {
+					parlayId: placed.id,
+					legCount: placed.leg_count,
+					stake: Number(placed.stake),
+					potentialPayout: Number(placed.potential_payout),
+				})
+				await this.builderService.clearWithPlacementToken(
+					userId,
+					guildId,
+					token,
+				)
+				return interaction.editReply(
+					this.builderService.renderMessage(
+						`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
+						0x57f287,
+					),
+				)
+			} catch (error) {
+				throw error
+			} finally {
+				clearInterval(leaseHeartbeat)
+				await this.builderService.releasePlacement(
+					userId,
+					guildId,
+					token,
+				)
+			}
 		} catch (error) {
 			logParlayBuilderError(error, { action: payload.action, userId })
 			const message = getParlayErrorMessage(error)

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -12,18 +12,22 @@ import {
 	TextInputStyle,
 } from 'discord.js'
 import {
+	buildParlayModalId,
 	getParlayErrorMessage,
 	logParlayBuilderError,
+	type ParlayBuilderIdentity,
 	ParlayBuilderService,
+	parseParlayButtonId,
+	STALE_PARLAY_BUILDER_MESSAGE,
 } from '../services/ParlayBuilderService.js'
 import { BetsCacheService } from '../utils/api/common/bets/BetsCacheService.js'
 import { BetslipManager } from '../utils/api/Khronos/bets/BetslipsManager.js'
 import BetslipWrapper from '../utils/api/Khronos/bets/betslip-wrapper.js'
-import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+import ParlayApiWrapper, {
+	type ParlayResponse,
+} from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
 import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
 import { CacheManager } from '../utils/cache/cache-manager.js'
-
-const removeId = /^parlay_btn_remove_(\d+)$/
 
 export class ParlayButtonHandler extends InteractionHandler {
 	private readonly builderService = new ParlayBuilderService()
@@ -41,44 +45,64 @@ export class ParlayButtonHandler extends InteractionHandler {
 	}
 
 	public override async parse(interaction: ButtonInteraction) {
-		if (!interaction.customId.startsWith('parlay_btn_')) return this.none()
-		if (interaction.customId === 'parlay_btn_add') {
-			try {
-				await interaction.showModal(await this.buildAddLegModal())
-			} catch (error) {
-				logParlayBuilderError(error, {
-					action: 'open_add_leg_modal',
-					userId: interaction.user.id,
-				})
+		const control = parseParlayButtonId(interaction.customId)
+		if (!control) {
+			if (interaction.customId.startsWith('parlay_btn_')) {
 				await interaction.reply({
-					content:
-						error instanceof Error
-							? error.message
-							: 'No upcoming games are available right now.',
-					ephemeral: true,
+					content: STALE_PARLAY_BUILDER_MESSAGE,
+					flags: MessageFlags.Ephemeral,
 				})
 			}
 			return this.none()
 		}
-		if (interaction.customId === 'parlay_btn_stake') {
-			await interaction.showModal(this.buildStakeModal())
+		const identity = {
+			sessionId: control.sessionId,
+			revision: control.revision,
+		}
+		if (control.action === 'add' || control.action === 'stake') {
+			try {
+				if (!interaction.guildId) {
+					throw new Error(
+						'Parlays can only be built inside a server.',
+					)
+				}
+				await this.builderService.assertCurrent(
+					interaction.user.id,
+					interaction.guildId,
+					identity,
+				)
+				await interaction.showModal(
+					control.action === 'add'
+						? await this.buildAddLegModal(identity)
+						: this.buildStakeModal(identity),
+				)
+			} catch (error) {
+				logParlayBuilderError(error, {
+					action: `open_${control.action}_modal`,
+					userId: interaction.user.id,
+				})
+				await interaction.reply({
+					content: getParlayErrorMessage(error),
+					flags: MessageFlags.Ephemeral,
+				})
+			}
 			return this.none()
 		}
-		const removeMatch = removeId.exec(interaction.customId)
-		if (removeMatch) {
+		if (control.action === 'remove') {
 			await interaction.deferUpdate()
 			return this.some({
 				action: 'remove',
-				index: Number(removeMatch[1]),
+				index: control.index!,
+				...identity,
 			})
 		}
-		if (interaction.customId === 'parlay_btn_cancel') {
+		if (control.action === 'cancel') {
 			await interaction.deferUpdate()
-			return this.some({ action: 'cancel' })
+			return this.some({ action: 'cancel', ...identity })
 		}
-		if (interaction.customId === 'parlay_btn_confirm') {
+		if (control.action === 'confirm') {
 			await interaction.deferUpdate()
-			return this.some({ action: 'confirm' })
+			return this.some({ action: 'confirm', ...identity })
 		}
 		return this.none()
 	}
@@ -86,18 +110,57 @@ export class ParlayButtonHandler extends InteractionHandler {
 	public async run(
 		interaction: ButtonInteraction,
 		payload:
-			| { action: 'remove'; index: number }
-			| { action: 'cancel' }
-			| { action: 'confirm' },
+			| ({ action: 'remove'; index: number } & ParlayBuilderIdentity)
+			| ({ action: 'cancel' } & ParlayBuilderIdentity)
+			| ({ action: 'confirm' } & ParlayBuilderIdentity),
 	) {
 		const userId = interaction.user.id
 		const guildId = interaction.guildId
+		const expected = {
+			sessionId: payload.sessionId,
+			revision: payload.revision,
+		}
+		let placementToken: string | undefined
+		let leaseHeartbeat: NodeJS.Timeout | undefined
 		try {
 			if (!guildId) {
 				throw new Error('Parlays can only be built inside a server.')
 			}
 			if (payload.action === 'cancel') {
-				await this.builderService.clear(userId, guildId)
+				const session = await this.builderService.assertCurrent(
+					userId,
+					guildId,
+					expected,
+				)
+				if (
+					session.placementPhase === 'placing' ||
+					session.placementPhase === 'unknown'
+				) {
+					const placed = await this.parlayApi.findByPlacement(
+						session.placementId,
+					)
+					if (placed) {
+						return this.finishPlacement(
+							interaction,
+							userId,
+							guildId,
+							expected,
+							placed,
+						)
+					}
+					if (session.placementPhase === 'placing') {
+						throw new Error(
+							'Your parlay placement is still being reconciled. Please wait for the result.',
+						)
+					}
+					await this.builderService.setPlacementState(
+						userId,
+						guildId,
+						expected,
+						'editing',
+					)
+				}
+				await this.builderService.clear(userId, guildId, expected)
 				return interaction.editReply(
 					this.builderService.renderMessage(
 						'Parlay builder cancelled.',
@@ -108,15 +171,59 @@ export class ParlayButtonHandler extends InteractionHandler {
 				const session = await this.builderService.removeLeg(
 					userId,
 					guildId,
+					expected,
 					payload.index,
 				)
 				return interaction.editReply(
 					this.builderService.render(session),
 				)
 			}
+			let current = await this.builderService.assertCurrent(
+				userId,
+				guildId,
+				expected,
+			)
+			if (
+				current.placementPhase === 'placed' &&
+				current.lastPlacementResponse
+			) {
+				return this.finishPlacement(
+					interaction,
+					userId,
+					guildId,
+					expected,
+					current.lastPlacementResponse,
+				)
+			}
+			if (current.placementPhase === 'unknown') {
+				const placed = await this.parlayApi.findByPlacement(
+					current.placementId,
+				)
+				if (placed) {
+					return this.finishPlacement(
+						interaction,
+						userId,
+						guildId,
+						expected,
+						placed,
+					)
+				}
+				current = await this.builderService.setPlacementState(
+					userId,
+					guildId,
+					expected,
+					'editing',
+				)
+			}
+			if (current.placementPhase === 'placing') {
+				throw new Error(
+					'Your parlay is already being placed. Please wait for the result.',
+				)
+			}
 			const reservation = await this.builderService.reserveForPlacement(
 				userId,
 				guildId,
+				expected,
 			)
 			if (!reservation) {
 				throw new Error(
@@ -124,6 +231,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 				)
 			}
 			const { session, token } = reservation
+			placementToken = token
 			let leaseLost = false
 			const assertPlacementLease = async () => {
 				if (leaseLost) {
@@ -143,7 +251,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 					)
 				}
 			}
-			const leaseHeartbeat = setInterval(() => {
+			leaseHeartbeat = setInterval(() => {
 				void assertPlacementLease().catch((error) =>
 					logParlayBuilderError(error, {
 						action: 'refresh_placement_reservation',
@@ -152,6 +260,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 				)
 			}, 30_000)
 			leaseHeartbeat.unref?.()
+			let placementRequested = false
 			try {
 				await assertPlacementLease()
 				this.builderService.validateForPlacement(session)
@@ -165,39 +274,67 @@ export class ParlayButtonHandler extends InteractionHandler {
 					user_id: userId,
 				})
 				await assertPlacementLease()
+				placementRequested = true
 				const placed = await this.parlayApi.place(
 					initialized.init_token,
+					session.placementId,
 				)
-				await assertPlacementLease()
-				await new BetslipManager(
-					new BetslipWrapper(),
-					new BetsCacheService(new CacheManager()),
-				).announceParlayPlaced(interaction, {
-					parlayId: placed.id,
-					legCount: placed.leg_count,
-					stake: Number(placed.stake),
-					potentialPayout: Number(placed.potential_payout),
-				})
-				await this.builderService.clearWithPlacementToken(
+				return this.finishPlacement(
+					interaction,
 					userId,
 					guildId,
+					expected,
+					placed,
 					token,
 				)
-				return interaction.editReply(
-					this.builderService.renderMessage(
-						`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
-						0x57f287,
-					),
-				)
 			} catch (error) {
+				if (!placementRequested) {
+					await this.builderService.setPlacementState(
+						userId,
+						guildId,
+						expected,
+						'editing',
+					)
+					throw error
+				}
+				await this.builderService.setPlacementState(
+					userId,
+					guildId,
+					expected,
+					'unknown',
+				)
+				try {
+					const placed = await this.parlayApi.findByPlacement(
+						session.placementId,
+					)
+					if (placed) {
+						return this.finishPlacement(
+							interaction,
+							userId,
+							guildId,
+							expected,
+							placed,
+							token,
+						)
+					}
+				} catch (reconciliationError) {
+					logParlayBuilderError(reconciliationError, {
+						action: 'reconcile_placement',
+						userId,
+					})
+					throw new Error(
+						'Your parlay placement is still being reconciled. Do not confirm again yet.',
+					)
+				}
+				await this.builderService.setPlacementState(
+					userId,
+					guildId,
+					expected,
+					'editing',
+				)
 				throw error
 			} finally {
 				clearInterval(leaseHeartbeat)
-				await this.builderService.releasePlacement(
-					userId,
-					guildId,
-					token,
-				)
 			}
 		} catch (error) {
 			logParlayBuilderError(error, { action: payload.action, userId })
@@ -206,10 +343,88 @@ export class ParlayButtonHandler extends InteractionHandler {
 				...this.builderService.renderMessage(message),
 				flags: MessageFlags.IsComponentsV2,
 			})
+		} finally {
+			if (leaseHeartbeat) clearInterval(leaseHeartbeat)
+			if (placementToken) {
+				try {
+					await this.builderService.releasePlacement(
+						userId,
+						guildId!,
+						placementToken,
+					)
+				} catch (error) {
+					logParlayBuilderError(error, {
+						action: 'release_placement_reservation',
+						userId,
+					})
+				}
+			}
 		}
 	}
 
-	private async buildAddLegModal(): Promise<ModalBuilder> {
+	private async finishPlacement(
+		interaction: ButtonInteraction,
+		userId: string,
+		guildId: string,
+		expected: ParlayBuilderIdentity,
+		placed: ParlayResponse,
+		placementToken?: string,
+	) {
+		try {
+			await this.builderService.setPlacementState(
+				userId,
+				guildId,
+				expected,
+				'placed',
+				placed,
+			)
+		} catch (error) {
+			logParlayBuilderError(error, {
+				action: 'persist_placed_parlay',
+				userId,
+			})
+		}
+		try {
+			await new BetslipManager(
+				new BetslipWrapper(),
+				new BetsCacheService(new CacheManager()),
+			).announceParlayPlaced(interaction, {
+				parlayId: placed.id,
+				legCount: placed.leg_count,
+				stake: Number(placed.stake),
+				potentialPayout: Number(placed.potential_payout),
+			})
+		} catch (error) {
+			logParlayBuilderError(error, {
+				action: 'announce_placed_parlay',
+				userId,
+			})
+		}
+		if (placementToken) {
+			try {
+				await this.builderService.clearWithPlacementToken(
+					userId,
+					guildId,
+					placementToken,
+				)
+			} catch (error) {
+				logParlayBuilderError(error, {
+					action: 'clear_placed_parlay_builder',
+					userId,
+				})
+			}
+		}
+		return interaction.editReply(
+			this.builderService.renderMessage(
+				`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
+				0x57f287,
+			),
+		)
+	}
+
+	private async buildAddLegModal(
+		identity: ParlayBuilderIdentity,
+	): Promise<ModalBuilder> {
 		const matches = ((await this.matchCache.getMatches()) ?? [])
 			.filter((match) => match.id && match.home_team && match.away_team)
 			.filter(
@@ -245,7 +460,7 @@ export class ParlayButtonHandler extends InteractionHandler {
 				})),
 			)
 		return new ModalBuilder()
-			.setCustomId('parlay_modal_add_leg')
+			.setCustomId(buildParlayModalId(identity, 'add-leg'))
 			.setTitle('Add a parlay leg')
 			.addLabelComponents(
 				new LabelBuilder()
@@ -286,9 +501,9 @@ export class ParlayButtonHandler extends InteractionHandler {
 			)
 	}
 
-	private buildStakeModal(): ModalBuilder {
+	private buildStakeModal(identity: ParlayBuilderIdentity): ModalBuilder {
 		return new ModalBuilder()
-			.setCustomId('parlay_modal_stake')
+			.setCustomId(buildParlayModalId(identity, 'stake'))
 			.setTitle('Set parlay stake')
 			.addLabelComponents(
 				new LabelBuilder()

--- a/src/interaction-handlers/parlay-button-handler.ts
+++ b/src/interaction-handlers/parlay-button-handler.ts
@@ -1,0 +1,249 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import {
+	type ButtonInteraction,
+	LabelBuilder,
+	MessageFlags,
+	ModalBuilder,
+	StringSelectMenuBuilder,
+	TextInputBuilder,
+	TextInputStyle,
+} from 'discord.js'
+import {
+	getParlayErrorMessage,
+	logParlayBuilderError,
+	ParlayBuilderService,
+} from '../services/ParlayBuilderService.js'
+import { BetsCacheService } from '../utils/api/common/bets/BetsCacheService.js'
+import { BetslipManager } from '../utils/api/Khronos/bets/BetslipsManager.js'
+import BetslipWrapper from '../utils/api/Khronos/bets/betslip-wrapper.js'
+import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+
+const removeId = /^parlay_btn_remove_(\d+)$/
+
+export class ParlayButtonHandler extends InteractionHandler {
+	private readonly builderService = new ParlayBuilderService()
+	private readonly parlayApi = new ParlayApiWrapper()
+	private readonly matchCache = new MatchCacheService(new CacheManager())
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.Button,
+		})
+	}
+
+	public override async parse(interaction: ButtonInteraction) {
+		if (!interaction.customId.startsWith('parlay_btn_')) return this.none()
+		if (interaction.customId === 'parlay_btn_add') {
+			try {
+				await interaction.showModal(await this.buildAddLegModal())
+			} catch (error) {
+				logParlayBuilderError(error, {
+					action: 'open_add_leg_modal',
+					userId: interaction.user.id,
+				})
+				await interaction.reply({
+					content:
+						error instanceof Error
+							? error.message
+							: 'No upcoming games are available right now.',
+					ephemeral: true,
+				})
+			}
+			return this.none()
+		}
+		if (interaction.customId === 'parlay_btn_stake') {
+			await interaction.showModal(this.buildStakeModal())
+			return this.none()
+		}
+		const removeMatch = removeId.exec(interaction.customId)
+		if (removeMatch) {
+			await interaction.deferUpdate()
+			return this.some({
+				action: 'remove',
+				index: Number(removeMatch[1]),
+			})
+		}
+		if (interaction.customId === 'parlay_btn_cancel') {
+			await interaction.deferUpdate()
+			return this.some({ action: 'cancel' })
+		}
+		if (interaction.customId === 'parlay_btn_confirm') {
+			await interaction.deferUpdate()
+			return this.some({ action: 'confirm' })
+		}
+		return this.none()
+	}
+
+	public async run(
+		interaction: ButtonInteraction,
+		payload:
+			| { action: 'remove'; index: number }
+			| { action: 'cancel' }
+			| { action: 'confirm' },
+	) {
+		const userId = interaction.user.id
+		try {
+			if (payload.action === 'cancel') {
+				await this.builderService.clear(userId)
+				return interaction.editReply(
+					this.builderService.renderMessage(
+						'Parlay builder cancelled.',
+					),
+				)
+			}
+			if (payload.action === 'remove') {
+				const session = await this.builderService.removeLeg(
+					userId,
+					payload.index,
+				)
+				return interaction.editReply(
+					this.builderService.render(session),
+				)
+			}
+			const session = await this.builderService.get(userId)
+			if (!session)
+				throw new Error(
+					'Your parlay builder expired. Run `/parlay` to start again.',
+				)
+			this.builderService.validateForPlacement(session)
+			const initialized = await this.parlayApi.init({
+				legs: session.legs.map(({ event_id, outcome_uuid }) => ({
+					event_id,
+					outcome_uuid,
+				})),
+				stake: session.stake!,
+				guild_id: interaction.guildId!,
+				user_id: userId,
+			})
+			const placed = await this.parlayApi.place(initialized.init_token)
+			await new BetslipManager(
+				new BetslipWrapper(),
+				new BetsCacheService(new CacheManager()),
+			).announceParlayPlaced(interaction, {
+				parlayId: placed.id,
+				legCount: placed.leg_count,
+				stake: Number(placed.stake),
+				potentialPayout: Number(placed.potential_payout),
+			})
+			await this.builderService.clear(userId)
+			return interaction.editReply(
+				this.builderService.renderMessage(
+					`## ✅ Parlay placed\n**${placed.leg_count} legs** • **$${Number(placed.stake).toFixed(2)}** at **${placed.combined_odds_american > 0 ? '+' : ''}${placed.combined_odds_american}**\nPotential payout: **$${Number(placed.potential_payout).toFixed(2)}**\nParlay ID: \`${placed.id}\``,
+					0x57f287,
+				),
+			)
+		} catch (error) {
+			logParlayBuilderError(error, { action: payload.action, userId })
+			const message = getParlayErrorMessage(error)
+			return interaction.editReply({
+				...this.builderService.renderMessage(message),
+				flags: MessageFlags.IsComponentsV2,
+			})
+		}
+	}
+
+	private async buildAddLegModal(): Promise<ModalBuilder> {
+		const matches = ((await this.matchCache.getMatches()) ?? [])
+			.filter((match) => match.id && match.home_team && match.away_team)
+			.filter(
+				(match) =>
+					!match.commence_time ||
+					new Date(match.commence_time).getTime() > Date.now(),
+			)
+			.slice(0, 25)
+		if (matches.length === 0)
+			throw new Error('No upcoming games are available right now.')
+		const gameSelect = new StringSelectMenuBuilder()
+			.setCustomId('parlay_game')
+			.setPlaceholder('Choose an upcoming game')
+			.setRequired(true)
+			.addOptions(
+				matches.map((match) => ({
+					label: `${match.away_team} @ ${match.home_team}`.slice(
+						0,
+						100,
+					),
+					value: match.id!,
+					description: match.commence_time
+						? new Date(match.commence_time).toLocaleString(
+								'en-US',
+								{
+									month: 'short',
+									day: 'numeric',
+									hour: 'numeric',
+									minute: '2-digit',
+								},
+							)
+						: 'Start time TBD',
+				})),
+			)
+		return new ModalBuilder()
+			.setCustomId('parlay_modal_add_leg')
+			.setTitle('Add a parlay leg')
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Game')
+					.setDescription('Choose an upcoming game')
+					.setStringSelectMenuComponent(gameSelect),
+			)
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Market')
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder()
+							.setCustomId('parlay_market')
+							.setPlaceholder('Choose market')
+							.addOptions(
+								{ label: 'Moneyline', value: 'h2h' },
+								{ label: 'Spread', value: 'spreads' },
+								{ label: 'Total', value: 'totals' },
+							)
+							.setRequired(true),
+					),
+			)
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Side')
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder()
+							.setCustomId('parlay_side')
+							.setPlaceholder('Choose side')
+							.addOptions(
+								{ label: 'Home team', value: 'home' },
+								{ label: 'Away team', value: 'away' },
+								{ label: 'Over', value: 'over' },
+								{ label: 'Under', value: 'under' },
+							)
+							.setRequired(true),
+					),
+			)
+	}
+
+	private buildStakeModal(): ModalBuilder {
+		return new ModalBuilder()
+			.setCustomId('parlay_modal_stake')
+			.setTitle('Set parlay stake')
+			.addLabelComponents(
+				new LabelBuilder()
+					.setLabel('Stake (whole dollars)')
+					.setTextInputComponent(
+						new TextInputBuilder()
+							.setCustomId('parlay_stake')
+							.setStyle(TextInputStyle.Short)
+							.setPlaceholder('10')
+							.setRequired(true)
+							.setMinLength(1)
+							.setMaxLength(6),
+					),
+			)
+	}
+}

--- a/src/interaction-handlers/parlay-cancel-handler.ts
+++ b/src/interaction-handlers/parlay-cancel-handler.ts
@@ -1,0 +1,99 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import { type ButtonInteraction } from 'discord.js'
+import {
+	type MyBetsDisplayData,
+	MyBetsFormatterService,
+} from '../utils/api/Khronos/bets/mybets-formatter.service.js'
+import { MyBetsPaginationService } from '../utils/api/Khronos/bets/mybets-pagination.service.js'
+import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+
+const parlayCancelPrefix = 'parlay_cancel_'
+
+const getParlayErrorMessage = (error: unknown): string => {
+	const data = (error as { response?: { data?: unknown } })?.response?.data
+	if (typeof data === 'object' && data !== null) {
+		const message = (data as { message?: unknown }).message
+		if (typeof message === 'string') return message
+		if (
+			Array.isArray(message) &&
+			message.every((item) => typeof item === 'string')
+		) {
+			return message.join(', ')
+		}
+	}
+	return error instanceof Error ? error.message : 'Unable to cancel parlay.'
+}
+
+export class ParlayCancelHandler extends InteractionHandler {
+	private readonly parlayApi = new ParlayApiWrapper()
+	private readonly paginationService = new MyBetsPaginationService()
+	private readonly formatterService = new MyBetsFormatterService()
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.Button,
+		})
+	}
+
+	public override async parse(interaction: ButtonInteraction) {
+		if (!interaction.customId.startsWith(parlayCancelPrefix))
+			return this.none()
+		const parlayId = interaction.customId.slice(parlayCancelPrefix.length)
+		if (!parlayId) return this.none()
+		await interaction.deferUpdate()
+		return this.some({ parlayId })
+	}
+
+	public async run(
+		interaction: ButtonInteraction,
+		payload: { parlayId: string },
+	) {
+		try {
+			await this.parlayApi.cancel(payload.parlayId, interaction.user.id)
+			const betsData = await this.paginationService.fetchUserBets(
+				interaction.user.id,
+			)
+			const historyPage = this.paginationService.getHistoryPage(
+				betsData.historyBets,
+				1,
+				betsData.historyParlays,
+			)
+			const displayData: MyBetsDisplayData = {
+				userId: interaction.user.id,
+				pendingBets: betsData.pendingBets,
+				pendingParlays: betsData.pendingParlays,
+				historyParlays: betsData.historyParlays,
+				historyPage,
+				groupedBets: this.paginationService.groupBetsByDate(
+					historyPage.bets,
+				),
+			}
+			await interaction.editReply(
+				await this.formatterService.buildEmbedResponse(
+					displayData,
+					interaction.guild ?? undefined,
+				),
+			)
+		} catch (error) {
+			this.container.logger.error({
+				message: 'Failed to cancel parlay',
+				metadata: {
+					userId: interaction.user.id,
+					parlayId: payload.parlayId,
+					error: getParlayErrorMessage(error),
+				},
+			})
+			await interaction.editReply({
+				content: `Unable to cancel this parlay: ${getParlayErrorMessage(error)}`,
+				components: [],
+			})
+		}
+	}
+}

--- a/src/interaction-handlers/parlay-cancel-handler.ts
+++ b/src/interaction-handlers/parlay-cancel-handler.ts
@@ -12,6 +12,14 @@ import ParlayApiWrapper from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
 
 const parlayCancelPrefix = 'parlay_cancel_'
 
+type ParlayCancelPayload =
+	| { kind: 'cancel'; parlayId: string; cancellationPage: number }
+	| {
+			kind: 'navigate'
+			action: 'first' | 'prev' | 'next' | 'last'
+			currentPage: number
+	  }
+
 const getParlayErrorMessage = (error: unknown): string => {
 	const data = (error as { response?: { data?: unknown } })?.response?.data
 	if (typeof data === 'object' && data !== null) {
@@ -25,6 +33,12 @@ const getParlayErrorMessage = (error: unknown): string => {
 		}
 	}
 	return error instanceof Error ? error.message : 'Unable to cancel parlay.'
+}
+
+const parsePage = (value: string): number | undefined => {
+	if (!/^\d+$/.test(value)) return undefined
+	const page = Number(value)
+	return Number.isSafeInteger(page) && page > 0 ? page : undefined
 }
 
 export class ParlayCancelHandler extends InteractionHandler {
@@ -45,53 +59,121 @@ export class ParlayCancelHandler extends InteractionHandler {
 	public override async parse(interaction: ButtonInteraction) {
 		if (!interaction.customId.startsWith(parlayCancelPrefix))
 			return this.none()
-		const parlayId = interaction.customId.slice(parlayCancelPrefix.length)
+		const payload = interaction.customId.slice(parlayCancelPrefix.length)
+
+		if (payload.startsWith('nav_')) {
+			const [, action, pageValue] = payload.split('_')
+			if (
+				(action !== 'first' &&
+					action !== 'prev' &&
+					action !== 'next' &&
+					action !== 'last') ||
+				!pageValue
+			) {
+				return this.none()
+			}
+			const currentPage = parsePage(pageValue)
+			if (!currentPage) return this.none()
+			await interaction.deferUpdate()
+			return this.some({ kind: 'navigate', action, currentPage })
+		}
+
+		const separator = payload.lastIndexOf('_')
+		const pageValue = payload.slice(separator + 1)
+		const cancellationPage = parsePage(pageValue) ?? 1
+		const encodedId = parsePage(pageValue)
+			? payload.slice(0, separator)
+			: payload
+		let parlayId: string
+		try {
+			parlayId = decodeURIComponent(encodedId)
+		} catch {
+			return this.none()
+		}
 		if (!parlayId) return this.none()
+
 		await interaction.deferUpdate()
-		return this.some({ parlayId })
+		return this.some({ kind: 'cancel', parlayId, cancellationPage })
+	}
+
+	private async render(
+		interaction: ButtonInteraction,
+		cancellationPage = 1,
+	): Promise<void> {
+		const betsData = await this.paginationService.fetchUserBets(
+			interaction.user.id,
+		)
+		const historyPage = this.paginationService.getHistoryPage(
+			betsData.historyBets,
+			1,
+			betsData.historyParlays,
+		)
+		const displayData: MyBetsDisplayData = {
+			userId: interaction.user.id,
+			pendingBets: betsData.pendingBets,
+			pendingParlays: betsData.pendingParlays,
+			historyParlays: betsData.historyParlays,
+			historyPage,
+			groupedBets: this.paginationService.groupBetsByDate(
+				historyPage.bets,
+			),
+			parlayFetchWarning: betsData.parlayFetchWarning,
+			cancellationPage,
+		}
+		await interaction.editReply(
+			await this.formatterService.buildEmbedResponse(
+				displayData,
+				interaction.guild ?? undefined,
+			),
+		)
 	}
 
 	public async run(
 		interaction: ButtonInteraction,
-		payload: { parlayId: string },
+		payload: ParlayCancelPayload,
 	) {
 		try {
-			await this.parlayApi.cancel(payload.parlayId, interaction.user.id)
-			const betsData = await this.paginationService.fetchUserBets(
-				interaction.user.id,
-			)
-			const historyPage = this.paginationService.getHistoryPage(
-				betsData.historyBets,
-				1,
-				betsData.historyParlays,
-			)
-			const displayData: MyBetsDisplayData = {
-				userId: interaction.user.id,
-				pendingBets: betsData.pendingBets,
-				pendingParlays: betsData.pendingParlays,
-				historyParlays: betsData.historyParlays,
-				historyPage,
-				groupedBets: this.paginationService.groupBetsByDate(
-					historyPage.bets,
-				),
+			if (payload.kind === 'navigate') {
+				let targetPage: number
+				switch (payload.action) {
+					case 'first':
+						targetPage = 1
+						break
+					case 'prev':
+						targetPage = Math.max(1, payload.currentPage - 1)
+						break
+					case 'next':
+						targetPage = payload.currentPage + 1
+						break
+					case 'last':
+						targetPage = Number.MAX_SAFE_INTEGER
+						break
+				}
+				await this.render(interaction, targetPage)
+				return
 			}
-			await interaction.editReply(
-				await this.formatterService.buildEmbedResponse(
-					displayData,
-					interaction.guild ?? undefined,
-				),
-			)
+
+			await this.parlayApi.cancel(payload.parlayId, interaction.user.id)
+			await this.render(interaction, payload.cancellationPage)
 		} catch (error) {
 			this.container.logger.error({
-				message: 'Failed to cancel parlay',
+				message:
+					payload.kind === 'cancel'
+						? 'Failed to cancel parlay'
+						: 'Failed to navigate parlay cancellations',
 				metadata: {
 					userId: interaction.user.id,
-					parlayId: payload.parlayId,
+					...(payload.kind === 'cancel'
+						? { parlayId: payload.parlayId }
+						: { action: payload.action }),
 					error: getParlayErrorMessage(error),
 				},
 			})
 			await interaction.editReply({
-				content: `Unable to cancel this parlay: ${getParlayErrorMessage(error)}`,
+				content:
+					payload.kind === 'cancel'
+						? `Unable to cancel this parlay: ${getParlayErrorMessage(error)}`
+						: 'Unable to load more cancellable parlays. Please run /mybets again.',
 				components: [],
 			})
 		}

--- a/src/interaction-handlers/parlay-modal-handler.ts
+++ b/src/interaction-handlers/parlay-modal-handler.ts
@@ -6,7 +6,11 @@ import { MessageFlags, type ModalSubmitInteraction } from 'discord.js'
 import {
 	getParlayErrorMessage,
 	logParlayBuilderError,
+	type ParlayBuilderIdentity,
 	ParlayBuilderService,
+	type ParlayModalKind,
+	parseParlayModalId,
+	STALE_PARLAY_BUILDER_MESSAGE,
 } from '../services/ParlayBuilderService.js'
 import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
 import { CacheManager } from '../utils/cache/cache-manager.js'
@@ -26,19 +30,26 @@ export class ParlayModalHandler extends InteractionHandler {
 	}
 
 	public override parse(interaction: ModalSubmitInteraction) {
-		if (!interaction.customId.startsWith('parlay_modal_'))
-			return this.none()
-		const kind = interaction.customId.replace('parlay_modal_', '')
-		if (kind !== 'add_leg' && kind !== 'stake') return this.none()
-		return this.some({
-			kind,
-		})
+		const parsed = parseParlayModalId(interaction.customId)
+		if (parsed) return this.some(parsed)
+		if (interaction.customId.startsWith('parlay_modal_')) {
+			return this.some({ kind: 'legacy' as const })
+		}
+		return this.none()
 	}
 
 	public async run(
 		interaction: ModalSubmitInteraction,
-		payload: { kind: 'add_leg' | 'stake' },
+		payload:
+			| ({ kind: ParlayModalKind } & ParlayBuilderIdentity)
+			| { kind: 'legacy' },
 	) {
+		if (payload.kind === 'legacy') {
+			return interaction.reply({
+				content: STALE_PARLAY_BUILDER_MESSAGE,
+				flags: MessageFlags.Ephemeral,
+			})
+		}
 		const userId = interaction.user.id
 		const guildId = interaction.guildId
 		if (!guildId) {
@@ -64,6 +75,10 @@ export class ParlayModalHandler extends InteractionHandler {
 			return interaction.editReply(options)
 		}
 		try {
+			const expected = {
+				sessionId: payload.sessionId,
+				revision: payload.revision,
+			}
 			if (payload.kind === 'stake') {
 				const rawStake = interaction.fields
 					.getTextInputValue('parlay_stake')
@@ -73,6 +88,7 @@ export class ParlayModalHandler extends InteractionHandler {
 				const session = await this.builderService.setStake(
 					userId,
 					guildId,
+					expected,
 					Number(rawStake),
 				)
 				return updateBuilder(this.builderService.render(session))
@@ -107,11 +123,16 @@ export class ParlayModalHandler extends InteractionHandler {
 			) {
 				throw new Error('Totals require Over or Under.')
 			}
-			const session = await this.builderService.addLeg(userId, guildId, {
-				matchId: gameId,
-				marketKey,
-				side,
-			})
+			const session = await this.builderService.addLeg(
+				userId,
+				guildId,
+				expected,
+				{
+					matchId: gameId,
+					marketKey,
+					side,
+				},
+			)
 			return updateBuilder(this.builderService.render(session))
 		} catch (error) {
 			logParlayBuilderError(error, { userId, modal: payload.kind })

--- a/src/interaction-handlers/parlay-modal-handler.ts
+++ b/src/interaction-handlers/parlay-modal-handler.ts
@@ -1,0 +1,102 @@
+import {
+	InteractionHandler,
+	InteractionHandlerTypes,
+} from '@sapphire/framework'
+import { type ModalSubmitInteraction } from 'discord.js'
+import {
+	getParlayErrorMessage,
+	logParlayBuilderError,
+	ParlayBuilderService,
+} from '../services/ParlayBuilderService.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+
+export class ParlayModalHandler extends InteractionHandler {
+	private readonly builderService = new ParlayBuilderService()
+	private readonly matchCache = new MatchCacheService(new CacheManager())
+
+	public constructor(
+		ctx: InteractionHandler.LoaderContext,
+		options: InteractionHandler.Options,
+	) {
+		super(ctx, {
+			...options,
+			interactionHandlerType: InteractionHandlerTypes.ModalSubmit,
+		})
+	}
+
+	public override parse(interaction: ModalSubmitInteraction) {
+		if (!interaction.customId.startsWith('parlay_modal_'))
+			return this.none()
+		const kind = interaction.customId.replace('parlay_modal_', '')
+		if (kind !== 'add_leg' && kind !== 'stake') return this.none()
+		return this.some({
+			kind,
+		})
+	}
+
+	public async run(
+		interaction: ModalSubmitInteraction,
+		payload: { kind: 'add_leg' | 'stake' },
+	) {
+		await interaction.deferReply({ ephemeral: true })
+		const userId = interaction.user.id
+		try {
+			if (payload.kind === 'stake') {
+				const rawStake = interaction.fields
+					.getTextInputValue('parlay_stake')
+					.trim()
+				if (!/^\d+$/.test(rawStake))
+					throw new Error('Stake must be a whole number. Try again.')
+				const session = await this.builderService.setStake(
+					userId,
+					Number(rawStake),
+				)
+				return interaction.editReply(
+					this.builderService.render(session),
+				)
+			}
+
+			const gameId =
+				interaction.fields.getStringSelectValues('parlay_game')[0]
+			const marketKey = interaction.fields.getStringSelectValues(
+				'parlay_market',
+			)[0] as 'h2h' | 'spreads' | 'totals'
+			const side = interaction.fields.getStringSelectValues(
+				'parlay_side',
+			)[0] as 'home' | 'away' | 'over' | 'under'
+			if (!gameId || !marketKey || !side)
+				throw new Error('Choose a game, market, and side.')
+			const match = await this.matchCache.getMatch(gameId)
+			if (!match) throw new Error('Choose a valid game from the list.')
+			if (marketKey === 'h2h' && (side === 'over' || side === 'under')) {
+				throw new Error(
+					'Over/Under is only valid for totals. Choose a team for moneyline.',
+				)
+			}
+			if (
+				(marketKey === 'spreads' || marketKey === 'h2h') &&
+				(side === 'over' || side === 'under')
+			) {
+				throw new Error('That side is not valid for this market.')
+			}
+			if (
+				marketKey === 'totals' &&
+				(side === 'home' || side === 'away')
+			) {
+				throw new Error('Totals require Over or Under.')
+			}
+			const session = await this.builderService.addLeg(userId, {
+				matchId: gameId,
+				marketKey,
+				side,
+			})
+			return interaction.editReply(this.builderService.render(session))
+		} catch (error) {
+			logParlayBuilderError(error, { userId, modal: payload.kind })
+			return interaction.editReply(
+				this.builderService.renderMessage(getParlayErrorMessage(error)),
+			)
+		}
+	}
+}

--- a/src/interaction-handlers/parlay-modal-handler.ts
+++ b/src/interaction-handlers/parlay-modal-handler.ts
@@ -2,7 +2,7 @@ import {
 	InteractionHandler,
 	InteractionHandlerTypes,
 } from '@sapphire/framework'
-import { type ModalSubmitInteraction } from 'discord.js'
+import { MessageFlags, type ModalSubmitInteraction } from 'discord.js'
 import {
 	getParlayErrorMessage,
 	logParlayBuilderError,
@@ -39,8 +39,30 @@ export class ParlayModalHandler extends InteractionHandler {
 		interaction: ModalSubmitInteraction,
 		payload: { kind: 'add_leg' | 'stake' },
 	) {
-		await interaction.deferReply({ ephemeral: true })
 		const userId = interaction.user.id
+		const guildId = interaction.guildId
+		if (!guildId) {
+			return interaction.reply({
+				content: 'Parlays can only be built inside a server.',
+				flags: MessageFlags.Ephemeral,
+			})
+		}
+		const updateBuilder = async (
+			options: ReturnType<ParlayBuilderService['render']>,
+			confirmation = 'Parlay builder updated.',
+		) => {
+			if (interaction.isFromMessage() && interaction.message) {
+				await interaction.message.edit(options)
+				return interaction.reply({
+					content: confirmation,
+					flags: MessageFlags.Ephemeral,
+				})
+			}
+			if (!interaction.deferred && !interaction.replied) {
+				await interaction.deferReply({ ephemeral: true })
+			}
+			return interaction.editReply(options)
+		}
 		try {
 			if (payload.kind === 'stake') {
 				const rawStake = interaction.fields
@@ -50,11 +72,10 @@ export class ParlayModalHandler extends InteractionHandler {
 					throw new Error('Stake must be a whole number. Try again.')
 				const session = await this.builderService.setStake(
 					userId,
+					guildId,
 					Number(rawStake),
 				)
-				return interaction.editReply(
-					this.builderService.render(session),
-				)
+				return updateBuilder(this.builderService.render(session))
 			}
 
 			const gameId =
@@ -86,16 +107,23 @@ export class ParlayModalHandler extends InteractionHandler {
 			) {
 				throw new Error('Totals require Over or Under.')
 			}
-			const session = await this.builderService.addLeg(userId, {
+			const session = await this.builderService.addLeg(userId, guildId, {
 				matchId: gameId,
 				marketKey,
 				side,
 			})
-			return interaction.editReply(this.builderService.render(session))
+			return updateBuilder(this.builderService.render(session))
 		} catch (error) {
 			logParlayBuilderError(error, { userId, modal: payload.kind })
-			return interaction.editReply(
+			if (interaction.isFromMessage() && interaction.message) {
+				return interaction.reply({
+					content: getParlayErrorMessage(error),
+					flags: MessageFlags.Ephemeral,
+				})
+			}
+			return updateBuilder(
 				this.builderService.renderMessage(getParlayErrorMessage(error)),
+				'Unable to update parlay builder.',
 			)
 		}
 	}

--- a/src/lib/startup/__tests__/env.test.ts
+++ b/src/lib/startup/__tests__/env.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const requiredEnv = {
+	NODE_ENV: 'development',
+	TOKEN: 'discord-token',
+	PREFIX: '!',
+	PROJECT_VERSION: 'test',
+	KH_API_URL: 'http://khronos:3000',
+	KH_API_TOKEN: 'kh-token',
+	R_HOST: 'redis',
+	R_PORT: '6379',
+	R_DB: '0',
+	R_PASS: 'redis-pass',
+	API_URL: 'http://pluto:2090',
+	API_KEY: 'api-key',
+	PATREON_API_URL: 'http://patreon:3000',
+	KH_PLUTO_CLIENT_KEY: 'client-key',
+	APP_OWNER_ID: 'owner',
+	AXIOM_DATASET: 'dataset',
+	AXIOM_API_TOKEN: 'axiom-token',
+	AXIOM_ORG_ID: 'org',
+	BULL_BOARD_USERNAME: 'admin',
+	BULL_BOARD_PASSWORD: 'password',
+	LOKI_URL: 'http://loki:3100',
+	LOKI_USER: 'loki',
+	LOKI_PASS: 'loki-pass',
+}
+
+for (const [key, value] of Object.entries(requiredEnv)) {
+	vi.stubEnv(key, value)
+}
+
+const { isSystemStartupMode, parseStartupEnv } = await import('../env.js')
+
+describe('Pluto system startup env gate', () => {
+	it('cannot activate system mode in production', () => {
+		expect(() =>
+			parseStartupEnv({
+				...requiredEnv,
+				NODE_ENV: 'production',
+				PLUTO_SYSTEM_MODE: '1',
+				PLUTO_SYSTEM_ALLOW: '1',
+			}),
+		).toThrow(/PLUTO_SYSTEM_MODE cannot be enabled/)
+	})
+
+	it('activates system mode only when both system flags are set outside production', () => {
+		const env = parseStartupEnv({
+			...requiredEnv,
+			TOKEN: undefined,
+			PLUTO_SYSTEM_MODE: '1',
+			PLUTO_SYSTEM_ALLOW: '1',
+		})
+
+		expect(isSystemStartupMode(env)).toBe(true)
+		expect(env.TOKEN).toBeUndefined()
+	})
+
+	it('keeps TOKEN required for normal production startup', () => {
+		expect(() =>
+			parseStartupEnv({
+				...requiredEnv,
+				NODE_ENV: 'production',
+				TOKEN: undefined,
+			}),
+		).toThrow(/TOKEN is required/)
+	})
+})

--- a/src/lib/startup/__tests__/pluto.test.ts
+++ b/src/lib/startup/__tests__/pluto.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ParsedStartupEnv } from '../env.js'
+
+const baseEnv: ParsedStartupEnv = {
+	NODE_ENV: 'development',
+	TOKEN: 'discord-token',
+	PREFIX: '!',
+	PROJECT_VERSION: 'test',
+	KH_API_URL: 'http://khronos:3000',
+	KH_API_TOKEN: 'kh-token',
+	R_HOST: 'redis',
+	R_PORT: 6379,
+	R_DB: 0,
+	R_PASS: 'redis-pass',
+	API_PORT: 2090,
+	API_URL: 'http://pluto:2090',
+	LOG_LEVEL: 'Info',
+	PATREON_API_URL: 'http://patreon:3000',
+	KH_PLUTO_CLIENT_KEY: 'client-key',
+	APP_OWNER_ID: 'owner',
+	AXIOM_DATASET: 'dataset',
+	AXIOM_API_TOKEN: 'axiom-token',
+	AXIOM_ORG_ID: 'org',
+	BULL_BOARD_USERNAME: 'admin',
+	BULL_BOARD_PASSWORD: 'password',
+	API_KEY: 'api-key',
+	LOKI_URL: 'http://loki:3100',
+	LOKI_USER: 'loki',
+	LOKI_PASS: 'loki-pass',
+	MAINTENANCE_MODE: false,
+	USE_MOCK_DATA: false,
+	MOCK_GUILD_SPORT: 'nba',
+	ANNOUNCE_PAYOUT_THRESHOLD: 100,
+	ANNOUNCE_MAX_PER_HOUR: 5,
+	BIG_WIN_ANNOUNCEMENTS_ENABLED: true,
+	RECAP_CRON: '0 9 * * 1',
+	RECAP_ENABLED: true,
+	RECAP_GUILD_IDS: '',
+	PLUTO_SYSTEM_MODE: false,
+	PLUTO_SYSTEM_ALLOW: false,
+}
+
+vi.mock('../env.js', () => ({
+	default: {},
+	isSystemStartupMode: (env: ParsedStartupEnv) =>
+		env.PLUTO_SYSTEM_MODE &&
+		env.PLUTO_SYSTEM_ALLOW &&
+		env.NODE_ENV !== 'production',
+}))
+
+vi.mock('../../../utils/api/routes/notifications/delivery-queue.js', () => ({
+	configureSystemNotificationDelivery: vi.fn(),
+	resetNotificationDeliveryQueue: vi.fn(),
+}))
+
+vi.mock('../../../utils/logging/WinstonLogger.js', () => ({
+	logger: { info: vi.fn(), error: vi.fn() },
+}))
+
+const { startPluto } = await import('../pluto.js')
+
+describe('Pluto startup orchestration', () => {
+	it('does not call Discord gateway login in system mode', async () => {
+		const client = {
+			login: vi.fn(),
+			destroy: vi.fn(),
+			logger: { fatal: vi.fn() },
+		}
+		const initializeSystemStartupServices = vi.fn(async () => undefined)
+
+		await startPluto({
+			client,
+			env: {
+				...baseEnv,
+				TOKEN: undefined,
+				PLUTO_SYSTEM_MODE: true,
+				PLUTO_SYSTEM_ALLOW: true,
+			},
+			initializeSystemStartupServices,
+			initializeStartupServices: vi.fn(async () => undefined),
+			exitProcess: vi.fn(),
+		})
+
+		expect(initializeSystemStartupServices).toHaveBeenCalledOnce()
+		expect(client.login).not.toHaveBeenCalled()
+		expect(client.destroy).not.toHaveBeenCalled()
+	})
+
+	it('still calls Discord gateway login for normal startup', async () => {
+		const client = {
+			login: vi.fn(async () => 'ready'),
+			destroy: vi.fn(),
+			logger: { fatal: vi.fn() },
+		}
+
+		await startPluto({
+			client,
+			env: baseEnv,
+			initializeStartupServices: vi.fn(async () => undefined),
+			initializeSystemStartupServices: vi.fn(async () => undefined),
+			exitProcess: vi.fn(),
+		})
+
+		expect(client.login).toHaveBeenCalledWith('discord-token')
+	})
+})

--- a/src/lib/startup/env.ts
+++ b/src/lib/startup/env.ts
@@ -1,25 +1,32 @@
 import { z } from 'zod'
 
+const envFlag = (value: unknown): boolean =>
+	value === true || value === 'true' || value === '1'
+
+const optionalNonEmptyString = z.preprocess(
+	(value) => (value === '' ? undefined : value),
+	z.string().min(1).optional(),
+)
+
+const requiredString = (message: string) => z.string().min(1, { message })
+
 // Define the schema for our environment variables
 const envSchema = z
 	.object({
-		NODE_ENV: z.enum(['development', 'production']),
-		TOKEN: z
-			.string()
-			.min(1, {
-				message: 'TOKEN is required for Discord bot authentication',
-			})
-			.describe('Discord bot token used for authentication'),
+		NODE_ENV: z.enum(['development', 'production', 'test']),
+		TOKEN: optionalNonEmptyString.describe(
+			'Discord bot token used for authentication',
+		),
 		PREFIX: z.string(),
 		PROJECT_VERSION: z.string(),
 		KH_API_URL: z.url(),
-		KH_API_TOKEN: z.string().min(1, {
-			message: 'KH_API_TOKEN is required for Khronos API authentication',
-		}),
+		KH_API_TOKEN: requiredString(
+			'KH_API_TOKEN is required for Khronos API authentication',
+		),
 		R_HOST: z.string(),
 		R_PORT: z.number().int().positive(),
 		R_DB: z.number().int().nonnegative(),
-		R_PASS: z.string().min(1, { message: 'R_PASS is required' }),
+		R_PASS: requiredString('R_PASS is required'),
 		API_PORT: z.number().int().positive(),
 		API_URL: z.string().url().min(1, { message: 'API_URL is required' }),
 		LOG_LEVEL: z.enum(['Trace', 'Debug', 'Info', 'Warn', 'Error', 'Fatal']),
@@ -27,28 +34,21 @@ const envSchema = z
 			.string()
 			.url()
 			.min(1, { message: 'PATREON_API_URL is required' }),
-		KH_PLUTO_CLIENT_KEY: z.string().min(1, {
-			message:
-				'KH_PLUTO_CLIENT_KEY is required for Khronos API authentication',
-		}),
+		KH_PLUTO_CLIENT_KEY: requiredString(
+			'KH_PLUTO_CLIENT_KEY is required for Khronos API authentication',
+		),
 		APP_OWNER_ID: z.string(),
 		AXIOM_DATASET: z.string(),
-		AXIOM_API_TOKEN: z.string().min(1, {
-			message: 'AXIOM_API_TOKEN is required for Axiom logging',
-		}),
+		AXIOM_API_TOKEN: requiredString(
+			'AXIOM_API_TOKEN is required for Axiom logging',
+		),
 		AXIOM_ORG_ID: z.string(),
-		BULL_BOARD_USERNAME: z
-			.string()
-			.min(1, { message: 'BULL_BOARD_USERNAME is required' }),
-		BULL_BOARD_PASSWORD: z
-			.string()
-			.min(1, { message: 'BULL_BOARD_PASSWORD is required' }),
-		API_KEY: z
-			.string()
-			.min(1, { message: 'API_KEY is required for API authentication' }),
+		BULL_BOARD_USERNAME: requiredString('BULL_BOARD_USERNAME is required'),
+		BULL_BOARD_PASSWORD: requiredString('BULL_BOARD_PASSWORD is required'),
+		API_KEY: requiredString('API_KEY is required for API authentication'),
 		LOKI_URL: z.string(),
-		LOKI_USER: z.string().min(1, { message: 'LOKI_USER is required' }),
-		LOKI_PASS: z.string().min(1, { message: 'LOKI_PASS is required' }),
+		LOKI_USER: requiredString('LOKI_USER is required'),
+		LOKI_PASS: requiredString('LOKI_PASS is required'),
 		MAINTENANCE_MODE: z.boolean(),
 		USE_MOCK_DATA: z.boolean().default(false),
 		MOCK_GUILD_BETTING_CHAN_ID: z.string().optional(),
@@ -65,8 +65,41 @@ const envSchema = z
 		RECAP_CHANNEL_ID: z.string().optional(),
 		RECAP_ENABLED: z.boolean().default(true),
 		RECAP_GUILD_IDS: z.string().default(''),
+		PLUTO_SYSTEM_MODE: z.boolean().default(false),
+		PLUTO_SYSTEM_ALLOW: z.boolean().default(false),
 	})
 	.superRefine((data, ctx) => {
+		const systemFlagsSet = data.PLUTO_SYSTEM_MODE && data.PLUTO_SYSTEM_ALLOW
+		// Hermetic XR/system boot requires both flags and NODE_ENV != production:
+		// PLUTO_SYSTEM_MODE=1 PLUTO_SYSTEM_ALLOW=1 NODE_ENV=development|test.
+		if (
+			data.NODE_ENV === 'production' &&
+			(data.PLUTO_SYSTEM_MODE || data.PLUTO_SYSTEM_ALLOW)
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['PLUTO_SYSTEM_MODE'],
+				message:
+					'PLUTO_SYSTEM_MODE cannot be enabled when NODE_ENV=production',
+			})
+		}
+		if (data.PLUTO_SYSTEM_MODE !== data.PLUTO_SYSTEM_ALLOW) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['PLUTO_SYSTEM_ALLOW'],
+				message:
+					'PLUTO_SYSTEM_MODE and PLUTO_SYSTEM_ALLOW must both be enabled for system startup',
+			})
+		}
+		const systemModeActive =
+			systemFlagsSet && data.NODE_ENV !== 'production'
+		if (!systemModeActive && !data.TOKEN) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['TOKEN'],
+				message: 'TOKEN is required for Discord bot authentication',
+			})
+		}
 		if (data.USE_MOCK_DATA && data.NODE_ENV === 'production') {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
@@ -95,52 +128,70 @@ const envSchema = z
 		}
 	})
 
+export type ParsedStartupEnv = z.infer<typeof envSchema>
+
+export function parseStartupEnv(
+	source: NodeJS.ProcessEnv = process.env,
+): ParsedStartupEnv {
+	return envSchema.parse({
+		NODE_ENV: source.NODE_ENV,
+		TOKEN: source.TOKEN,
+		PREFIX: source.PREFIX,
+		PROJECT_VERSION: source.PROJECT_VERSION,
+		KH_API_URL: source.KH_API_URL,
+		KH_API_TOKEN: source.KH_API_TOKEN,
+		R_HOST: source.R_HOST,
+		R_PORT: Number.parseInt(source.R_PORT || '6379', 10),
+		R_DB: Number.parseInt(source.R_DB || '0', 10),
+		R_PASS: source.R_PASS,
+		API_PORT: Number.parseInt(source.APIPORT || '2090', 10),
+		API_URL: source.API_URL,
+		LOG_LEVEL: source.LOG_LEVEL || 'Info',
+		PATREON_API_URL: source.PATREON_API_URL,
+		KH_PLUTO_CLIENT_KEY: source.KH_PLUTO_CLIENT_KEY,
+		APP_OWNER_ID: source.APP_OWNER_ID,
+		AXIOM_DATASET: source.AXIOM_DATASET,
+		AXIOM_API_TOKEN: source.AXIOM_API_TOKEN,
+		AXIOM_ORG_ID: source.AXIOM_ORG_ID,
+		BULL_BOARD_USERNAME: source.BULL_BOARD_USERNAME,
+		BULL_BOARD_PASSWORD: source.BULL_BOARD_PASSWORD,
+		API_KEY: source.API_KEY,
+		LOKI_URL: source.LOKI_URL,
+		LOKI_USER: source.LOKI_USER,
+		LOKI_PASS: source.LOKI_PASS,
+		MAINTENANCE_MODE: envFlag(source.MAINTENANCE_MODE),
+		USE_MOCK_DATA: envFlag(source.USE_MOCK_DATA),
+		MOCK_GUILD_BETTING_CHAN_ID: source.MOCK_GUILD_BETTING_CHAN_ID,
+		DEV_GUILD_GAMES_CATEGORY_ID: source.DEV_GUILD_GAMES_CATEGORY_ID,
+		MOCK_GUILD_SPORT: source.MOCK_GUILD_SPORT || 'nba',
+		ANNOUNCE_PAYOUT_THRESHOLD: Number.parseFloat(
+			source.ANNOUNCE_PAYOUT_THRESHOLD || '100',
+		),
+		ANNOUNCE_MAX_PER_HOUR: Number.parseInt(
+			source.ANNOUNCE_MAX_PER_HOUR || '5',
+			10,
+		),
+		BIG_WIN_ANNOUNCEMENTS_ENABLED:
+			source.BIG_WIN_ANNOUNCEMENTS_ENABLED !== 'false',
+		RECAP_CRON: source.RECAP_CRON,
+		RECAP_CHANNEL_ID: source.RECAP_CHANNEL_ID,
+		RECAP_ENABLED: source.RECAP_ENABLED !== 'false',
+		RECAP_GUILD_IDS: source.RECAP_GUILD_IDS || source.GUILD_ID || '',
+		PLUTO_SYSTEM_MODE: envFlag(source.PLUTO_SYSTEM_MODE),
+		PLUTO_SYSTEM_ALLOW: envFlag(source.PLUTO_SYSTEM_ALLOW),
+	})
+}
+
+export function isSystemStartupMode(env: ParsedStartupEnv): boolean {
+	return (
+		env.PLUTO_SYSTEM_MODE &&
+		env.PLUTO_SYSTEM_ALLOW &&
+		env.NODE_ENV !== 'production'
+	)
+}
+
 // Parse and validate the environment variables
-const env = envSchema.parse({
-	NODE_ENV: process.env.NODE_ENV,
-	TOKEN: process.env.TOKEN,
-	PREFIX: process.env.PREFIX,
-	PROJECT_VERSION: process.env.PROJECT_VERSION,
-	KH_API_URL: process.env.KH_API_URL,
-	KH_API_TOKEN: process.env.KH_API_TOKEN,
-	R_HOST: process.env.R_HOST,
-	R_PORT: Number.parseInt(process.env.R_PORT || '6379', 10),
-	R_DB: Number.parseInt(process.env.R_DB || '0', 10),
-	R_PASS: process.env.R_PASS,
-	API_PORT: Number.parseInt(process.env.APIPORT || '2090', 10),
-	API_URL: process.env.API_URL,
-	LOG_LEVEL: process.env.LOG_LEVEL || 'Info',
-	PATREON_API_URL: process.env.PATREON_API_URL,
-	KH_PLUTO_CLIENT_KEY: process.env.KH_PLUTO_CLIENT_KEY,
-	APP_OWNER_ID: process.env.APP_OWNER_ID,
-	AXIOM_DATASET: process.env.AXIOM_DATASET,
-	AXIOM_API_TOKEN: process.env.AXIOM_API_TOKEN,
-	AXIOM_ORG_ID: process.env.AXIOM_ORG_ID,
-	BULL_BOARD_USERNAME: process.env.BULL_BOARD_USERNAME,
-	BULL_BOARD_PASSWORD: process.env.BULL_BOARD_PASSWORD,
-	API_KEY: process.env.API_KEY,
-	LOKI_URL: process.env.LOKI_URL,
-	LOKI_USER: process.env.LOKI_USER,
-	LOKI_PASS: process.env.LOKI_PASS,
-	MAINTENANCE_MODE: process.env.MAINTENANCE_MODE === 'true',
-	USE_MOCK_DATA: process.env.USE_MOCK_DATA === 'true',
-	MOCK_GUILD_BETTING_CHAN_ID: process.env.MOCK_GUILD_BETTING_CHAN_ID,
-	DEV_GUILD_GAMES_CATEGORY_ID: process.env.DEV_GUILD_GAMES_CATEGORY_ID,
-	MOCK_GUILD_SPORT: process.env.MOCK_GUILD_SPORT || 'nba',
-	ANNOUNCE_PAYOUT_THRESHOLD: Number.parseFloat(
-		process.env.ANNOUNCE_PAYOUT_THRESHOLD || '100',
-	),
-	ANNOUNCE_MAX_PER_HOUR: Number.parseInt(
-		process.env.ANNOUNCE_MAX_PER_HOUR || '5',
-		10,
-	),
-	BIG_WIN_ANNOUNCEMENTS_ENABLED:
-		process.env.BIG_WIN_ANNOUNCEMENTS_ENABLED !== 'false',
-	RECAP_CRON: process.env.RECAP_CRON,
-	RECAP_CHANNEL_ID: process.env.RECAP_CHANNEL_ID,
-	RECAP_ENABLED: process.env.RECAP_ENABLED !== 'false',
-	RECAP_GUILD_IDS: process.env.RECAP_GUILD_IDS || process.env.GUILD_ID || '',
-})
+const env = parseStartupEnv()
 
 // Debug logging for environment validation (redacts sensitive values)
 const shouldLogDebug =
@@ -166,6 +217,8 @@ if (shouldLogDebug) {
 		LOKI_USER: env.LOKI_USER,
 		MAINTENANCE_MODE: env.MAINTENANCE_MODE,
 		USE_MOCK_DATA: env.USE_MOCK_DATA,
+		PLUTO_SYSTEM_MODE: env.PLUTO_SYSTEM_MODE,
+		PLUTO_SYSTEM_ALLOW: env.PLUTO_SYSTEM_ALLOW,
 		MOCK_GUILD_BETTING_CHAN_ID: env.MOCK_GUILD_BETTING_CHAN_ID,
 		DEV_GUILD_GAMES_CATEGORY_ID: env.DEV_GUILD_GAMES_CATEGORY_ID,
 		MOCK_GUILD_SPORT: env.MOCK_GUILD_SPORT,

--- a/src/lib/startup/env.ts
+++ b/src/lib/startup/env.ts
@@ -61,6 +61,10 @@ const envSchema = z
 			.default(100),
 		ANNOUNCE_MAX_PER_HOUR: z.number().int().positive().default(5),
 		BIG_WIN_ANNOUNCEMENTS_ENABLED: z.boolean().default(true),
+		RECAP_CRON: z.string().default('0 9 * * 1'),
+		RECAP_CHANNEL_ID: z.string().optional(),
+		RECAP_ENABLED: z.boolean().default(true),
+		RECAP_GUILD_IDS: z.string().default(''),
 	})
 	.superRefine((data, ctx) => {
 		if (data.USE_MOCK_DATA && data.NODE_ENV === 'production') {
@@ -132,6 +136,10 @@ const env = envSchema.parse({
 	),
 	BIG_WIN_ANNOUNCEMENTS_ENABLED:
 		process.env.BIG_WIN_ANNOUNCEMENTS_ENABLED !== 'false',
+	RECAP_CRON: process.env.RECAP_CRON,
+	RECAP_CHANNEL_ID: process.env.RECAP_CHANNEL_ID,
+	RECAP_ENABLED: process.env.RECAP_ENABLED !== 'false',
+	RECAP_GUILD_IDS: process.env.RECAP_GUILD_IDS || process.env.GUILD_ID || '',
 })
 
 // Debug logging for environment validation (redacts sensitive values)
@@ -164,6 +172,10 @@ if (shouldLogDebug) {
 		ANNOUNCE_PAYOUT_THRESHOLD: env.ANNOUNCE_PAYOUT_THRESHOLD,
 		ANNOUNCE_MAX_PER_HOUR: env.ANNOUNCE_MAX_PER_HOUR,
 		BIG_WIN_ANNOUNCEMENTS_ENABLED: env.BIG_WIN_ANNOUNCEMENTS_ENABLED,
+		RECAP_CRON: env.RECAP_CRON,
+		RECAP_CHANNEL_ID: env.RECAP_CHANNEL_ID,
+		RECAP_ENABLED: env.RECAP_ENABLED,
+		RECAP_GUILD_IDS: env.RECAP_GUILD_IDS,
 		// Redacted sensitive fields
 		TOKEN: '[REDACTED]',
 		KH_API_TOKEN: '[REDACTED]',

--- a/src/lib/startup/env.ts
+++ b/src/lib/startup/env.ts
@@ -54,6 +54,13 @@ const envSchema = z
 		MOCK_GUILD_BETTING_CHAN_ID: z.string().optional(),
 		DEV_GUILD_GAMES_CATEGORY_ID: z.string().optional(),
 		MOCK_GUILD_SPORT: z.enum(['nba', 'nfl']).default('nba'),
+		ANNOUNCE_PAYOUT_THRESHOLD: z
+			.number()
+			.finite()
+			.nonnegative()
+			.default(100),
+		ANNOUNCE_MAX_PER_HOUR: z.number().int().positive().default(5),
+		BIG_WIN_ANNOUNCEMENTS_ENABLED: z.boolean().default(true),
 	})
 	.superRefine((data, ctx) => {
 		if (data.USE_MOCK_DATA && data.NODE_ENV === 'production') {
@@ -116,6 +123,15 @@ const env = envSchema.parse({
 	MOCK_GUILD_BETTING_CHAN_ID: process.env.MOCK_GUILD_BETTING_CHAN_ID,
 	DEV_GUILD_GAMES_CATEGORY_ID: process.env.DEV_GUILD_GAMES_CATEGORY_ID,
 	MOCK_GUILD_SPORT: process.env.MOCK_GUILD_SPORT || 'nba',
+	ANNOUNCE_PAYOUT_THRESHOLD: Number.parseFloat(
+		process.env.ANNOUNCE_PAYOUT_THRESHOLD || '100',
+	),
+	ANNOUNCE_MAX_PER_HOUR: Number.parseInt(
+		process.env.ANNOUNCE_MAX_PER_HOUR || '5',
+		10,
+	),
+	BIG_WIN_ANNOUNCEMENTS_ENABLED:
+		process.env.BIG_WIN_ANNOUNCEMENTS_ENABLED !== 'false',
 })
 
 // Debug logging for environment validation (redacts sensitive values)
@@ -145,6 +161,9 @@ if (shouldLogDebug) {
 		MOCK_GUILD_BETTING_CHAN_ID: env.MOCK_GUILD_BETTING_CHAN_ID,
 		DEV_GUILD_GAMES_CATEGORY_ID: env.DEV_GUILD_GAMES_CATEGORY_ID,
 		MOCK_GUILD_SPORT: env.MOCK_GUILD_SPORT,
+		ANNOUNCE_PAYOUT_THRESHOLD: env.ANNOUNCE_PAYOUT_THRESHOLD,
+		ANNOUNCE_MAX_PER_HOUR: env.ANNOUNCE_MAX_PER_HOUR,
+		BIG_WIN_ANNOUNCEMENTS_ENABLED: env.BIG_WIN_ANNOUNCEMENTS_ENABLED,
 		// Redacted sensitive fields
 		TOKEN: '[REDACTED]',
 		KH_API_TOKEN: '[REDACTED]',

--- a/src/lib/startup/pluto.ts
+++ b/src/lib/startup/pluto.ts
@@ -1,0 +1,82 @@
+import { configureSystemNotificationDelivery } from '../../utils/api/routes/notifications/delivery-queue.js'
+import { logger } from '../../utils/logging/WinstonLogger.js'
+import env, { isSystemStartupMode, type ParsedStartupEnv } from './env.js'
+
+interface StartupClient {
+	login(token: string): Promise<unknown>
+	destroy(): void
+	logger: {
+		fatal(error: unknown): unknown
+	}
+}
+
+export interface StartPlutoOptions {
+	client: StartupClient
+	env?: ParsedStartupEnv
+	initializeStartupServices?: () => Promise<void>
+	initializeSystemStartupServices?: () => Promise<void>
+	exitProcess?: (code: number) => never | void
+}
+
+async function initializeRedisBackedStartupServices() {
+	// These modules intentionally start Koa, Redis queues, and cron workers when
+	// loaded, so startup keeps the side-effect imports behind the explicit boot step.
+	await import('./cache.js')
+	await import('../../utils/api/Khronos/KhronosInstances.js')
+	await import('../../utils/api/koa/index.js')
+	await import('../../utils/cache/queue/ChannelCreationQueue.js')
+	await import('../../utils/cron/index.js')
+}
+
+export async function initializeStartupServices(
+	startupEnv: ParsedStartupEnv = env,
+) {
+	if (startupEnv.USE_MOCK_DATA) {
+		logger.info({
+			message:
+				'Mock data mode enabled; skipping Redis-backed startup services',
+			source: 'startup:mock-data',
+		})
+		return
+	}
+
+	await initializeRedisBackedStartupServices()
+}
+
+export async function initializeSystemStartupServices() {
+	configureSystemNotificationDelivery()
+	await initializeRedisBackedStartupServices()
+}
+
+export async function startPluto({
+	client,
+	env: startupEnv = env,
+	initializeStartupServices: initializeServices = () =>
+		initializeStartupServices(startupEnv),
+	initializeSystemStartupServices:
+		initializeSystemServices = initializeSystemStartupServices,
+	exitProcess = process.exit,
+}: StartPlutoOptions): Promise<void> {
+	try {
+		if (isSystemStartupMode(startupEnv)) {
+			await initializeSystemServices()
+			logger.info({
+				message:
+					'Pluto system mode is up without Discord gateway login',
+				source: 'startup:system',
+			})
+			return
+		}
+
+		await initializeServices()
+		await client.login(startupEnv.TOKEN)
+		logger.info('Pluto is up and running!')
+	} catch (error) {
+		logger.error({
+			message: 'Failed to login',
+		})
+		client.logger.fatal(error)
+		client.destroy()
+		exitProcess(1)
+	}
+}

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import {
 	ActionRowBuilder,
 	ButtonBuilder,
@@ -42,18 +43,36 @@ export interface AddParlayLegSelection {
 	side: ParlaySide
 }
 
-export const parlayBuilderKey = (userId: string): string =>
-	`parlay-builder:${userId}`
+export const parlayBuilderKey = (userId: string, guildId: string): string =>
+	`parlay-builder:${guildId}:${userId}`
+
+const parlayBuilderLockKey = (userId: string, guildId: string): string =>
+	`${parlayBuilderKey(userId, guildId)}:lock`
+
+const parlayBuilderPlacementKey = (userId: string, guildId: string): string =>
+	`${parlayBuilderKey(userId, guildId)}:placement`
+
+type BuilderCache = Pick<CacheManager, 'get' | 'set' | 'remove'> & {
+	setIfAbsent?: CacheManager['setIfAbsent']
+	compareAndRemove?: CacheManager['compareAndRemove']
+	refreshIfOwned?: CacheManager['refreshIfOwned']
+}
+
+const mutationQueues = new Map<string, Promise<unknown>>()
+const localPlacementReservations = new Map<string, string>()
 
 export class ParlayBuilderService {
 	constructor(
-		private readonly cache: CacheManager = new CacheManager(),
+		private readonly cache: BuilderCache = new CacheManager(),
 		private readonly matchCache = new MatchCacheService(new CacheManager()),
 		private readonly parlayApi = new ParlayApiWrapper(),
 	) {}
 
-	async get(userId: string): Promise<ParlayBuilderSession | null> {
-		const value = await this.cache.get(parlayBuilderKey(userId))
+	async get(
+		userId: string,
+		guildId: string,
+	): Promise<ParlayBuilderSession | null> {
+		const value = await this.cache.get(parlayBuilderKey(userId, guildId))
 		if (!value || typeof value !== 'object') return null
 		const session = value as Partial<ParlayBuilderSession>
 		if (!Array.isArray(session.legs)) return null
@@ -63,81 +82,258 @@ export class ParlayBuilderService {
 		}
 	}
 
-	async start(userId: string): Promise<ParlayBuilderSession> {
-		const session: ParlayBuilderSession = { legs: [], stake: null }
-		await this.save(userId, session)
-		return session
+	async start(
+		userId: string,
+		guildId: string,
+	): Promise<ParlayBuilderSession> {
+		return this.withSessionLock(userId, guildId, async () => {
+			await this.ensureNotReserved(userId, guildId)
+			const session: ParlayBuilderSession = { legs: [], stake: null }
+			await this.saveUnlocked(userId, guildId, session)
+			return session
+		})
 	}
 
-	async save(userId: string, session: ParlayBuilderSession): Promise<void> {
+	private async saveUnlocked(
+		userId: string,
+		guildId: string,
+		session: ParlayBuilderSession,
+	): Promise<void> {
 		await this.cache.set(
-			parlayBuilderKey(userId),
+			parlayBuilderKey(userId, guildId),
 			session,
 			PARLAY_BUILDER_TTL_SECONDS,
 		)
 	}
 
-	async clear(userId: string): Promise<void> {
-		await this.cache.remove(parlayBuilderKey(userId))
+	async clear(userId: string, guildId: string): Promise<void> {
+		await this.clearWithPlacementToken(userId, guildId)
+	}
+
+	async clearWithPlacementToken(
+		userId: string,
+		guildId: string,
+		placementToken?: string,
+	): Promise<void> {
+		await this.withSessionLock(userId, guildId, async () => {
+			const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+			const localOwner = localPlacementReservations.get(reservationKey)
+			if (localOwner && localOwner !== placementToken) {
+				throw new Error(
+					'Your parlay is already being placed. Please wait for the result.',
+				)
+			}
+			if (this.cache.setIfAbsent) {
+				const active = await this.cache.get(reservationKey)
+				if (
+					placementToken ? active !== placementToken : Boolean(active)
+				) {
+					throw new Error(
+						'Your parlay is already being placed. Please wait for the result.',
+					)
+				}
+			}
+			await this.cache.remove(parlayBuilderKey(userId, guildId))
+		})
 	}
 
 	async setStake(
 		userId: string,
+		guildId: string,
 		stake: number,
 	): Promise<ParlayBuilderSession> {
 		if (!Number.isSafeInteger(stake) || stake <= 0) {
 			throw new Error('Stake must be a whole number greater than $0.')
 		}
-		const session = await this.get(userId)
-		if (!session)
-			throw new Error(
-				'Your parlay builder expired. Run `/parlay` to start again.',
-			)
-		const updated = { ...session, stake }
-		await this.save(userId, updated)
-		return updated
+		return this.mutateSession(userId, guildId, (session) => ({
+			...session,
+			stake,
+		}))
 	}
 
 	async removeLeg(
 		userId: string,
+		guildId: string,
 		index: number,
 	): Promise<ParlayBuilderSession> {
-		const session = await this.get(userId)
-		if (!session)
-			throw new Error(
-				'Your parlay builder expired. Run `/parlay` to start again.',
-			)
-		if (index < 0 || index >= session.legs.length) {
-			throw new Error('That parlay leg is no longer available.')
-		}
-		const updated = {
-			...session,
-			legs: session.legs.filter((_, i) => i !== index),
-		}
-		await this.save(userId, updated)
-		return updated
+		return this.mutateSession(userId, guildId, (session) => {
+			if (index < 0 || index >= session.legs.length) {
+				throw new Error('That parlay leg is no longer available.')
+			}
+			return {
+				...session,
+				legs: session.legs.filter((_, i) => i !== index),
+			}
+		})
 	}
 
 	async addLeg(
 		userId: string,
+		guildId: string,
 		selection: AddParlayLegSelection,
 	): Promise<ParlayBuilderSession> {
-		const session = await this.get(userId)
-		if (!session)
-			throw new Error(
-				'Your parlay builder expired. Run `/parlay` to start again.',
-			)
-		if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
-			throw new Error('A parlay can contain at most 6 legs.')
-		}
-		if (session.legs.some((leg) => leg.event_id === selection.matchId)) {
-			throw new Error('Each parlay leg must use a different game.')
-		}
+		return this.mutateSession(userId, guildId, async (session) => {
+			if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
+				throw new Error('A parlay can contain at most 6 legs.')
+			}
+			if (
+				session.legs.some((item) => item.event_id === selection.matchId)
+			) {
+				throw new Error('Each parlay leg must use a different game.')
+			}
+			const leg = await this.resolveLeg(selection)
+			return { ...session, legs: [...session.legs, leg] }
+		})
+	}
 
-		const leg = await this.resolveLeg(selection)
-		const updated = { ...session, legs: [...session.legs, leg] }
-		await this.save(userId, updated)
-		return updated
+	/**
+	 * Reserve a builder before calling Khronos. The Redis NX boundary keeps
+	 * duplicate confirm interactions from placing the same wager twice.
+	 */
+	async reserveForPlacement(
+		userId: string,
+		guildId: string,
+	): Promise<{ session: ParlayBuilderSession; token: string } | null> {
+		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+		if (localPlacementReservations.has(reservationKey)) return null
+		const token = randomUUID()
+		localPlacementReservations.set(reservationKey, token)
+		let acquired = !this.cache.setIfAbsent
+		let sessionFound = false
+		try {
+			if (this.cache.setIfAbsent) {
+				acquired = await this.cache.setIfAbsent(
+					reservationKey,
+					token,
+					120,
+				)
+				if (!acquired) return null
+			}
+			const session = await this.get(userId, guildId)
+			if (!session) return null
+			sessionFound = true
+			return { session, token }
+		} finally {
+			if (!acquired || !sessionFound) {
+				await this.releasePlacement(userId, guildId, token)
+			}
+		}
+	}
+
+	async releasePlacement(
+		userId: string,
+		guildId: string,
+		token?: string,
+	): Promise<void> {
+		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+		if (token && this.cache.compareAndRemove) {
+			await this.cache.compareAndRemove(reservationKey, token)
+		} else {
+			await this.cache.remove(reservationKey)
+		}
+		if (
+			!token ||
+			localPlacementReservations.get(reservationKey) === token
+		) {
+			localPlacementReservations.delete(reservationKey)
+		}
+	}
+
+	async refreshPlacement(
+		userId: string,
+		guildId: string,
+		token: string,
+	): Promise<boolean> {
+		if (!this.cache.refreshIfOwned) return true
+		return this.cache.refreshIfOwned(
+			parlayBuilderPlacementKey(userId, guildId),
+			token,
+			120,
+		)
+	}
+
+	private async mutateSession(
+		userId: string,
+		guildId: string,
+		mutator: (
+			session: ParlayBuilderSession,
+		) => ParlayBuilderSession | Promise<ParlayBuilderSession>,
+	): Promise<ParlayBuilderSession> {
+		return this.withSessionLock(userId, guildId, async () => {
+			await this.ensureNotReserved(userId, guildId)
+			const session = await this.get(userId, guildId)
+			if (!session)
+				throw new Error(
+					'Your parlay builder expired. Run `/parlay` to start again.',
+				)
+			const updated = await mutator(session)
+			await this.saveUnlocked(userId, guildId, updated)
+			return updated
+		})
+	}
+
+	private async ensureNotReserved(
+		userId: string,
+		guildId: string,
+	): Promise<void> {
+		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+		if (localPlacementReservations.has(reservationKey)) {
+			throw new Error(
+				'Your parlay is already being placed. Please wait for the result.',
+			)
+		}
+		if (this.cache.setIfAbsent && (await this.cache.get(reservationKey))) {
+			throw new Error(
+				'Your parlay is already being placed. Please wait for the result.',
+			)
+		}
+	}
+
+	private async withSessionLock<T>(
+		userId: string,
+		guildId: string,
+		operation: () => Promise<T>,
+	): Promise<T> {
+		const scope = parlayBuilderKey(userId, guildId)
+		const previous = mutationQueues.get(scope) ?? Promise.resolve()
+		const current = previous
+			.catch(() => undefined)
+			.then(async () => {
+				const token = randomUUID()
+				const lockKey = parlayBuilderLockKey(userId, guildId)
+				let locked = false
+				if (this.cache.setIfAbsent) {
+					for (let attempt = 0; attempt < 40; attempt += 1) {
+						if (await this.cache.setIfAbsent(lockKey, token, 120)) {
+							locked = true
+							break
+						}
+						await new Promise((resolve) => setTimeout(resolve, 25))
+					}
+					if (!locked)
+						throw new Error(
+							'Your parlay builder is busy. Please try again in a moment.',
+						)
+				}
+				try {
+					return await operation()
+				} finally {
+					if (locked) {
+						if (this.cache.compareAndRemove) {
+							await this.cache.compareAndRemove(lockKey, token)
+						} else {
+							await this.cache.remove(lockKey)
+						}
+					}
+				}
+			})
+		mutationQueues.set(scope, current)
+		try {
+			return await current
+		} finally {
+			if (mutationQueues.get(scope) === current)
+				mutationQueues.delete(scope)
+		}
 	}
 
 	async resolveLeg(
@@ -155,9 +351,14 @@ export class ParlayBuilderService {
 				'That game has already started. Choose another game.',
 			)
 		}
+		if (!match.sport) {
+			throw new Error(
+				'That game is missing sport information. Please try again.',
+			)
+		}
 
 		const outcomes = await this.parlayApi.getEventOutcomes(
-			match.sport ?? 'nba',
+			match.sport,
 			match.id,
 		)
 		const marketOutcomes = outcomes.filter(

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -1,0 +1,367 @@
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ContainerBuilder,
+	type InteractionEditReplyOptions,
+	MessageFlags,
+	SectionBuilder,
+	SeparatorSpacingSize,
+} from 'discord.js'
+import ParlayApiWrapper, {
+	type EventOutcome,
+	type ParlayLegInput,
+	type ParlayMarketKey,
+} from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
+import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
+import { combineAmericanOdds } from '../utils/betting/american-odds.js'
+import { CacheManager } from '../utils/cache/cache-manager.js'
+import { logger } from '../utils/logging/WinstonLogger.js'
+
+export const PARLAY_BUILDER_TTL_SECONDS = 15 * 60
+export const PARLAY_BUILDER_MAX_LEGS = 6
+
+export interface ParlayBuilderLeg extends ParlayLegInput {
+	market_key: ParlayMarketKey
+	selection_display: string
+	odds_american: number
+	point: number | null
+	commence_time: string
+}
+
+export interface ParlayBuilderSession {
+	legs: ParlayBuilderLeg[]
+	stake: number | null
+}
+
+export type ParlaySide = 'home' | 'away' | 'over' | 'under'
+
+export interface AddParlayLegSelection {
+	matchId: string
+	marketKey: ParlayMarketKey
+	side: ParlaySide
+}
+
+export const parlayBuilderKey = (userId: string): string =>
+	`parlay-builder:${userId}`
+
+export class ParlayBuilderService {
+	constructor(
+		private readonly cache: CacheManager = new CacheManager(),
+		private readonly matchCache = new MatchCacheService(new CacheManager()),
+		private readonly parlayApi = new ParlayApiWrapper(),
+	) {}
+
+	async get(userId: string): Promise<ParlayBuilderSession | null> {
+		const value = await this.cache.get(parlayBuilderKey(userId))
+		if (!value || typeof value !== 'object') return null
+		const session = value as Partial<ParlayBuilderSession>
+		if (!Array.isArray(session.legs)) return null
+		return {
+			legs: session.legs as ParlayBuilderLeg[],
+			stake: typeof session.stake === 'number' ? session.stake : null,
+		}
+	}
+
+	async start(userId: string): Promise<ParlayBuilderSession> {
+		const session: ParlayBuilderSession = { legs: [], stake: null }
+		await this.save(userId, session)
+		return session
+	}
+
+	async save(userId: string, session: ParlayBuilderSession): Promise<void> {
+		await this.cache.set(
+			parlayBuilderKey(userId),
+			session,
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	}
+
+	async clear(userId: string): Promise<void> {
+		await this.cache.remove(parlayBuilderKey(userId))
+	}
+
+	async setStake(
+		userId: string,
+		stake: number,
+	): Promise<ParlayBuilderSession> {
+		if (!Number.isSafeInteger(stake) || stake <= 0) {
+			throw new Error('Stake must be a whole number greater than $0.')
+		}
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		const updated = { ...session, stake }
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async removeLeg(
+		userId: string,
+		index: number,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		if (index < 0 || index >= session.legs.length) {
+			throw new Error('That parlay leg is no longer available.')
+		}
+		const updated = {
+			...session,
+			legs: session.legs.filter((_, i) => i !== index),
+		}
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async addLeg(
+		userId: string,
+		selection: AddParlayLegSelection,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.get(userId)
+		if (!session)
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
+			throw new Error('A parlay can contain at most 6 legs.')
+		}
+		if (session.legs.some((leg) => leg.event_id === selection.matchId)) {
+			throw new Error('Each parlay leg must use a different game.')
+		}
+
+		const leg = await this.resolveLeg(selection)
+		const updated = { ...session, legs: [...session.legs, leg] }
+		await this.save(userId, updated)
+		return updated
+	}
+
+	async resolveLeg(
+		selection: AddParlayLegSelection,
+	): Promise<ParlayBuilderLeg> {
+		const match = await this.matchCache.getMatch(selection.matchId)
+		if (!match?.id || !match.home_team || !match.away_team) {
+			throw new Error('Choose a valid upcoming game from the list.')
+		}
+		if (
+			match.commence_time &&
+			new Date(match.commence_time).getTime() <= Date.now()
+		) {
+			throw new Error(
+				'That game has already started. Choose another game.',
+			)
+		}
+
+		const outcomes = await this.parlayApi.getEventOutcomes(
+			match.sport ?? 'nba',
+			match.id,
+		)
+		const marketOutcomes = outcomes.filter(
+			(outcome) => outcome.market_key === selection.marketKey,
+		)
+		const outcome = this.selectOutcome(
+			marketOutcomes,
+			selection.side,
+			match.home_team,
+			match.away_team,
+		)
+		if (!outcome?.uuid || outcome.price === undefined) {
+			throw new Error(
+				'That selection is no longer available. Try another leg.',
+			)
+		}
+
+		const selectionDisplay = this.selectionDisplay(
+			selection.marketKey,
+			selection.side,
+			match.home_team,
+			match.away_team,
+			outcome.point,
+		)
+		return {
+			event_id: match.id,
+			outcome_uuid: outcome.uuid,
+			market_key: selection.marketKey,
+			selection_display: selectionDisplay,
+			odds_american: outcome.price,
+			point: outcome.point ?? null,
+			commence_time: match.commence_time ?? new Date().toISOString(),
+		}
+	}
+
+	private selectOutcome(
+		outcomes: EventOutcome[],
+		side: ParlaySide,
+		homeTeam: string,
+		awayTeam: string,
+	): EventOutcome | undefined {
+		return outcomes.find((outcome) => {
+			const name = outcome.name?.trim().toLowerCase()
+			const position = outcome.position?.toLowerCase()
+			const outcomeType = outcome.outcome_type?.toLowerCase()
+			if (side === 'over' || side === 'under') {
+				return name === side || outcomeType === side
+			}
+			const team = side === 'home' ? homeTeam : awayTeam
+			return (
+				name === team.toLowerCase() ||
+				position === side ||
+				outcomeType === `team_${side}`
+			)
+		})
+	}
+
+	private selectionDisplay(
+		market: ParlayMarketKey,
+		side: ParlaySide,
+		homeTeam: string,
+		awayTeam: string,
+		point?: number | null,
+	): string {
+		if (market === 'totals')
+			return `${side === 'over' ? 'Over' : 'Under'}${point === undefined || point === null ? '' : ` ${point}`}`
+		const team = side === 'home' ? homeTeam : awayTeam
+		return market === 'spreads' && point !== undefined && point !== null
+			? `${team} ${point > 0 ? '+' : ''}${point}`
+			: team
+	}
+
+	validateForPlacement(session: ParlayBuilderSession): void {
+		if (session.legs.length < 2) {
+			throw new Error('Add at least 2 different games before confirming.')
+		}
+		if (session.legs.length > PARLAY_BUILDER_MAX_LEGS) {
+			throw new Error('A parlay can contain at most 6 legs.')
+		}
+		if (!session.stake)
+			throw new Error('Set a stake before confirming your parlay.')
+	}
+
+	getOddsSummary(session: ParlayBuilderSession): {
+		american: number
+		decimal: number
+		potentialPayout: number | null
+	} {
+		if (session.legs.length === 0) {
+			return { american: 0, decimal: 1, potentialPayout: null }
+		}
+		const combined = combineAmericanOdds(
+			session.legs.map((leg) => leg.odds_american),
+		)
+		return {
+			...combined,
+			potentialPayout:
+				session.stake === null
+					? null
+					: Math.round(session.stake * combined.decimal * 100) / 100,
+		}
+	}
+
+	render(session: ParlayBuilderSession): InteractionEditReplyOptions {
+		const summary = this.getOddsSummary(session)
+		const container = new ContainerBuilder().setAccentColor(0x5865f2)
+		container.addTextDisplayComponents((text) =>
+			text.setContent('## 🎲 Build your parlay'),
+		)
+		if (session.legs.length === 0) {
+			container.addTextDisplayComponents((text) =>
+				text.setContent(
+					'Add 2–6 legs from different upcoming games to get started.',
+				),
+			)
+		}
+		for (const [index, leg] of session.legs.entries()) {
+			const section = new SectionBuilder()
+				.addTextDisplayComponents((text) =>
+					text.setContent(
+						`**${index + 1}. ${leg.selection_display}**\n${leg.market_key} • ${leg.odds_american > 0 ? '+' : ''}${leg.odds_american} • <t:${Math.floor(new Date(leg.commence_time).getTime() / 1000)}:f>`,
+					),
+				)
+				.setButtonAccessory(
+					new ButtonBuilder()
+						.setCustomId(`parlay_btn_remove_${index}`)
+						.setLabel('Remove')
+						.setStyle(ButtonStyle.Danger),
+				)
+			container.addSectionComponents(section)
+		}
+		container.addSeparatorComponents((separator) =>
+			separator.setDivider(true).setSpacing(SeparatorSpacingSize.Small),
+		)
+		const payoutText =
+			summary.potentialPayout === null
+				? 'Set a stake to calculate potential payout.'
+				: `Potential payout: **$${summary.potentialPayout.toFixed(2)}**`
+		container.addTextDisplayComponents((text) =>
+			text.setContent(
+				`Combined odds: **${summary.american > 0 ? '+' : ''}${summary.american || '—'}** (${summary.decimal.toFixed(2)}x)\nStake: **${session.stake === null ? 'Not set' : `$${session.stake.toFixed(2)}`}**\n${payoutText}`,
+			),
+		)
+		container.addActionRowComponents((row) =>
+			row.addComponents(
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_add')
+					.setLabel('Add Leg')
+					.setStyle(ButtonStyle.Primary),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_stake')
+					.setLabel('Set Stake')
+					.setStyle(ButtonStyle.Secondary),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_confirm')
+					.setLabel('Confirm')
+					.setStyle(ButtonStyle.Success)
+					.setDisabled(
+						session.legs.length < 2 || session.stake === null,
+					),
+				new ButtonBuilder()
+					.setCustomId('parlay_btn_cancel')
+					.setLabel('Cancel')
+					.setStyle(ButtonStyle.Danger),
+			),
+		)
+		return { components: [container], flags: MessageFlags.IsComponentsV2 }
+	}
+
+	renderMessage(
+		content: string,
+		color = 0xed4245,
+	): InteractionEditReplyOptions {
+		const container = new ContainerBuilder()
+			.setAccentColor(color)
+			.addTextDisplayComponents((text) => text.setContent(content))
+		return { components: [container], flags: MessageFlags.IsComponentsV2 }
+	}
+}
+
+export function logParlayBuilderError(
+	error: unknown,
+	metadata: Record<string, unknown>,
+): void {
+	logger.error('parlay_builder_error', {
+		...metadata,
+		error: error instanceof Error ? error.message : String(error),
+	})
+}
+
+export function getParlayErrorMessage(error: unknown): string {
+	const responseData = (error as { response?: { data?: unknown } })?.response
+		?.data
+	if (typeof responseData === 'object' && responseData !== null) {
+		const message = (responseData as { message?: unknown }).message
+		if (typeof message === 'string') return message
+		if (
+			Array.isArray(message) &&
+			message.every((item) => typeof item === 'string')
+		) {
+			return message.join(', ')
+		}
+	}
+	return error instanceof Error
+		? error.message
+		: 'Unable to process your parlay.'
+}

--- a/src/services/ParlayBuilderService.ts
+++ b/src/services/ParlayBuilderService.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { randomBytes, randomUUID } from 'node:crypto'
 import {
 	ActionRowBuilder,
 	ButtonBuilder,
@@ -13,6 +13,7 @@ import ParlayApiWrapper, {
 	type EventOutcome,
 	type ParlayLegInput,
 	type ParlayMarketKey,
+	type ParlayResponse,
 } from '../utils/api/Khronos/parlays/ParlayApiWrapper.js'
 import MatchCacheService from '../utils/api/routes/cache/match-cache-service.js'
 import { combineAmericanOdds } from '../utils/betting/american-odds.js'
@@ -31,8 +32,107 @@ export interface ParlayBuilderLeg extends ParlayLegInput {
 }
 
 export interface ParlayBuilderSession {
+	sessionId: string
+	revision: number
 	legs: ParlayBuilderLeg[]
 	stake: number | null
+	placementId: string
+	placementPhase: ParlayPlacementPhase
+	lastPlacementResponse: ParlayResponse | null
+}
+
+export type ParlayPlacementPhase = 'editing' | 'placing' | 'placed' | 'unknown'
+
+export type ParlayBuilderIdentity = Pick<
+	ParlayBuilderSession,
+	'sessionId' | 'revision'
+>
+
+export type ParlayButtonAction =
+	| 'add'
+	| 'stake'
+	| 'confirm'
+	| 'cancel'
+	| 'remove'
+
+export type ParlayModalKind = 'add-leg' | 'stake'
+
+export const STALE_PARLAY_BUILDER_MESSAGE =
+	'This parlay builder is no longer current. Use the latest builder or run `/parlay` again.'
+
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{12}$/
+const PLACEMENT_ID_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const BUTTON_ID_PATTERN =
+	/^parlay\.btn\.([A-Za-z0-9_-]{12})\.(0|[1-9]\d*)\.(add|stake|confirm|cancel|remove)(?:\.(0|[1-9]\d*))?$/
+const MODAL_ID_PATTERN =
+	/^parlay\.modal\.([A-Za-z0-9_-]{12})\.(0|[1-9]\d*)\.(add-leg|stake)$/
+
+function isPlacementPhase(value: unknown): value is ParlayPlacementPhase {
+	return (
+		value === 'editing' ||
+		value === 'placing' ||
+		value === 'placed' ||
+		value === 'unknown'
+	)
+}
+
+export function parlayIdentity(
+	session: ParlayBuilderSession,
+): ParlayBuilderIdentity {
+	return { sessionId: session.sessionId, revision: session.revision }
+}
+
+export function buildParlayButtonId(
+	identity: ParlayBuilderIdentity,
+	action: ParlayButtonAction,
+	index?: number,
+): string {
+	if (action === 'remove') {
+		if (!Number.isSafeInteger(index) || Number(index) < 0) {
+			throw new Error('Remove controls require a nonnegative leg index.')
+		}
+		return `parlay.btn.${identity.sessionId}.${identity.revision}.${action}.${index}`
+	}
+	return `parlay.btn.${identity.sessionId}.${identity.revision}.${action}`
+}
+
+export function parseParlayButtonId(customId: string):
+	| (ParlayBuilderIdentity & {
+			action: ParlayButtonAction
+			index?: number
+	  })
+	| null {
+	const match = BUTTON_ID_PATTERN.exec(customId)
+	if (!match) return null
+	const action = match[3] as ParlayButtonAction
+	const index = match[4] === undefined ? undefined : Number(match[4])
+	if ((action === 'remove') !== (index !== undefined)) return null
+	return {
+		sessionId: match[1],
+		revision: Number(match[2]),
+		action,
+		...(index === undefined ? {} : { index }),
+	}
+}
+
+export function buildParlayModalId(
+	identity: ParlayBuilderIdentity,
+	kind: ParlayModalKind,
+): string {
+	return `parlay.modal.${identity.sessionId}.${identity.revision}.${kind}`
+}
+
+export function parseParlayModalId(
+	customId: string,
+): (ParlayBuilderIdentity & { kind: ParlayModalKind }) | null {
+	const match = MODAL_ID_PATTERN.exec(customId)
+	if (!match) return null
+	return {
+		sessionId: match[1],
+		revision: Number(match[2]),
+		kind: match[3] as ParlayModalKind,
+	}
 }
 
 export type ParlaySide = 'home' | 'away' | 'over' | 'under'
@@ -75,10 +175,27 @@ export class ParlayBuilderService {
 		const value = await this.cache.get(parlayBuilderKey(userId, guildId))
 		if (!value || typeof value !== 'object') return null
 		const session = value as Partial<ParlayBuilderSession>
-		if (!Array.isArray(session.legs)) return null
+		if (
+			!SESSION_ID_PATTERN.test(session.sessionId ?? '') ||
+			!Number.isSafeInteger(session.revision) ||
+			Number(session.revision) < 0 ||
+			!Array.isArray(session.legs) ||
+			!PLACEMENT_ID_PATTERN.test(session.placementId ?? '') ||
+			!isPlacementPhase(session.placementPhase) ||
+			(session.lastPlacementResponse !== null &&
+				typeof session.lastPlacementResponse !== 'object')
+		) {
+			return null
+		}
 		return {
+			sessionId: session.sessionId!,
+			revision: session.revision!,
 			legs: session.legs as ParlayBuilderLeg[],
 			stake: typeof session.stake === 'number' ? session.stake : null,
+			placementId: session.placementId!,
+			placementPhase: session.placementPhase!,
+			lastPlacementResponse:
+				session.lastPlacementResponse as ParlayResponse | null,
 		}
 	}
 
@@ -88,7 +205,15 @@ export class ParlayBuilderService {
 	): Promise<ParlayBuilderSession> {
 		return this.withSessionLock(userId, guildId, async () => {
 			await this.ensureNotReserved(userId, guildId)
-			const session: ParlayBuilderSession = { legs: [], stake: null }
+			const session: ParlayBuilderSession = {
+				sessionId: randomBytes(9).toString('base64url'),
+				revision: 0,
+				legs: [],
+				stake: null,
+				placementId: randomUUID(),
+				placementPhase: 'editing',
+				lastPlacementResponse: null,
+			}
 			await this.saveUnlocked(userId, guildId, session)
 			return session
 		})
@@ -106,8 +231,17 @@ export class ParlayBuilderService {
 		)
 	}
 
-	async clear(userId: string, guildId: string): Promise<void> {
-		await this.clearWithPlacementToken(userId, guildId)
+	async clear(
+		userId: string,
+		guildId: string,
+		expected: ParlayBuilderIdentity,
+	): Promise<void> {
+		await this.withSessionLock(userId, guildId, async () => {
+			await this.ensureNotReserved(userId, guildId)
+			const session = await this.requireSession(userId, guildId)
+			this.assertIdentity(session, expected)
+			await this.cache.remove(parlayBuilderKey(userId, guildId))
+		})
 	}
 
 	async clearWithPlacementToken(
@@ -140,12 +274,13 @@ export class ParlayBuilderService {
 	async setStake(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 		stake: number,
 	): Promise<ParlayBuilderSession> {
 		if (!Number.isSafeInteger(stake) || stake <= 0) {
 			throw new Error('Stake must be a whole number greater than $0.')
 		}
-		return this.mutateSession(userId, guildId, (session) => ({
+		return this.mutateSession(userId, guildId, expected, (session) => ({
 			...session,
 			stake,
 		}))
@@ -154,9 +289,10 @@ export class ParlayBuilderService {
 	async removeLeg(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 		index: number,
 	): Promise<ParlayBuilderSession> {
-		return this.mutateSession(userId, guildId, (session) => {
+		return this.mutateSession(userId, guildId, expected, (session) => {
 			if (index < 0 || index >= session.legs.length) {
 				throw new Error('That parlay leg is no longer available.')
 			}
@@ -170,20 +306,30 @@ export class ParlayBuilderService {
 	async addLeg(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 		selection: AddParlayLegSelection,
 	): Promise<ParlayBuilderSession> {
-		return this.mutateSession(userId, guildId, async (session) => {
-			if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
-				throw new Error('A parlay can contain at most 6 legs.')
-			}
-			if (
-				session.legs.some((item) => item.event_id === selection.matchId)
-			) {
-				throw new Error('Each parlay leg must use a different game.')
-			}
-			const leg = await this.resolveLeg(selection)
-			return { ...session, legs: [...session.legs, leg] }
-		})
+		return this.mutateSession(
+			userId,
+			guildId,
+			expected,
+			async (session) => {
+				if (session.legs.length >= PARLAY_BUILDER_MAX_LEGS) {
+					throw new Error('A parlay can contain at most 6 legs.')
+				}
+				if (
+					session.legs.some(
+						(item) => item.event_id === selection.matchId,
+					)
+				) {
+					throw new Error(
+						'Each parlay leg must use a different game.',
+					)
+				}
+				const leg = await this.resolveLeg(selection)
+				return { ...session, legs: [...session.legs, leg] }
+			},
+		)
 	}
 
 	/**
@@ -193,31 +339,70 @@ export class ParlayBuilderService {
 	async reserveForPlacement(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 	): Promise<{ session: ParlayBuilderSession; token: string } | null> {
-		const reservationKey = parlayBuilderPlacementKey(userId, guildId)
-		if (localPlacementReservations.has(reservationKey)) return null
-		const token = randomUUID()
-		localPlacementReservations.set(reservationKey, token)
-		let acquired = !this.cache.setIfAbsent
-		let sessionFound = false
-		try {
-			if (this.cache.setIfAbsent) {
-				acquired = await this.cache.setIfAbsent(
-					reservationKey,
-					token,
-					120,
-				)
-				if (!acquired) return null
+		return this.withSessionLock(userId, guildId, async () => {
+			const reservationKey = parlayBuilderPlacementKey(userId, guildId)
+			if (localPlacementReservations.has(reservationKey)) return null
+			const session = await this.requireSession(userId, guildId)
+			this.assertIdentity(session, expected)
+			if (session.placementPhase !== 'editing') return null
+			const token = randomUUID()
+			localPlacementReservations.set(reservationKey, token)
+			let acquired = !this.cache.setIfAbsent
+			let reserved = false
+			try {
+				if (this.cache.setIfAbsent) {
+					acquired = await this.cache.setIfAbsent(
+						reservationKey,
+						token,
+						120,
+					)
+					if (!acquired) return null
+				}
+				const placingSession: ParlayBuilderSession = {
+					...session,
+					placementPhase: 'placing',
+				}
+				await this.saveUnlocked(userId, guildId, placingSession)
+				reserved = true
+				return { session: placingSession, token }
+			} finally {
+				if (!reserved) {
+					await this.releasePlacement(userId, guildId, token)
+				}
 			}
-			const session = await this.get(userId, guildId)
-			if (!session) return null
-			sessionFound = true
-			return { session, token }
-		} finally {
-			if (!acquired || !sessionFound) {
-				await this.releasePlacement(userId, guildId, token)
+		})
+	}
+
+	async setPlacementState(
+		userId: string,
+		guildId: string,
+		expected: ParlayBuilderIdentity,
+		placementPhase: ParlayPlacementPhase,
+		lastPlacementResponse: ParlayResponse | null = null,
+	): Promise<ParlayBuilderSession> {
+		return this.withSessionLock(userId, guildId, async () => {
+			const session = await this.requireSession(userId, guildId)
+			this.assertIdentity(session, expected)
+			const updated: ParlayBuilderSession = {
+				...session,
+				placementPhase,
+				lastPlacementResponse,
 			}
-		}
+			await this.saveUnlocked(userId, guildId, updated)
+			return updated
+		})
+	}
+
+	async assertCurrent(
+		userId: string,
+		guildId: string,
+		expected: ParlayBuilderIdentity,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.requireSession(userId, guildId)
+		this.assertIdentity(session, expected)
+		return session
 	}
 
 	async releasePlacement(
@@ -255,21 +440,49 @@ export class ParlayBuilderService {
 	private async mutateSession(
 		userId: string,
 		guildId: string,
+		expected: ParlayBuilderIdentity,
 		mutator: (
 			session: ParlayBuilderSession,
 		) => ParlayBuilderSession | Promise<ParlayBuilderSession>,
 	): Promise<ParlayBuilderSession> {
 		return this.withSessionLock(userId, guildId, async () => {
 			await this.ensureNotReserved(userId, guildId)
-			const session = await this.get(userId, guildId)
-			if (!session)
-				throw new Error(
-					'Your parlay builder expired. Run `/parlay` to start again.',
-				)
+			const session = await this.requireSession(userId, guildId)
+			this.assertIdentity(session, expected)
 			const updated = await mutator(session)
-			await this.saveUnlocked(userId, guildId, updated)
-			return updated
+			const versioned: ParlayBuilderSession = {
+				...updated,
+				sessionId: session.sessionId,
+				revision: session.revision + 1,
+			}
+			await this.saveUnlocked(userId, guildId, versioned)
+			return versioned
 		})
+	}
+
+	private async requireSession(
+		userId: string,
+		guildId: string,
+	): Promise<ParlayBuilderSession> {
+		const session = await this.get(userId, guildId)
+		if (!session) {
+			throw new Error(
+				'Your parlay builder expired. Run `/parlay` to start again.',
+			)
+		}
+		return session
+	}
+
+	private assertIdentity(
+		session: ParlayBuilderSession,
+		expected: ParlayBuilderIdentity,
+	): void {
+		if (
+			session.sessionId !== expected.sessionId ||
+			session.revision !== expected.revision
+		) {
+			throw new Error(STALE_PARLAY_BUILDER_MESSAGE)
+		}
 	}
 
 	private async ensureNotReserved(
@@ -484,7 +697,9 @@ export class ParlayBuilderService {
 				)
 				.setButtonAccessory(
 					new ButtonBuilder()
-						.setCustomId(`parlay_btn_remove_${index}`)
+						.setCustomId(
+							buildParlayButtonId(session, 'remove', index),
+						)
 						.setLabel('Remove')
 						.setStyle(ButtonStyle.Danger),
 				)
@@ -505,22 +720,22 @@ export class ParlayBuilderService {
 		container.addActionRowComponents((row) =>
 			row.addComponents(
 				new ButtonBuilder()
-					.setCustomId('parlay_btn_add')
+					.setCustomId(buildParlayButtonId(session, 'add'))
 					.setLabel('Add Leg')
 					.setStyle(ButtonStyle.Primary),
 				new ButtonBuilder()
-					.setCustomId('parlay_btn_stake')
+					.setCustomId(buildParlayButtonId(session, 'stake'))
 					.setLabel('Set Stake')
 					.setStyle(ButtonStyle.Secondary),
 				new ButtonBuilder()
-					.setCustomId('parlay_btn_confirm')
+					.setCustomId(buildParlayButtonId(session, 'confirm'))
 					.setLabel('Confirm')
 					.setStyle(ButtonStyle.Success)
 					.setDisabled(
 						session.legs.length < 2 || session.stake === null,
 					),
 				new ButtonBuilder()
-					.setCustomId('parlay_btn_cancel')
+					.setCustomId(buildParlayButtonId(session, 'cancel'))
 					.setLabel('Cancel')
 					.setStyle(ButtonStyle.Danger),
 			),

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -21,8 +21,12 @@ vi.mock('../../utils/cache/cache-manager.js', () => ({
 }))
 
 const {
+	buildParlayButtonId,
+	buildParlayModalId,
 	PARLAY_BUILDER_MAX_LEGS,
 	PARLAY_BUILDER_TTL_SECONDS,
+	parseParlayButtonId,
+	parseParlayModalId,
 	ParlayBuilderService,
 } = await import('../ParlayBuilderService.js')
 
@@ -41,7 +45,9 @@ const makeCache = (): CacheStub => ({
 	remove: vi.fn().mockResolvedValue(true),
 })
 
-const makeSession = (legs = 0) => ({
+const makeSession = (legs = 0, revision = 0) => ({
+	sessionId: 'sessionA0001',
+	revision,
 	legs: Array.from({ length: legs }, (_, index) => ({
 		event_id: `event-${index}`,
 		outcome_uuid: `outcome-${index}`,
@@ -52,7 +58,31 @@ const makeSession = (legs = 0) => ({
 		commence_time: '2099-01-01T00:00:00.000Z',
 	})),
 	stake: null,
+	placementId: '00000000-0000-4000-8000-000000000001',
+	placementPhase: 'editing' as const,
+	lastPlacementResponse: null,
 })
+
+const identityOf = (session: ReturnType<typeof makeSession>) => ({
+	sessionId: session.sessionId,
+	revision: session.revision,
+})
+
+const useStatefulSessionCache = (cache: CacheStub) => {
+	const values = new Map<string, unknown>()
+	cache.get.mockImplementation((key: string) =>
+		Promise.resolve(values.get(key)),
+	)
+	cache.set.mockImplementation((key: string, value: unknown) => {
+		values.set(key, structuredClone(value))
+		return Promise.resolve(true)
+	})
+	cache.remove.mockImplementation((key: string) => {
+		values.delete(key)
+		return Promise.resolve(true)
+	})
+	return values
+}
 
 describe('ParlayBuilderService', () => {
 	let cache: CacheStub
@@ -71,29 +101,144 @@ describe('ParlayBuilderService', () => {
 		)
 	})
 
-	it('stores one user session with the 15 minute TTL', async () => {
-		await service.start('user-1', 'guild-1')
+	it('stores one versioned user session with the 15 minute TTL', async () => {
+		const session = await service.start('user-1', 'guild-1')
 
 		expect(cache.set).toHaveBeenCalledWith(
 			'parlay-builder:guild-1:user-1',
-			{ legs: [], stake: null },
+			{
+				sessionId: expect.stringMatching(/^[A-Za-z0-9_-]{12}$/),
+				revision: 0,
+				legs: [],
+				stake: null,
+				placementId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
+				placementPhase: 'editing',
+				lastPlacementResponse: null,
+			},
 			PARLAY_BUILDER_TTL_SECONDS,
+		)
+		expect(session.revision).toBe(0)
+	})
+
+	it('persists one stable placement identity for the builder lifecycle', async () => {
+		const session = await service.start('user-1', 'guild-1')
+
+		expect(session).toMatchObject({
+			placementPhase: 'editing',
+			lastPlacementResponse: null,
+		})
+		expect(session.placementId).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
 		)
 	})
 
-	it('rejects duplicate events and the seventh leg', async () => {
-		cache.get.mockResolvedValue(makeSession(1))
+	it('replaces the previous builder identity and expires legacy sessions', async () => {
+		const values = useStatefulSessionCache(cache)
+		const first = await service.start('user-1', 'guild-1')
+		const second = await service.start('user-1', 'guild-1')
+
+		expect(second.sessionId).not.toBe(first.sessionId)
+		values.set('parlay-builder:guild-2:user-2', { legs: [], stake: null })
+		await expect(service.get('user-2', 'guild-2')).resolves.toBeNull()
+	})
+
+	it('rejects a stale identity without mutating the replacement builder', async () => {
+		const values = useStatefulSessionCache(cache)
+		const current = makeSession(2, 4)
+		values.set('parlay-builder:guild-1:user-1', current)
+
 		await expect(
-			service.addLeg('user-1', 'guild-1', {
+			service.setStake(
+				'user-1',
+				'guild-1',
+				{ sessionId: 'sessionOLD01', revision: 3 },
+				25,
+			),
+		).rejects.toThrow('no longer current')
+		expect(values.get('parlay-builder:guild-1:user-1')).toEqual(current)
+	})
+
+	it('rejects stale cancel and confirm actions before any side effect', async () => {
+		const values = useStatefulSessionCache(cache)
+		const current = { ...makeSession(2, 4), stake: 10 }
+		const stale = { sessionId: current.sessionId, revision: 3 }
+		values.set('parlay-builder:guild-1:user-1', current)
+		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
+
+		await expect(service.clear('user-1', 'guild-1', stale)).rejects.toThrow(
+			'no longer current',
+		)
+		await expect(
+			service.reserveForPlacement('user-1', 'guild-1', stale),
+		).rejects.toThrow('no longer current')
+
+		expect(values.get('parlay-builder:guild-1:user-1')).toEqual(current)
+		expect(
+			cache.setIfAbsent.mock.calls.some(([key]) =>
+				String(key).endsWith(':placement'),
+			),
+		).toBe(false)
+	})
+
+	it('allows only one concurrent mutation from the same revision', async () => {
+		const values = useStatefulSessionCache(cache)
+		const current = makeSession(2)
+		values.set('parlay-builder:guild-1:user-1', current)
+
+		const results = await Promise.allSettled([
+			service.setStake('user-1', 'guild-1', identityOf(current), 10),
+			service.setStake('user-1', 'guild-1', identityOf(current), 20),
+		])
+
+		expect(
+			results.filter((result) => result.status === 'fulfilled'),
+		).toHaveLength(1)
+		expect(
+			results.filter((result) => result.status === 'rejected'),
+		).toHaveLength(1)
+		expect(values.get('parlay-builder:guild-1:user-1')).toMatchObject({
+			sessionId: current.sessionId,
+			revision: 1,
+		})
+	})
+
+	it('does not let an old remove-index control target a revised leg list', async () => {
+		const values = useStatefulSessionCache(cache)
+		const original = makeSession(3)
+		values.set('parlay-builder:guild-1:user-1', original)
+
+		const revised = await service.removeLeg(
+			'user-1',
+			'guild-1',
+			identityOf(original),
+			0,
+		)
+		await expect(
+			service.removeLeg('user-1', 'guild-1', identityOf(original), 1),
+		).rejects.toThrow('no longer current')
+
+		expect(values.get('parlay-builder:guild-1:user-1')).toEqual(revised)
+		expect(revised.legs.map((leg) => leg.event_id)).toEqual([
+			'event-1',
+			'event-2',
+		])
+	})
+
+	it('rejects duplicate events and the seventh leg', async () => {
+		const oneLeg = makeSession(1)
+		cache.get.mockResolvedValue(oneLeg)
+		await expect(
+			service.addLeg('user-1', 'guild-1', identityOf(oneLeg), {
 				matchId: 'event-0',
 				marketKey: 'h2h',
 				side: 'home',
 			}),
 		).rejects.toThrow('different game')
 
-		cache.get.mockResolvedValue(makeSession(PARLAY_BUILDER_MAX_LEGS))
+		const maxLegs = makeSession(PARLAY_BUILDER_MAX_LEGS)
+		cache.get.mockResolvedValue(maxLegs)
 		await expect(
-			service.addLeg('user-1', 'guild-1', {
+			service.addLeg('user-1', 'guild-1', identityOf(maxLegs), {
 				matchId: 'event-new',
 				marketKey: 'h2h',
 				side: 'home',
@@ -102,7 +247,8 @@ describe('ParlayBuilderService', () => {
 	})
 
 	it('resolves a home moneyline outcome from Khronos', async () => {
-		cache.get.mockResolvedValue(makeSession())
+		const session = makeSession()
+		cache.get.mockResolvedValue(session)
 		matchCache.getMatch.mockResolvedValue({
 			id: 'event-1',
 			home_team: 'Home Team',
@@ -119,11 +265,16 @@ describe('ParlayBuilderService', () => {
 			},
 		])
 
-		const result = await service.addLeg('user-1', 'guild-1', {
-			matchId: 'event-1',
-			marketKey: 'h2h',
-			side: 'home',
-		})
+		const result = await service.addLeg(
+			'user-1',
+			'guild-1',
+			identityOf(session),
+			{
+				matchId: 'event-1',
+				marketKey: 'h2h',
+				side: 'home',
+			},
+		)
 
 		expect(result.legs[0]).toMatchObject({
 			event_id: 'event-1',
@@ -139,7 +290,8 @@ describe('ParlayBuilderService', () => {
 	})
 
 	it('rejects matches without sport metadata instead of defaulting to NBA', async () => {
-		cache.get.mockResolvedValue(makeSession())
+		const session = makeSession()
+		cache.get.mockResolvedValue(session)
 		matchCache.getMatch.mockResolvedValue({
 			id: 'event-no-sport',
 			home_team: 'Home Team',
@@ -148,7 +300,7 @@ describe('ParlayBuilderService', () => {
 		})
 
 		await expect(
-			service.addLeg('user-1', 'guild-1', {
+			service.addLeg('user-1', 'guild-1', identityOf(session), {
 				matchId: 'event-no-sport',
 				marketKey: 'h2h',
 				side: 'home',
@@ -158,17 +310,30 @@ describe('ParlayBuilderService', () => {
 	})
 
 	it('reserves a session so concurrent confirmation can only place once', async () => {
-		cache.get.mockResolvedValue({ ...makeSession(2), stake: 10 })
+		const session = { ...makeSession(2), stake: 10 }
+		cache.get.mockResolvedValue(session)
 		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
 		cache.compareAndRemove = vi.fn().mockResolvedValue(true)
 
-		const first = await service.reserveForPlacement('user-1', 'guild-1')
-		const second = await service.reserveForPlacement('user-1', 'guild-1')
+		const first = await service.reserveForPlacement(
+			'user-1',
+			'guild-1',
+			identityOf(session),
+		)
+		const second = await service.reserveForPlacement(
+			'user-1',
+			'guild-1',
+			identityOf(session),
+		)
 
 		expect(first).not.toBeNull()
 		expect(second).toBeNull()
 		await service.releasePlacement('user-1', 'guild-1', first?.token)
-		const third = await service.reserveForPlacement('user-1', 'guild-1')
+		const third = await service.reserveForPlacement(
+			'user-1',
+			'guild-1',
+			identityOf(session),
+		)
 		expect(third).not.toBeNull()
 		await service.releasePlacement('user-1', 'guild-1', third?.token)
 	})
@@ -181,9 +346,9 @@ describe('ParlayBuilderService', () => {
 				: Promise.resolve({ ...makeSession(2), stake: 10 }),
 		)
 
-		await expect(service.clear('user-1', 'guild-1')).rejects.toThrow(
-			'already being placed',
-		)
+		await expect(
+			service.clear('user-1', 'guild-1', identityOf(makeSession(2))),
+		).rejects.toThrow('already being placed')
 		expect(cache.remove).not.toHaveBeenCalledWith(
 			'parlay-builder:guild-1:user-1',
 		)
@@ -236,13 +401,39 @@ describe('ParlayBuilderService', () => {
 		).toThrow('Set a stake')
 	})
 
-	it('renders a Components V2 card with per-leg remove controls', () => {
-		const response = service.render({ ...makeSession(2), stake: 10 })
+	it('renders a Components V2 card with versioned controls', () => {
+		const session = { ...makeSession(2, 7), stake: 10 }
+		const response = service.render(session)
 		const container = response.components?.[0]
 		const json = (container as { toJSON: () => unknown }).toJSON()
 
 		expect(response.flags).toBeDefined()
-		expect(JSON.stringify(json)).toContain('parlay_btn_remove_0')
-		expect(JSON.stringify(json)).toContain('parlay_btn_confirm')
+		expect(JSON.stringify(json)).toContain(
+			'parlay.btn.sessionA0001.7.remove.0',
+		)
+		expect(JSON.stringify(json)).toContain(
+			'parlay.btn.sessionA0001.7.confirm',
+		)
+	})
+
+	it('round-trips only well-formed versioned control identities', () => {
+		const identity = identityOf(makeSession(0, 9))
+		const removeId = buildParlayButtonId(identity, 'remove', 2)
+		const modalId = buildParlayModalId(identity, 'add-leg')
+
+		expect(parseParlayButtonId(removeId)).toEqual({
+			...identity,
+			action: 'remove',
+			index: 2,
+		})
+		expect(parseParlayModalId(modalId)).toEqual({
+			...identity,
+			kind: 'add-leg',
+		})
+		expect(parseParlayButtonId('parlay_btn_remove:2')).toBeNull()
+		expect(
+			parseParlayButtonId(`parlay.btn.${identity.sessionId}.9.remove`),
+		).toBeNull()
+		expect(parseParlayModalId('parlay_modal_add_leg')).toBeNull()
 	})
 })

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../utils/logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../../utils/api/routes/cache/match-cache-service.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getMatch: vi.fn(), getMatches: vi.fn() }
+	}),
+}))
+
+vi.mock('../../utils/api/Khronos/parlays/ParlayApiWrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getEventOutcomes: vi.fn() }
+	}),
+}))
+
+vi.mock('../../utils/cache/cache-manager.js', () => ({
+	CacheManager: vi.fn(),
+}))
+
+const {
+	PARLAY_BUILDER_MAX_LEGS,
+	PARLAY_BUILDER_TTL_SECONDS,
+	ParlayBuilderService,
+} = await import('../ParlayBuilderService.js')
+
+type CacheStub = {
+	get: ReturnType<typeof vi.fn>
+	set: ReturnType<typeof vi.fn>
+	remove: ReturnType<typeof vi.fn>
+}
+
+const makeCache = (): CacheStub => ({
+	get: vi.fn(),
+	set: vi.fn().mockResolvedValue(true),
+	remove: vi.fn().mockResolvedValue(true),
+})
+
+const makeSession = (legs = 0) => ({
+	legs: Array.from({ length: legs }, (_, index) => ({
+		event_id: `event-${index}`,
+		outcome_uuid: `outcome-${index}`,
+		market_key: 'h2h' as const,
+		selection_display: `Team ${index}`,
+		odds_american: 100,
+		point: null,
+		commence_time: '2099-01-01T00:00:00.000Z',
+	})),
+	stake: null,
+})
+
+describe('ParlayBuilderService', () => {
+	let cache: CacheStub
+	let matchCache: { getMatch: ReturnType<typeof vi.fn> }
+	let parlayApi: { getEventOutcomes: ReturnType<typeof vi.fn> }
+	let service: InstanceType<typeof ParlayBuilderService>
+
+	beforeEach(() => {
+		cache = makeCache()
+		matchCache = { getMatch: vi.fn() }
+		parlayApi = { getEventOutcomes: vi.fn() }
+		service = new ParlayBuilderService(
+			cache as never,
+			matchCache as never,
+			parlayApi as never,
+		)
+	})
+
+	it('stores one user session with the 15 minute TTL', async () => {
+		await service.start('user-1')
+
+		expect(cache.set).toHaveBeenCalledWith(
+			'parlay-builder:user-1',
+			{ legs: [], stake: null },
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	})
+
+	it('rejects duplicate events and the seventh leg', async () => {
+		cache.get.mockResolvedValue(makeSession(1))
+		await expect(
+			service.addLeg('user-1', {
+				matchId: 'event-0',
+				marketKey: 'h2h',
+				side: 'home',
+			}),
+		).rejects.toThrow('different game')
+
+		cache.get.mockResolvedValue(makeSession(PARLAY_BUILDER_MAX_LEGS))
+		await expect(
+			service.addLeg('user-1', {
+				matchId: 'event-new',
+				marketKey: 'h2h',
+				side: 'home',
+			}),
+		).rejects.toThrow('at most 6')
+	})
+
+	it('resolves a home moneyline outcome from Khronos', async () => {
+		cache.get.mockResolvedValue(makeSession())
+		matchCache.getMatch.mockResolvedValue({
+			id: 'event-1',
+			home_team: 'Home Team',
+			away_team: 'Away Team',
+			sport: 'basketball_nba',
+			commence_time: '2099-01-01T00:00:00.000Z',
+		})
+		parlayApi.getEventOutcomes.mockResolvedValue([
+			{
+				uuid: 'outcome-1',
+				market_key: 'h2h',
+				name: 'Home Team',
+				price: -110,
+			},
+		])
+
+		const result = await service.addLeg('user-1', {
+			matchId: 'event-1',
+			marketKey: 'h2h',
+			side: 'home',
+		})
+
+		expect(result.legs[0]).toMatchObject({
+			event_id: 'event-1',
+			outcome_uuid: 'outcome-1',
+			selection_display: 'Home Team',
+			odds_american: -110,
+		})
+		expect(cache.set).toHaveBeenLastCalledWith(
+			'parlay-builder:user-1',
+			expect.objectContaining({ legs: expect.any(Array) }),
+			PARLAY_BUILDER_TTL_SECONDS,
+		)
+	})
+
+	it('calculates combined odds and stake-aware payout', async () => {
+		const session = {
+			...makeSession(2),
+			stake: 10,
+		}
+		const summary = service.getOddsSummary(session)
+
+		expect(summary.decimal).toBe(4)
+		expect(summary.american).toBe(300)
+		expect(summary.potentialPayout).toBe(40)
+	})
+
+	it('requires two legs and a stake before placement', () => {
+		expect(() => service.validateForPlacement(makeSession(1))).toThrow(
+			'at least 2',
+		)
+		expect(() =>
+			service.validateForPlacement({ ...makeSession(2), stake: null }),
+		).toThrow('Set a stake')
+	})
+
+	it('renders a Components V2 card with per-leg remove controls', () => {
+		const response = service.render({ ...makeSession(2), stake: 10 })
+		const container = response.components?.[0]
+		const json = (container as { toJSON: () => unknown }).toJSON()
+
+		expect(response.flags).toBeDefined()
+		expect(JSON.stringify(json)).toContain('parlay_btn_remove_0')
+		expect(JSON.stringify(json)).toContain('parlay_btn_confirm')
+	})
+})

--- a/src/services/__tests__/ParlayBuilderService.test.ts
+++ b/src/services/__tests__/ParlayBuilderService.test.ts
@@ -30,6 +30,9 @@ type CacheStub = {
 	get: ReturnType<typeof vi.fn>
 	set: ReturnType<typeof vi.fn>
 	remove: ReturnType<typeof vi.fn>
+	setIfAbsent?: ReturnType<typeof vi.fn>
+	compareAndRemove?: ReturnType<typeof vi.fn>
+	refreshIfOwned?: ReturnType<typeof vi.fn>
 }
 
 const makeCache = (): CacheStub => ({
@@ -69,10 +72,10 @@ describe('ParlayBuilderService', () => {
 	})
 
 	it('stores one user session with the 15 minute TTL', async () => {
-		await service.start('user-1')
+		await service.start('user-1', 'guild-1')
 
 		expect(cache.set).toHaveBeenCalledWith(
-			'parlay-builder:user-1',
+			'parlay-builder:guild-1:user-1',
 			{ legs: [], stake: null },
 			PARLAY_BUILDER_TTL_SECONDS,
 		)
@@ -81,7 +84,7 @@ describe('ParlayBuilderService', () => {
 	it('rejects duplicate events and the seventh leg', async () => {
 		cache.get.mockResolvedValue(makeSession(1))
 		await expect(
-			service.addLeg('user-1', {
+			service.addLeg('user-1', 'guild-1', {
 				matchId: 'event-0',
 				marketKey: 'h2h',
 				side: 'home',
@@ -90,7 +93,7 @@ describe('ParlayBuilderService', () => {
 
 		cache.get.mockResolvedValue(makeSession(PARLAY_BUILDER_MAX_LEGS))
 		await expect(
-			service.addLeg('user-1', {
+			service.addLeg('user-1', 'guild-1', {
 				matchId: 'event-new',
 				marketKey: 'h2h',
 				side: 'home',
@@ -116,7 +119,7 @@ describe('ParlayBuilderService', () => {
 			},
 		])
 
-		const result = await service.addLeg('user-1', {
+		const result = await service.addLeg('user-1', 'guild-1', {
 			matchId: 'event-1',
 			marketKey: 'h2h',
 			side: 'home',
@@ -129,10 +132,87 @@ describe('ParlayBuilderService', () => {
 			odds_american: -110,
 		})
 		expect(cache.set).toHaveBeenLastCalledWith(
-			'parlay-builder:user-1',
+			'parlay-builder:guild-1:user-1',
 			expect.objectContaining({ legs: expect.any(Array) }),
 			PARLAY_BUILDER_TTL_SECONDS,
 		)
+	})
+
+	it('rejects matches without sport metadata instead of defaulting to NBA', async () => {
+		cache.get.mockResolvedValue(makeSession())
+		matchCache.getMatch.mockResolvedValue({
+			id: 'event-no-sport',
+			home_team: 'Home Team',
+			away_team: 'Away Team',
+			commence_time: '2099-01-01T00:00:00.000Z',
+		})
+
+		await expect(
+			service.addLeg('user-1', 'guild-1', {
+				matchId: 'event-no-sport',
+				marketKey: 'h2h',
+				side: 'home',
+			}),
+		).rejects.toThrow('missing sport information')
+		expect(parlayApi.getEventOutcomes).not.toHaveBeenCalled()
+	})
+
+	it('reserves a session so concurrent confirmation can only place once', async () => {
+		cache.get.mockResolvedValue({ ...makeSession(2), stake: 10 })
+		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
+		cache.compareAndRemove = vi.fn().mockResolvedValue(true)
+
+		const first = await service.reserveForPlacement('user-1', 'guild-1')
+		const second = await service.reserveForPlacement('user-1', 'guild-1')
+
+		expect(first).not.toBeNull()
+		expect(second).toBeNull()
+		await service.releasePlacement('user-1', 'guild-1', first?.token)
+		const third = await service.reserveForPlacement('user-1', 'guild-1')
+		expect(third).not.toBeNull()
+		await service.releasePlacement('user-1', 'guild-1', third?.token)
+	})
+
+	it('rejects cancellation while placement owns the builder', async () => {
+		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
+		cache.get.mockImplementation((key: string) =>
+			key.endsWith(':placement')
+				? Promise.resolve('active-token')
+				: Promise.resolve({ ...makeSession(2), stake: 10 }),
+		)
+
+		await expect(service.clear('user-1', 'guild-1')).rejects.toThrow(
+			'already being placed',
+		)
+		expect(cache.remove).not.toHaveBeenCalledWith(
+			'parlay-builder:guild-1:user-1',
+		)
+	})
+
+	it('refreshes a placement lease through the cache owner check', async () => {
+		cache.refreshIfOwned = vi.fn().mockResolvedValue(true)
+
+		await expect(
+			service.refreshPlacement('user-1', 'guild-1', 'owner-token'),
+		).resolves.toBe(true)
+		expect(cache.refreshIfOwned).toHaveBeenCalledWith(
+			'parlay-builder:guild-1:user-1:placement',
+			'owner-token',
+			120,
+		)
+	})
+
+	it('reports a lost placement lease instead of fencing a new owner', async () => {
+		cache.setIfAbsent = vi.fn().mockResolvedValue(true)
+		cache.refreshIfOwned = vi.fn().mockResolvedValue(false)
+		await expect(
+			service.refreshPlacement('user-1', 'guild-1', 'owner-token'),
+		).resolves.toBe(false)
+
+		cache.get.mockResolvedValue(false)
+		await expect(
+			service.clearWithPlacementToken('user-1', 'guild-1', 'owner-token'),
+		).rejects.toThrow('already being placed')
 	})
 
 	it('calculates combined odds and stake-aware payout', async () => {

--- a/src/services/engagement/BigWinAnnouncementService.ts
+++ b/src/services/engagement/BigWinAnnouncementService.ts
@@ -1,0 +1,279 @@
+import { EmbedBuilder, type MessageCreateOptions } from 'discord.js'
+import embedColors from '../../lib/colorsConfig.js'
+import env from '../../lib/startup/env.js'
+import MoneyFormatter from '../../utils/api/common/money-formatting/money-format.js'
+import GuildWrapper from '../../utils/api/Khronos/guild/guild-wrapper.js'
+import redisCache from '../../utils/cache/redis-instance.js'
+import { logger } from '../../utils/logging/WinstonLogger.js'
+
+export const BIG_WIN_ANNOUNCEMENT_MAX_PER_HOUR = 5
+export const BIG_WIN_ANNOUNCEMENT_TTL_SECONDS = 60 * 60
+export const BIG_WIN_ANNOUNCEMENT_DEDUP_TTL_SECONDS = 7 * 24 * 60 * 60
+export const BIG_WIN_DEDUP_KEY_PREFIX = 'pluto:big-win-announcement:sent'
+export const BIG_WIN_RATE_KEY_PREFIX = 'pluto:big-win-announcement:rate'
+
+export interface BigWinAnnouncementRedis {
+	set(
+		key: string,
+		value: string,
+		...args: Array<string | number>
+	): Promise<string | null>
+	incr(key: string): Promise<number>
+	decr(key: string): Promise<number>
+	expire(key: string, seconds: number): Promise<number>
+	del(key: string): Promise<number>
+}
+
+export interface BigWinAnnouncementSender {
+	sendToBettingChannel(
+		guildId: string,
+		options: MessageCreateOptions,
+	): Promise<unknown>
+}
+
+export interface BigWinParlayInput {
+	parlayId: string
+	guildId: string
+	userId: string
+	payout: number
+	stake: number
+	combinedOddsAmerican: number
+	legs: number
+}
+
+export interface BigWinSingleBetInput {
+	betId: string | number
+	guildId: string
+	userId: string
+	payout: number
+	betAmount: number
+	team: string
+	oddsAmerican?: number
+}
+
+type AnnouncementKind = 'parlay' | 'bet'
+
+interface AnnouncementInput {
+	kind: AnnouncementKind
+	id: string | number
+	guildId: string
+	userId: string
+	payout: number
+	buildEmbed: () => EmbedBuilder
+}
+
+function getAnnouncementThreshold(): number {
+	const configured = Number(env.ANNOUNCE_PAYOUT_THRESHOLD)
+	return Number.isFinite(configured) && configured >= 0 ? configured : 100
+}
+
+/**
+ * Delivers high-value wins to a guild's betting channel.
+ *
+ * Redis reserves the event before Discord delivery. This makes duplicate
+ * Khronos callbacks safe even when Pluto processes them concurrently. The
+ * per-guild counter is a rolling one-hour window shared by all Pluto replicas.
+ */
+export class BigWinAnnouncementService {
+	constructor(
+		private readonly redis: BigWinAnnouncementRedis = redisCache as unknown as BigWinAnnouncementRedis,
+		private readonly sender: BigWinAnnouncementSender = new GuildWrapper(),
+		private readonly threshold = getAnnouncementThreshold(),
+		private readonly maxPerHour = env.ANNOUNCE_MAX_PER_HOUR ??
+			BIG_WIN_ANNOUNCEMENT_MAX_PER_HOUR,
+		private readonly enabled = env.BIG_WIN_ANNOUNCEMENTS_ENABLED ?? true,
+	) {}
+
+	async announceParlayWin(input: BigWinParlayInput): Promise<boolean> {
+		return this.announce({
+			kind: 'parlay',
+			id: input.parlayId,
+			guildId: input.guildId,
+			userId: input.userId,
+			payout: input.payout,
+			buildEmbed: () =>
+				new EmbedBuilder()
+					.setTitle('💰 Big Parlay Win! 💰')
+					.setDescription(
+						`<@${input.userId}> just hit a huge parlay!`,
+					)
+					.setColor(embedColors.success)
+					.addFields(
+						{
+							name: '🧾 Legs',
+							value: String(input.legs),
+							inline: true,
+						},
+						{
+							name: '📈 Combined Odds',
+							value: this.formatOdds(input.combinedOddsAmerican),
+							inline: true,
+						},
+						{
+							name: '🏆 Payout',
+							value: MoneyFormatter.toUSD(input.payout),
+							inline: false,
+						},
+					)
+					.setFooter({ text: `Parlay ID: ${input.parlayId}` })
+					.setTimestamp(),
+		})
+	}
+
+	async announceSingleBetWin(input: BigWinSingleBetInput): Promise<boolean> {
+		return this.announce({
+			kind: 'bet',
+			id: input.betId,
+			guildId: input.guildId,
+			userId: input.userId,
+			payout: input.payout,
+			buildEmbed: () =>
+				new EmbedBuilder()
+					.setTitle('💰 Big Win! 💰')
+					.setDescription(`<@${input.userId}> just landed a big win!`)
+					.setColor(embedColors.success)
+					.addFields(
+						{
+							name: '🎯 Selection',
+							value: input.team,
+							inline: true,
+						},
+						...(input.oddsAmerican === undefined
+							? []
+							: [
+									{
+										name: '📈 Odds',
+										value: this.formatOdds(
+											input.oddsAmerican,
+										),
+										inline: true,
+									},
+								]),
+						{
+							name: '🏆 Payout',
+							value: MoneyFormatter.toUSD(input.payout),
+							inline: false,
+						},
+					)
+					.setFooter({ text: `Bet ID: ${input.betId}` })
+					.setTimestamp(),
+		})
+	}
+
+	private async announce(input: AnnouncementInput): Promise<boolean> {
+		if (
+			!this.enabled ||
+			!Number.isFinite(input.payout) ||
+			input.payout < this.threshold
+		) {
+			return false
+		}
+
+		const dedupKey = `${BIG_WIN_DEDUP_KEY_PREFIX}:${input.kind}:${input.id}`
+		const rateKey = `${BIG_WIN_RATE_KEY_PREFIX}:${input.guildId}`
+		let rateCounted = false
+
+		try {
+			const reserved = await this.redis.set(
+				dedupKey,
+				'1',
+				'EX',
+				BIG_WIN_ANNOUNCEMENT_DEDUP_TTL_SECONDS,
+				'NX',
+			)
+			if (reserved !== 'OK') return false
+
+			const count = await this.redis.incr(rateKey)
+			rateCounted = true
+			if (count === 1) {
+				try {
+					await this.redis.expire(
+						rateKey,
+						BIG_WIN_ANNOUNCEMENT_TTL_SECONDS,
+					)
+				} catch (error) {
+					await this.compensateRateCounter(rateKey)
+					await this.releaseReservation(dedupKey)
+					logger.error({
+						event: 'big_win.announcement_rate_expiry_failed',
+						guild_id: input.guildId,
+						error:
+							error instanceof Error
+								? error.message
+								: String(error),
+					})
+					return false
+				}
+			}
+			if (count > this.maxPerHour) {
+				await this.releaseReservation(dedupKey)
+				logger.info({
+					event: 'big_win.announcement_rate_limited',
+					guild_id: input.guildId,
+					kind: input.kind,
+					id: input.id,
+					count,
+					max_per_hour: this.maxPerHour,
+				})
+				return false
+			}
+
+			await this.sender.sendToBettingChannel(input.guildId, {
+				embeds: [input.buildEmbed()],
+			})
+			return true
+		} catch (error) {
+			await this.releaseReservation(dedupKey)
+			if (rateCounted) {
+				await this.compensateRateCounter(rateKey)
+			}
+			logger.error({
+				event: 'big_win.announcement_failed',
+				guild_id: input.guildId,
+				kind: input.kind,
+				id: input.id,
+				payout: input.payout,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return false
+		}
+	}
+
+	private async releaseReservation(dedupKey: string): Promise<void> {
+		try {
+			await this.redis.del(dedupKey)
+		} catch (error) {
+			logger.warn({
+				event: 'big_win.announcement_reservation_cleanup_failed',
+				dedup_key: dedupKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	private async compensateRateCounter(rateKey: string): Promise<void> {
+		try {
+			const remaining = await this.redis.decr(rateKey)
+			if (remaining <= 0) {
+				await this.redis.del(rateKey)
+			} else {
+				await this.redis.expire(
+					rateKey,
+					BIG_WIN_ANNOUNCEMENT_TTL_SECONDS,
+				)
+			}
+		} catch (error) {
+			logger.warn({
+				event: 'big_win.announcement_rate_cleanup_failed',
+				rate_key: rateKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	private formatOdds(odds: number): string {
+		return odds > 0 ? `+${odds}` : String(odds)
+	}
+}
+
+export default BigWinAnnouncementService

--- a/src/services/engagement/__tests__/BigWinAnnouncementService.test.ts
+++ b/src/services/engagement/__tests__/BigWinAnnouncementService.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	redis: {
+		set: vi.fn(),
+		incr: vi.fn(),
+		decr: vi.fn(),
+		expire: vi.fn(),
+		del: vi.fn(),
+	},
+	sendToBettingChannel: vi.fn(),
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	},
+}))
+
+vi.mock('../../../utils/cache/redis-instance.js', () => ({
+	default: mocks.redis,
+}))
+
+vi.mock('../../../lib/startup/env.js', () => ({
+	default: { ANNOUNCE_PAYOUT_THRESHOLD: 100 },
+}))
+
+vi.mock('../../../utils/logging/WinstonLogger.js', () => ({
+	logger: mocks.logger,
+}))
+
+vi.mock('../../../utils/api/Khronos/guild/guild-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { sendToBettingChannel: mocks.sendToBettingChannel }
+	}),
+}))
+
+import { BigWinAnnouncementService } from '../BigWinAnnouncementService.js'
+
+const parlay = {
+	parlayId: 'parlay-1',
+	guildId: 'guild-1',
+	userId: 'user-1',
+	payout: 100,
+	stake: 10,
+	combinedOddsAmerican: 900,
+	legs: 3,
+}
+
+describe('BigWinAnnouncementService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.redis.set.mockResolvedValue('OK')
+		mocks.redis.incr.mockResolvedValue(1)
+		mocks.redis.decr.mockResolvedValue(0)
+		mocks.redis.expire.mockResolvedValue(1)
+		mocks.redis.del.mockResolvedValue(1)
+		mocks.sendToBettingChannel.mockResolvedValue({})
+	})
+
+	it('does not announce below threshold and announces at the boundary', async () => {
+		const service = new BigWinAnnouncementService(
+			mocks.redis,
+			{ sendToBettingChannel: mocks.sendToBettingChannel },
+			100,
+		)
+
+		await expect(
+			service.announceParlayWin({ ...parlay, payout: 99.99 }),
+		).resolves.toBe(false)
+		expect(mocks.redis.set).not.toHaveBeenCalled()
+
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(true)
+		expect(mocks.sendToBettingChannel).toHaveBeenCalledOnce()
+		const [, options] = mocks.sendToBettingChannel.mock.calls[0]
+		const embed = options.embeds[0].toJSON()
+		expect(embed.title).toBe('💰 Big Parlay Win! 💰')
+		expect(embed.description).toContain('<@user-1>')
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: '🧾 Legs', value: '3' }),
+				expect.objectContaining({
+					name: '🏆 Payout',
+					value: '$100.00',
+				}),
+			]),
+		)
+	})
+
+	it('uses Redis deduplication to send each parlay only once', async () => {
+		const service = new BigWinAnnouncementService(mocks.redis, {
+			sendToBettingChannel: mocks.sendToBettingChannel,
+		})
+
+		await service.announceParlayWin(parlay)
+		mocks.redis.set.mockResolvedValueOnce(null)
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(false)
+
+		expect(mocks.sendToBettingChannel).toHaveBeenCalledOnce()
+		expect(mocks.redis.set).toHaveBeenNthCalledWith(
+			2,
+			'pluto:big-win-announcement:sent:parlay:parlay-1',
+			'1',
+			'EX',
+			7 * 24 * 60 * 60,
+			'NX',
+		)
+	})
+
+	it('enforces the per-guild hourly rate limit across announcement kinds', async () => {
+		mocks.redis.incr.mockResolvedValue(2)
+		const service = new BigWinAnnouncementService(
+			mocks.redis,
+			{ sendToBettingChannel: mocks.sendToBettingChannel },
+			100,
+			1,
+		)
+
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(false)
+		expect(mocks.sendToBettingChannel).not.toHaveBeenCalled()
+		expect(mocks.logger.info).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'big_win.announcement_rate_limited',
+				guild_id: 'guild-1',
+			}),
+		)
+	})
+
+	it('formats large single-bet wins for the betting channel', async () => {
+		const service = new BigWinAnnouncementService(mocks.redis, {
+			sendToBettingChannel: mocks.sendToBettingChannel,
+		})
+
+		await expect(
+			service.announceSingleBetWin({
+				betId: 42,
+				guildId: 'guild-1',
+				userId: 'user-1',
+				payout: 250,
+				betAmount: 25,
+				team: 'Lakers',
+				oddsAmerican: 900,
+			}),
+		).resolves.toBe(true)
+
+		const [, options] = mocks.sendToBettingChannel.mock.calls[0]
+		const embed = options.embeds[0].toJSON()
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🎯 Selection',
+					value: 'Lakers',
+				}),
+				expect.objectContaining({ name: '📈 Odds', value: '+900' }),
+				expect.objectContaining({
+					name: '🏆 Payout',
+					value: '$250.00',
+				}),
+			]),
+		)
+	})
+
+	it('releases reservations and rate capacity when delivery fails', async () => {
+		mocks.sendToBettingChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
+		const service = new BigWinAnnouncementService(mocks.redis, {
+			sendToBettingChannel: mocks.sendToBettingChannel,
+		})
+
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(false)
+		expect(mocks.redis.del).toHaveBeenCalledWith(
+			'pluto:big-win-announcement:sent:parlay:parlay-1',
+		)
+		expect(mocks.redis.decr).toHaveBeenCalledWith(
+			'pluto:big-win-announcement:rate:guild-1',
+		)
+	})
+
+	it('does not reserve a failed rate window when expiry fails', async () => {
+		mocks.redis.expire.mockRejectedValueOnce(new Error('Redis unavailable'))
+		const service = new BigWinAnnouncementService(mocks.redis, {
+			sendToBettingChannel: mocks.sendToBettingChannel,
+		})
+
+		await expect(service.announceParlayWin(parlay)).resolves.toBe(false)
+		expect(mocks.redis.del).toHaveBeenCalledWith(
+			'pluto:big-win-announcement:sent:parlay:parlay-1',
+		)
+		expect(mocks.redis.decr).toHaveBeenCalledWith(
+			'pluto:big-win-announcement:rate:guild-1',
+		)
+	})
+})

--- a/src/utils/admin-handlers/admin-predictions-handler.ts
+++ b/src/utils/admin-handlers/admin-predictions-handler.ts
@@ -119,7 +119,8 @@ export class AdminPredictionsHandler {
 				return
 			}
 
-			// Delete the prediction
+			// The admin input resolves to the unique prediction UUID, so use the
+			// explicit DELETE /prediction/by-id/:prediction_id route.
 			await predictionApiWrapper.deletePredictionById({
 				predictionId: matchedPrediction.id,
 				userId: user.id,

--- a/src/utils/api/Khronos/bets/BetslipsManager.ts
+++ b/src/utils/api/Khronos/bets/BetslipsManager.ts
@@ -300,6 +300,42 @@ export class BetslipManager {
 		}
 	}
 
+	/**
+	 * Announce a successfully placed parlay through the same guild betting
+	 * channel pathway used by singles.
+	 */
+	public async announceParlayPlaced(
+		interaction: CommandInteraction | ButtonInteraction,
+		details: {
+			parlayId: string
+			legCount: number
+			stake: number
+			potentialPayout: number
+		},
+	): Promise<void> {
+		try {
+			if (!interaction.guildId) {
+				logger.warn('Cannot announce parlay - no guild context')
+				return
+			}
+
+			const publicEmbed = new EmbedBuilder()
+				.setDescription(
+					`<@${interaction.user.id}> placed a **${details.legCount}-leg parlay** for **\`$${details.stake.toFixed(2)}\`**!`,
+				)
+				.setColor(embedColors.success)
+				.setFooter({
+					text: `Potential payout: $${details.potentialPayout.toFixed(2)} • Parlay ${details.parlayId.slice(0, 8)}`,
+				})
+
+			await new GuildWrapper().sendToBettingChannel(interaction.guildId, {
+				embeds: [publicEmbed],
+			})
+		} catch (error) {
+			logger.warn('Failed to announce parlay placed', { error })
+		}
+	}
+
 	private formatBetStr(betAmount: string, payout: string, profit: string) {
 		const b = '**'
 		const formattedBetData = `${b}${betAmount}${b} -> ${b}${payout}${b}\n${b}Profit:${b} ${b}${profit}${b}`

--- a/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
+++ b/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
@@ -138,7 +138,30 @@ describe('MyBetsFormatterService parlays', () => {
 		})
 
 		expect(JSON.stringify(response.components)).toContain(
-			'parlay_cancel_parlay-123456',
+			'parlay_cancel_parlay-123456_1',
+		)
+	})
+
+	it('surfaces partial parlay retrieval warnings in the pending embed', async () => {
+		const response = await formatter.buildEmbedResponse({
+			userId: 'user-1',
+			pendingBets: [],
+			pendingParlays: [],
+			historyParlays: [],
+			parlayFetchWarning:
+				'Some parlays could not be loaded. Refresh /mybets to try again.',
+			historyPage: {
+				bets: [],
+				parlays: [],
+				entries: [],
+				page: 1,
+				totalPages: 1,
+			},
+			groupedBets: [],
+		})
+
+		expect(response.embeds?.[0]?.toJSON().description).toContain(
+			'Some parlays could not be loaded',
 		)
 	})
 })
@@ -171,6 +194,89 @@ describe('MyBetsPaginationService parlay history', () => {
 		expect(result.historyParlays).toHaveLength(1)
 	})
 
+	it('loads every parlay API page before local history pagination', async () => {
+		const betsWrapper = {
+			getUserBetslips: vi.fn().mockResolvedValue([]),
+		}
+		const parlaysWrapper = {
+			getUserParlays: vi
+				.fn()
+				.mockResolvedValueOnce({
+					parlays: [parlay({ id: 'page-1', status: 'lost' })],
+					page: 1,
+					limit: 100,
+					total: 201,
+					total_pages: 3,
+				})
+				.mockResolvedValueOnce({
+					parlays: [parlay({ id: 'page-2', status: 'lost' })],
+					page: 2,
+					limit: 100,
+					total: 201,
+					total_pages: 3,
+				})
+				.mockResolvedValueOnce({
+					parlays: [parlay({ id: 'page-3', status: 'lost' })],
+					page: 3,
+					limit: 100,
+					total: 201,
+					total_pages: 3,
+				}),
+		}
+		const service = new MyBetsPaginationService(
+			betsWrapper as never,
+			parlaysWrapper as never,
+		)
+
+		const result = await service.fetchUserBets('user-1')
+
+		expect(parlaysWrapper.getUserParlays).toHaveBeenNthCalledWith(
+			1,
+			'user-1',
+			{ page: 1, limit: 100 },
+		)
+		expect(parlaysWrapper.getUserParlays).toHaveBeenNthCalledWith(
+			3,
+			'user-1',
+			{ page: 3, limit: 100 },
+		)
+		expect(result.historyParlays).toHaveLength(3)
+	})
+
+	it('keeps successful parlay pages and warns when a later page fails', async () => {
+		const betsWrapper = {
+			getUserBetslips: vi.fn().mockResolvedValue([]),
+		}
+		const parlaysWrapper = {
+			getUserParlays: vi
+				.fn()
+				.mockResolvedValueOnce({
+					parlays: [parlay({ id: 'page-1', status: 'lost' })],
+					total_pages: 3,
+				})
+				.mockResolvedValueOnce({
+					parlays: [parlay({ id: 'page-2', status: 'lost' })],
+					total_pages: 3,
+				})
+				.mockRejectedValueOnce(new Error('page 3 unavailable')),
+		}
+		const service = new MyBetsPaginationService(
+			betsWrapper as never,
+			parlaysWrapper as never,
+		)
+
+		const result = await service.fetchUserBets('user-1')
+
+		expect(result.historyParlays).toHaveLength(2)
+		expect(result.historyParlays.map((item) => item.id)).toEqual([
+			'page-1',
+			'page-2',
+		])
+		expect(result.parlayFetchWarning).toContain(
+			'Some parlays could not be loaded',
+		)
+	})
+
 	it('paginates singles and parlays together in date order', () => {
 		const service = new MyBetsPaginationService(
 			{ getUserBetslips: vi.fn() } as never,
@@ -194,5 +300,99 @@ describe('MyBetsPaginationService parlay history', () => {
 		expect(page.entries).toHaveLength(2)
 		expect(page.entries[0]?.kind).toBe('parlay')
 		expect(page.entries[1]?.kind).toBe('bet')
+	})
+
+	it('keeps mixed history chronology in the rendered embed', async () => {
+		const service = new MyBetsPaginationService(
+			{ getUserBetslips: vi.fn() } as never,
+			{ getUserParlays: vi.fn() } as never,
+		)
+		const formatter = new MyBetsFormatterService()
+		const bet = {
+			betid: 1,
+			betresult: 'won',
+			team: 'SINGLE',
+			amount: 10,
+			payout: 20,
+			profit: 10,
+			dateofbet: '2026-07-10T00:00:00.000Z',
+		} as never
+		const newerParlay = parlay({
+			created_at: '2026-07-11T00:00:00.000Z',
+			status: 'lost',
+		})
+		const historyPage = service.getHistoryPage([bet], 1, [newerParlay])
+
+		const embed = await formatter.buildHistoryEmbed(
+			historyPage,
+			service.groupBetsByDate(historyPage.bets),
+		)
+		const description = embed.toJSON().description ?? ''
+
+		expect(description.indexOf('3-leg Parlay')).toBeLessThan(
+			description.indexOf('SINGLE'),
+		)
+	})
+
+	it('reserves the navigation row when capping cancellation buttons', async () => {
+		const formatter = new MyBetsFormatterService()
+		const pendingParlays = Array.from({ length: 21 }, (_, index) =>
+			parlay({
+				id: `parlay-${index}`,
+				legs: parlay().legs.map((leg) => ({
+					...leg,
+					commence_time: '2099-01-01T00:00:00.000Z',
+				})),
+			}),
+		)
+		const response = await formatter.buildEmbedResponse({
+			userId: 'user-1',
+			pendingBets: [],
+			pendingParlays,
+			historyParlays: [],
+			historyPage: {
+				bets: [],
+				parlays: [],
+				entries: [],
+				page: 1,
+				totalPages: 2,
+			},
+			groupedBets: [],
+		})
+		const components = response.components as unknown as ReadonlyArray<{
+			components?: Array<{ data?: { custom_id?: string } }>
+		}>
+		const cancelButtons = components
+			.flatMap((row) => row.components ?? [])
+			.filter(
+				(button) =>
+					button.data?.custom_id?.startsWith('parlay_cancel_') &&
+					!button.data?.custom_id?.startsWith('parlay_cancel_nav_'),
+			)
+
+		expect(components).toHaveLength(5)
+		expect(cancelButtons).toHaveLength(15)
+		expect(JSON.stringify(response.components)).toContain(
+			'parlay_cancel_nav_next_1',
+		)
+
+		const secondPageResponse = await formatter.buildEmbedResponse({
+			userId: 'user-1',
+			pendingBets: [],
+			pendingParlays,
+			historyParlays: [],
+			historyPage: {
+				bets: [],
+				parlays: [],
+				entries: [],
+				page: 1,
+				totalPages: 2,
+			},
+			groupedBets: [],
+			cancellationPage: 2,
+		})
+		expect(JSON.stringify(secondPageResponse.components)).toContain(
+			'parlay_cancel_parlay-20_2',
+		)
 	})
 })

--- a/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
+++ b/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
@@ -160,7 +160,7 @@ describe('MyBetsFormatterService parlays', () => {
 			groupedBets: [],
 		})
 
-		expect(response.embeds?.[0]?.toJSON().description).toContain(
+		expect(JSON.stringify(response.embeds?.[0])).toContain(
 			'Some parlays could not be loaded',
 		)
 	})

--- a/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
+++ b/src/utils/api/Khronos/bets/__tests__/mybets-parlays.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../betslip-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getUserBetslips: vi.fn() }
+	}),
+}))
+
+vi.mock('../../parlays/ParlayApiWrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getUserParlays: vi.fn() }
+	}),
+}))
+
+const { MyBetsFormatterService } = await import(
+	'../mybets-formatter.service.js'
+)
+const { MyBetsPaginationService } = await import(
+	'../mybets-pagination.service.js'
+)
+
+const parlay = (overrides: Record<string, unknown> = {}) => ({
+	id: 'parlay-123456',
+	user_id: 'user-1',
+	guild_id: 'guild-1',
+	stake: 10,
+	combined_odds_american: 300,
+	potential_payout: 40,
+	actual_payout: null,
+	status: 'pending' as const,
+	leg_count: 3,
+	created_at: '2026-07-11T12:00:00.000Z',
+	settled_at: null,
+	legs: [
+		{
+			id: 'leg-late',
+			event_id: 'event-late',
+			outcome_uuid: 'outcome-late',
+			market_key: 'h2h' as const,
+			selection_display: 'Late Team',
+			odds_american: 100,
+			point: null,
+			commence_time: '2026-07-13T12:00:00.000Z',
+			result: 'pending' as const,
+			settled_at: null,
+		},
+		{
+			id: 'leg-early',
+			event_id: 'event-early',
+			outcome_uuid: 'outcome-early',
+			market_key: 'totals' as const,
+			selection_display: 'Over 220.5',
+			odds_american: -110,
+			point: 220.5,
+			commence_time: '2026-07-12T12:00:00.000Z',
+			result: 'pending' as const,
+			settled_at: null,
+		},
+	],
+	...overrides,
+})
+
+describe('MyBetsFormatterService parlays', () => {
+	const formatter = new MyBetsFormatterService()
+
+	it('orders parlay legs by commence time and renders pending glyphs', () => {
+		const line = formatter.formatPendingParlayLine(parlay())
+
+		expect(line.indexOf('Over 220.5')).toBeLessThan(
+			line.indexOf('Late Team'),
+		)
+		expect(line).toContain('⏳')
+		expect(line).toContain('Odds: `+300`')
+	})
+
+	it('highlights the lost leg in resolved history and renders push as neutral', () => {
+		const line = formatter.formatHistoryParlayLine(
+			parlay({
+				status: 'lost',
+				actual_payout: 0,
+				legs: parlay().legs.map((leg, index) => ({
+					...leg,
+					result: index === 0 ? ('lost' as const) : ('push' as const),
+				})),
+			}),
+		)
+
+		expect(line).toContain('busted')
+		expect(line).toContain('❌')
+		expect(line).toContain('➖')
+	})
+
+	it('only exposes pending parlays before the earliest leg starts', () => {
+		const pending = parlay({
+			legs: parlay().legs.map((leg) => ({
+				...leg,
+				commence_time: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+		const started = parlay({
+			legs: parlay().legs.map((leg, index) => ({
+				...leg,
+				commence_time:
+					index === 0
+						? '2020-01-01T00:00:00.000Z'
+						: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+
+		expect(formatter.canCancelParlay(pending)).toBe(true)
+		expect(formatter.canCancelParlay(started)).toBe(false)
+	})
+
+	it('adds a cancel button for cancellable pending parlays', async () => {
+		const pending = parlay({
+			legs: parlay().legs.map((leg) => ({
+				...leg,
+				commence_time: '2099-01-01T00:00:00.000Z',
+			})),
+		})
+		const response = await formatter.buildEmbedResponse({
+			userId: 'user-1',
+			pendingBets: [],
+			pendingParlays: [pending],
+			historyParlays: [],
+			historyPage: {
+				bets: [],
+				parlays: [],
+				entries: [],
+				page: 1,
+				totalPages: 1,
+			},
+			groupedBets: [],
+		})
+
+		expect(JSON.stringify(response.components)).toContain(
+			'parlay_cancel_parlay-123456',
+		)
+	})
+})
+
+describe('MyBetsPaginationService parlay history', () => {
+	it('fetches singles and parlays together', async () => {
+		const betsWrapper = {
+			getUserBetslips: vi.fn().mockResolvedValue([
+				{ betresult: 'pending', dateofbet: '2026-07-11T00:00:00.000Z' },
+				{ betresult: 'won', dateofbet: '2026-07-10T00:00:00.000Z' },
+			]),
+		}
+		const parlaysWrapper = {
+			getUserParlays: vi.fn().mockResolvedValue({
+				parlays: [
+					parlay({ status: 'pending' }),
+					parlay({ status: 'lost' }),
+				],
+			}),
+		}
+		const service = new MyBetsPaginationService(
+			betsWrapper as never,
+			parlaysWrapper as never,
+		)
+
+		const result = await service.fetchUserBets('user-1')
+		expect(result.pendingBets).toHaveLength(1)
+		expect(result.historyBets).toHaveLength(1)
+		expect(result.pendingParlays).toHaveLength(1)
+		expect(result.historyParlays).toHaveLength(1)
+	})
+
+	it('paginates singles and parlays together in date order', () => {
+		const service = new MyBetsPaginationService(
+			{ getUserBetslips: vi.fn() } as never,
+			{ getUserParlays: vi.fn() } as never,
+		)
+		const page = service.getHistoryPage(
+			[
+				{
+					dateofbet: '2026-07-10T00:00:00.000Z',
+				} as never,
+			],
+			1,
+			[
+				parlay({
+					created_at: '2026-07-11T00:00:00.000Z',
+					status: 'lost',
+				}),
+			],
+		)
+
+		expect(page.entries).toHaveLength(2)
+		expect(page.entries[0]?.kind).toBe('parlay')
+		expect(page.entries[1]?.kind).toBe('bet')
+	})
+})

--- a/src/utils/api/Khronos/bets/mybets-formatter.service.ts
+++ b/src/utils/api/Khronos/bets/mybets-formatter.service.ts
@@ -27,6 +27,8 @@ export interface MyBetsDisplayData {
 	historyParlays: UserParlay[]
 	historyPage: HistoryPage
 	groupedBets: BetsByDate[]
+	parlayFetchWarning?: string
+	cancellationPage?: number
 }
 
 export class MyBetsFormatterService {
@@ -170,18 +172,24 @@ export class MyBetsFormatterService {
 		pendingBets: PlacedBetslip[],
 		guild?: Guild,
 		pendingParlays: UserParlay[] = [],
+		parlayFetchWarning?: string,
 	): Promise<EmbedBuilder> {
 		const embed = new EmbedBuilder()
 			.setTitle('⏳ Pending Bets')
 			.setColor(embedColors.PlutoYellow)
 
-		if (pendingBets.length === 0 && pendingParlays.length === 0) {
+		if (
+			pendingBets.length === 0 &&
+			pendingParlays.length === 0 &&
+			!parlayFetchWarning
+		) {
 			embed.setDescription('You have no pending bets.')
 			return embed
 		}
 
-		const lines = pendingBets.map((bet) =>
-			this.formatPendingBetLine(bet, guild),
+		const lines = parlayFetchWarning ? [`⚠️ ${parlayFetchWarning}`] : []
+		lines.push(
+			...pendingBets.map((bet) => this.formatPendingBetLine(bet, guild)),
 		)
 		lines.push(
 			...pendingParlays.map((parlay) =>
@@ -201,26 +209,50 @@ export class MyBetsFormatterService {
 			.setTitle(`📜 Bet History`)
 			.setColor(embedColors.PlutoBlue)
 
-		if (historyPage.bets.length === 0) {
+		if (historyPage.entries.length === 0) {
 			embed.setDescription(
 				'No bet history found. Place some bets to see them here!',
 			)
 			return embed
 		}
 
-		const lines: string[] = []
+		embed.setDescription(
+			this.buildChronologicalHistoryLines(
+				historyPage,
+				groupedBets,
+				guild,
+			).join('\n\n'),
+		)
+		return embed
+	}
+
+	private buildChronologicalHistoryLines(
+		historyPage: HistoryPage,
+		groupedBets: BetsByDate[],
+		guild?: Guild,
+	): string[] {
+		const dateByBet = new Map<PlacedBetslip, string>()
 		for (const group of groupedBets) {
-			lines.push(`**${group.date}**`)
-			for (const bet of group.bets) {
-				lines.push(this.formatHistoryBetLine(bet, guild))
-			}
-		}
-		for (const parlay of historyPage.parlays) {
-			lines.push(this.formatHistoryParlayLine(parlay))
+			for (const bet of group.bets) dateByBet.set(bet, group.date)
 		}
 
-		embed.setDescription(lines.join('\n\n'))
-		return embed
+		const lines: string[] = []
+		let lastDate: string | undefined
+		for (const entry of historyPage.entries) {
+			if (entry.kind === 'parlay') {
+				lines.push(this.formatHistoryParlayLine(entry.parlay))
+				continue
+			}
+
+			const date = dateByBet.get(entry.bet)
+			if (date && date !== lastDate) {
+				lines.push(`**${date}**`)
+				lastDate = date
+			}
+			lines.push(this.formatHistoryBetLine(entry.bet, guild))
+		}
+
+		return lines
 	}
 
 	buildPaginationButtons(
@@ -257,6 +289,40 @@ export class MyBetsFormatterService {
 		return row
 	}
 
+	private buildCancellationPaginationButtons(
+		currentPage: number,
+		totalPages: number,
+	): ActionRowBuilder<ButtonBuilder> {
+		const button = (
+			action: 'first' | 'prev' | 'next' | 'last',
+			label: string,
+			style: ButtonStyle,
+			disabled: boolean,
+		) =>
+			new ButtonBuilder()
+				.setCustomId(`parlay_cancel_nav_${action}_${currentPage}`)
+				.setLabel(label)
+				.setStyle(style)
+				.setDisabled(disabled)
+
+		return new ActionRowBuilder<ButtonBuilder>().addComponents(
+			button('first', '⏮', ButtonStyle.Secondary, currentPage <= 1),
+			button('prev', '◀', ButtonStyle.Primary, currentPage <= 1),
+			new ButtonBuilder()
+				.setCustomId(`parlay_cancel_nav_page_${currentPage}`)
+				.setLabel(`Cancel ${currentPage}/${totalPages}`)
+				.setStyle(ButtonStyle.Secondary)
+				.setDisabled(true),
+			button('next', '▶', ButtonStyle.Primary, currentPage >= totalPages),
+			button(
+				'last',
+				'⏭',
+				ButtonStyle.Secondary,
+				currentPage >= totalPages,
+			),
+		)
+	}
+
 	async buildComponentsV2Response(
 		data: MyBetsDisplayData,
 		guild?: Guild,
@@ -286,6 +352,11 @@ export class MyBetsFormatterService {
 				sep.setSpacing(SeparatorSpacingSize.Large).setDivider(true),
 			)
 		}
+		if (data.parlayFetchWarning) {
+			container.addTextDisplayComponents((text) =>
+				text.setContent(`⚠️ ${data.parlayFetchWarning}`),
+			)
+		}
 
 		// History Section
 		container.addTextDisplayComponents((text) =>
@@ -304,19 +375,13 @@ export class MyBetsFormatterService {
 				),
 			)
 		} else {
-			for (const group of data.groupedBets) {
+			for (const line of this.buildChronologicalHistoryLines(
+				data.historyPage,
+				data.groupedBets,
+				guild,
+			)) {
 				container.addTextDisplayComponents((text) =>
-					text.setContent(`### ${group.date}`),
-				)
-				for (const bet of group.bets) {
-					container.addTextDisplayComponents((text) =>
-						text.setContent(this.formatHistoryBetLine(bet, guild)),
-					)
-				}
-			}
-			for (const parlay of data.historyPage.parlays) {
-				container.addTextDisplayComponents((text) =>
-					text.setContent(this.formatHistoryParlayLine(parlay)),
+					text.setContent(line),
 				)
 			}
 		}
@@ -348,6 +413,7 @@ export class MyBetsFormatterService {
 			data.pendingBets,
 			guild,
 			data.pendingParlays,
+			data.parlayFetchWarning,
 		)
 		embeds.push(pendingEmbed)
 
@@ -372,15 +438,49 @@ export class MyBetsFormatterService {
 		const cancellable = data.pendingParlays.filter((parlay) =>
 			this.canCancelParlay(parlay),
 		)
-		for (let index = 0; index < cancellable.length; index += 5) {
+		const hasNavigation = data.historyPage.totalPages > 1
+		const maxRowsWithoutCancellationNavigation = hasNavigation ? 4 : 5
+		const needsCancellationNavigation =
+			cancellable.length > maxRowsWithoutCancellationNavigation * 5
+		const maxCancellationRows = Math.max(
+			1,
+			maxRowsWithoutCancellationNavigation -
+				(needsCancellationNavigation ? 1 : 0),
+		)
+		const cancellationPageSize = maxCancellationRows * 5
+		const cancellationTotalPages = Math.max(
+			1,
+			Math.ceil(cancellable.length / cancellationPageSize),
+		)
+		const cancellationPage = Math.max(
+			1,
+			Math.min(data.cancellationPage ?? 1, cancellationTotalPages),
+		)
+		if (needsCancellationNavigation) {
+			components.push(
+				this.buildCancellationPaginationButtons(
+					cancellationPage,
+					cancellationTotalPages,
+				),
+			)
+		}
+		const visibleCancellable = cancellable.slice(
+			(cancellationPage - 1) * cancellationPageSize,
+			cancellationPage * cancellationPageSize,
+		)
+		for (let index = 0; index < visibleCancellable.length; index += 5) {
 			components.push(
 				new ActionRowBuilder<ButtonBuilder>().addComponents(
-					...cancellable.slice(index, index + 5).map((parlay) =>
-						new ButtonBuilder()
-							.setCustomId(`parlay_cancel_${parlay.id}`)
-							.setLabel(`Cancel ${parlay.id.slice(0, 6)}`)
-							.setStyle(ButtonStyle.Danger),
-					),
+					...visibleCancellable
+						.slice(index, index + 5)
+						.map((parlay) =>
+							new ButtonBuilder()
+								.setCustomId(
+									`parlay_cancel_${encodeURIComponent(parlay.id)}_${cancellationPage}`,
+								)
+								.setLabel(`Cancel ${parlay.id.slice(0, 6)}`)
+								.setStyle(ButtonStyle.Danger),
+						),
 				),
 			)
 		}

--- a/src/utils/api/Khronos/bets/mybets-formatter.service.ts
+++ b/src/utils/api/Khronos/bets/mybets-formatter.service.ts
@@ -17,11 +17,14 @@ import {
 	buildMyBetsNavCustomId,
 	mybetsNavPageId,
 } from '../../../../lib/interfaces/interaction-handlers/interaction-handlers.interface.js'
+import type { UserParlay } from '../parlays/ParlayApiWrapper.js'
 import type { BetsByDate, HistoryPage } from './mybets-pagination.service.js'
 
 export interface MyBetsDisplayData {
 	userId: string
 	pendingBets: PlacedBetslip[]
+	pendingParlays: UserParlay[]
+	historyParlays: UserParlay[]
 	historyPage: HistoryPage
 	groupedBets: BetsByDate[]
 }
@@ -73,6 +76,61 @@ export class MyBetsFormatterService {
 		return `${teamEmoji} ${shortName}`.trim()
 	}
 
+	private getParlayLegGlyph(
+		result: UserParlay['legs'][number]['result'],
+	): string {
+		switch (result) {
+			case 'won':
+				return '✅'
+			case 'lost':
+				return '❌'
+			case 'push':
+			case 'void':
+				return '➖'
+			default:
+				return '⏳'
+		}
+	}
+
+	private formatParlayLegs(parlay: UserParlay): string {
+		return [...parlay.legs]
+			.sort(
+				(a, b) =>
+					new Date(a.commence_time).getTime() -
+					new Date(b.commence_time).getTime(),
+			)
+			.map((leg) => {
+				const busted = parlay.status === 'lost' && leg.result === 'lost'
+				return `${this.getParlayLegGlyph(leg.result)} ${busted ? `**${leg.selection_display} (busted)**` : leg.selection_display} • ${leg.market_key} • <t:${Math.floor(new Date(leg.commence_time).getTime() / 1000)}:d>`
+			})
+			.join('\n')
+	}
+
+	formatPendingParlayLine(parlay: UserParlay): string {
+		return `**🎲 ${parlay.leg_count}-leg Parlay**\nStake: \`$${Number(parlay.stake).toFixed(2)}\` • Odds: \`${parlay.combined_odds_american > 0 ? '+' : ''}${parlay.combined_odds_american}\` • Potential: \`$${Number(parlay.potential_payout).toFixed(2)}\`\n${this.formatParlayLegs(parlay)}`
+	}
+
+	formatHistoryParlayLine(parlay: UserParlay): string {
+		const payout =
+			parlay.actual_payout === null
+				? 'N/A'
+				: `$${Number(parlay.actual_payout).toFixed(2)}`
+		const status = parlay.status.replace('_', ' ')
+		return `**${parlay.status === 'won' ? '✅' : parlay.status === 'lost' ? '❌' : '➖'} ${parlay.leg_count}-leg Parlay — ${status}**\nStake: \`$${Number(parlay.stake).toFixed(2)}\` • Actual payout: \`${payout}\`\n${this.formatParlayLegs(parlay)}`
+	}
+
+	canCancelParlay(parlay: UserParlay, now = Date.now()): boolean {
+		return (
+			parlay.status === 'pending' &&
+			parlay.legs.length > 0 &&
+			Math.min(
+				...parlay.legs.map((leg) =>
+					new Date(leg.commence_time).getTime(),
+				),
+			) > now
+		)
+	}
+
 	formatPendingBetLine(bet: PlacedBetslip, guild?: Guild): string {
 		const team = this.formatTeamName(bet.team ?? 'Unknown', guild)
 		const amount = this.formatMoney(bet.amount)
@@ -111,18 +169,24 @@ export class MyBetsFormatterService {
 	async buildPendingEmbed(
 		pendingBets: PlacedBetslip[],
 		guild?: Guild,
+		pendingParlays: UserParlay[] = [],
 	): Promise<EmbedBuilder> {
 		const embed = new EmbedBuilder()
 			.setTitle('⏳ Pending Bets')
 			.setColor(embedColors.PlutoYellow)
 
-		if (pendingBets.length === 0) {
+		if (pendingBets.length === 0 && pendingParlays.length === 0) {
 			embed.setDescription('You have no pending bets.')
 			return embed
 		}
 
 		const lines = pendingBets.map((bet) =>
 			this.formatPendingBetLine(bet, guild),
+		)
+		lines.push(
+			...pendingParlays.map((parlay) =>
+				this.formatPendingParlayLine(parlay),
+			),
 		)
 		embed.setDescription(lines.join('\n\n'))
 		return embed
@@ -150,6 +214,9 @@ export class MyBetsFormatterService {
 			for (const bet of group.bets) {
 				lines.push(this.formatHistoryBetLine(bet, guild))
 			}
+		}
+		for (const parlay of historyPage.parlays) {
+			lines.push(this.formatHistoryParlayLine(parlay))
 		}
 
 		embed.setDescription(lines.join('\n\n'))
@@ -199,7 +266,7 @@ export class MyBetsFormatterService {
 		)
 
 		// Pending Bets Section
-		if (data.pendingBets.length > 0) {
+		if (data.pendingBets.length > 0 || data.pendingParlays.length > 0) {
 			container.addTextDisplayComponents((text) =>
 				text.setContent('## ⏳ Pending Bets'),
 			)
@@ -207,6 +274,11 @@ export class MyBetsFormatterService {
 			for (const bet of data.pendingBets) {
 				container.addTextDisplayComponents((text) =>
 					text.setContent(this.formatPendingBetLine(bet, guild)),
+				)
+			}
+			for (const parlay of data.pendingParlays) {
+				container.addTextDisplayComponents((text) =>
+					text.setContent(this.formatPendingParlayLine(parlay)),
 				)
 			}
 
@@ -222,7 +294,10 @@ export class MyBetsFormatterService {
 			),
 		)
 
-		if (data.historyPage.bets.length === 0) {
+		if (
+			data.historyPage.bets.length === 0 &&
+			data.historyPage.parlays.length === 0
+		) {
 			container.addTextDisplayComponents((text) =>
 				text.setContent(
 					'*No bet history found. Place some bets to see them here!*',
@@ -238,6 +313,11 @@ export class MyBetsFormatterService {
 						text.setContent(this.formatHistoryBetLine(bet, guild)),
 					)
 				}
+			}
+			for (const parlay of data.historyPage.parlays) {
+				container.addTextDisplayComponents((text) =>
+					text.setContent(this.formatHistoryParlayLine(parlay)),
+				)
 			}
 		}
 
@@ -267,6 +347,7 @@ export class MyBetsFormatterService {
 		const pendingEmbed = await this.buildPendingEmbed(
 			data.pendingBets,
 			guild,
+			data.pendingParlays,
 		)
 		embeds.push(pendingEmbed)
 
@@ -285,6 +366,21 @@ export class MyBetsFormatterService {
 				this.buildPaginationButtons(
 					data.historyPage.page,
 					data.historyPage.totalPages,
+				),
+			)
+		}
+		const cancellable = data.pendingParlays.filter((parlay) =>
+			this.canCancelParlay(parlay),
+		)
+		for (let index = 0; index < cancellable.length; index += 5) {
+			components.push(
+				new ActionRowBuilder<ButtonBuilder>().addComponents(
+					...cancellable.slice(index, index + 5).map((parlay) =>
+						new ButtonBuilder()
+							.setCustomId(`parlay_cancel_${parlay.id}`)
+							.setLabel(`Cancel ${parlay.id.slice(0, 6)}`)
+							.setStyle(ButtonStyle.Danger),
+					),
 				),
 			)
 		}

--- a/src/utils/api/Khronos/bets/mybets-pagination.service.ts
+++ b/src/utils/api/Khronos/bets/mybets-pagination.service.ts
@@ -2,16 +2,27 @@ import type { PlacedBetslip } from '@pluto-khronos/api-client'
 import { PlacedBetslipBetresultEnum } from '@pluto-khronos/api-client'
 import { format, isValid, parseISO } from 'date-fns'
 import { logger } from '../../../logging/WinstonLogger.js'
+import ParlayApiWrapper, {
+	type UserParlay,
+} from '../parlays/ParlayApiWrapper.js'
 import BetslipWrapper from './betslip-wrapper.js'
 
 export interface MyBetsData {
 	pendingBets: PlacedBetslip[]
 	historyBets: PlacedBetslip[]
+	pendingParlays: UserParlay[]
+	historyParlays: UserParlay[]
 	totalPages: number
 }
 
+export type HistoryEntry =
+	| { kind: 'bet'; bet: PlacedBetslip }
+	| { kind: 'parlay'; parlay: UserParlay }
+
 export interface HistoryPage {
 	bets: PlacedBetslip[]
+	parlays: UserParlay[]
+	entries: HistoryEntry[]
 	page: number
 	totalPages: number
 }
@@ -24,27 +35,65 @@ export interface BetsByDate {
 export class MyBetsPaginationService {
 	private readonly PAGE_SIZE = 10
 	private betslipWrapper: BetslipWrapper
+	private parlayWrapper: ParlayApiWrapper
 
-	constructor(betslipWrapper?: BetslipWrapper) {
+	constructor(
+		betslipWrapper?: BetslipWrapper,
+		parlayWrapper?: ParlayApiWrapper,
+	) {
 		this.betslipWrapper = betslipWrapper ?? new BetslipWrapper()
+		this.parlayWrapper = parlayWrapper ?? new ParlayApiWrapper()
 	}
 
 	async fetchUserBets(userId: string): Promise<MyBetsData> {
 		try {
-			const allBets = await this.betslipWrapper.getUserBetslips({
-				userid: userId,
-			})
+			const [betsResult, parlaysResult] = await Promise.allSettled([
+				this.betslipWrapper.getUserBetslips({ userid: userId }),
+				this.parlayWrapper.getUserParlays(userId, { limit: 100 }),
+			])
+			if (betsResult.status === 'rejected') throw betsResult.reason
+			const allBets = betsResult.value
+			const parlayResponse =
+				parlaysResult.status === 'fulfilled'
+					? parlaysResult.value
+					: { parlays: [] }
+			if (parlaysResult.status === 'rejected') {
+				logger.warn(
+					'Failed to fetch user parlays; showing singles only',
+					{
+						source: this.fetchUserBets.name,
+						userId,
+						error:
+							parlaysResult.reason instanceof Error
+								? parlaysResult.reason.message
+								: String(parlaysResult.reason),
+					},
+				)
+			}
 
 			const { pending, history } = this.splitBetsByStatus(allBets)
+			const pendingParlays = parlayResponse.parlays.filter(
+				(parlay) => parlay.status === 'pending',
+			)
+			const historyParlays = parlayResponse.parlays.filter(
+				(parlay) => parlay.status !== 'pending',
+			)
 			const sortedHistory = this.sortByDateDesc(history)
+			const sortedHistoryParlays =
+				this.sortParlaysByDateDesc(historyParlays)
 			const totalPages = Math.max(
 				1,
-				Math.ceil(sortedHistory.length / this.PAGE_SIZE),
+				Math.ceil(
+					(sortedHistory.length + sortedHistoryParlays.length) /
+						this.PAGE_SIZE,
+				),
 			)
 
 			return {
 				pendingBets: pending,
 				historyBets: sortedHistory,
+				pendingParlays,
+				historyParlays: sortedHistoryParlays,
 				totalPages,
 			}
 		} catch (error) {
@@ -86,17 +135,51 @@ export class MyBetsPaginationService {
 		})
 	}
 
-	getHistoryPage(historyBets: PlacedBetslip[], page: number): HistoryPage {
+	private sortParlaysByDateDesc(parlays: UserParlay[]): UserParlay[] {
+		return [...parlays].sort(
+			(a, b) =>
+				new Date(b.created_at).getTime() -
+				new Date(a.created_at).getTime(),
+		)
+	}
+
+	getHistoryPage(
+		historyBets: PlacedBetslip[],
+		page: number,
+		historyParlays: UserParlay[] = [],
+	): HistoryPage {
+		const entries: HistoryEntry[] = [
+			...historyBets.map((bet) => ({ kind: 'bet' as const, bet })),
+			...historyParlays.map((parlay) => ({
+				kind: 'parlay' as const,
+				parlay,
+			})),
+		].sort((a, b) => {
+			const dateA =
+				a.kind === 'bet' ? a.bet.dateofbet : a.parlay.created_at
+			const dateB =
+				b.kind === 'bet' ? b.bet.dateofbet : b.parlay.created_at
+			return (
+				new Date(dateB ?? 0).getTime() - new Date(dateA ?? 0).getTime()
+			)
+		})
 		const totalPages = Math.max(
 			1,
-			Math.ceil(historyBets.length / this.PAGE_SIZE),
+			Math.ceil(entries.length / this.PAGE_SIZE),
 		)
 		const clampedPage = Math.max(1, Math.min(page, totalPages))
 		const start = (clampedPage - 1) * this.PAGE_SIZE
 		const end = start + this.PAGE_SIZE
+		const pageEntries = entries.slice(start, end)
 
 		return {
-			bets: historyBets.slice(start, end),
+			bets: pageEntries.flatMap((entry) =>
+				entry.kind === 'bet' ? [entry.bet] : [],
+			),
+			parlays: pageEntries.flatMap((entry) =>
+				entry.kind === 'parlay' ? [entry.parlay] : [],
+			),
+			entries: pageEntries,
 			page: clampedPage,
 			totalPages,
 		}

--- a/src/utils/api/Khronos/bets/mybets-pagination.service.ts
+++ b/src/utils/api/Khronos/bets/mybets-pagination.service.ts
@@ -13,6 +13,7 @@ export interface MyBetsData {
 	pendingParlays: UserParlay[]
 	historyParlays: UserParlay[]
 	totalPages: number
+	parlayFetchWarning?: string
 }
 
 export type HistoryEntry =
@@ -32,6 +33,11 @@ export interface BetsByDate {
 	bets: PlacedBetslip[]
 }
 
+interface ParlayFetchResult {
+	parlays: UserParlay[]
+	warning?: string
+}
+
 export class MyBetsPaginationService {
 	private readonly PAGE_SIZE = 10
 	private betslipWrapper: BetslipWrapper
@@ -49,14 +55,18 @@ export class MyBetsPaginationService {
 		try {
 			const [betsResult, parlaysResult] = await Promise.allSettled([
 				this.betslipWrapper.getUserBetslips({ userid: userId }),
-				this.parlayWrapper.getUserParlays(userId, { limit: 100 }),
+				this.fetchAllUserParlays(userId),
 			])
 			if (betsResult.status === 'rejected') throw betsResult.reason
 			const allBets = betsResult.value
 			const parlayResponse =
 				parlaysResult.status === 'fulfilled'
 					? parlaysResult.value
-					: { parlays: [] }
+					: {
+							parlays: [],
+							warning:
+								'Some parlays could not be loaded. Refresh /mybets to try again.',
+						}
 			if (parlaysResult.status === 'rejected') {
 				logger.warn(
 					'Failed to fetch user parlays; showing singles only',
@@ -95,6 +105,7 @@ export class MyBetsPaginationService {
 				pendingParlays,
 				historyParlays: sortedHistoryParlays,
 				totalPages,
+				parlayFetchWarning: parlayResponse.warning,
 			}
 		} catch (error) {
 			logger.error('Failed to fetch user betslips', {
@@ -107,6 +118,47 @@ export class MyBetsPaginationService {
 
 			throw error
 		}
+	}
+
+	private async fetchAllUserParlays(
+		userId: string,
+	): Promise<ParlayFetchResult> {
+		const pageSize = 100
+		const firstPage = await this.parlayWrapper.getUserParlays(userId, {
+			page: 1,
+			limit: pageSize,
+		})
+		const totalPages = Math.max(1, firstPage.total_pages || 1)
+		const parlays = [...firstPage.parlays]
+
+		for (let page = 2; page <= totalPages; page++) {
+			try {
+				const nextPage = await this.parlayWrapper.getUserParlays(
+					userId,
+					{
+						page,
+						limit: pageSize,
+					},
+				)
+				parlays.push(...nextPage.parlays)
+			} catch (error) {
+				logger.warn('Failed to fetch a later user parlay page', {
+					source: this.fetchAllUserParlays.name,
+					userId,
+					page,
+					totalPages,
+					error:
+						error instanceof Error ? error.message : String(error),
+				})
+				return {
+					parlays,
+					warning:
+						'Some parlays could not be loaded. Refresh /mybets to try again.',
+				}
+			}
+		}
+
+		return { parlays }
 	}
 
 	private splitBetsByStatus(bets: PlacedBetslip[]): {

--- a/src/utils/api/Khronos/guild/guild-wrapper.ts
+++ b/src/utils/api/Khronos/guild/guild-wrapper.ts
@@ -209,7 +209,11 @@ export default class GuildWrapper {
 		options: MessageCreateOptions,
 		expectedGuildId?: string,
 	): Promise<Message> {
-		this.validateSnowflake(channelId, 'target', expectedGuildId ?? 'unknown')
+		this.validateSnowflake(
+			channelId,
+			'target',
+			expectedGuildId ?? 'unknown',
+		)
 
 		let channel: Channel | null
 		try {

--- a/src/utils/api/Khronos/guild/guild-wrapper.ts
+++ b/src/utils/api/Khronos/guild/guild-wrapper.ts
@@ -196,17 +196,21 @@ export default class GuildWrapper {
 	}
 
 	/**
-	 * Sends a message to an explicitly supplied text channel.
+	 * Sends a message to an explicitly supplied Discord text channel.
 	 *
-	 * This is used by trusted cross-service payloads that carry a channel
-	 * snapshot (for example, the Khronos daily-props delivery contract). The
-	 * configured prediction-channel helper remains the default for commands.
+	 * Trusted cross-service payloads can carry a resolved channel snapshot
+	 * (for example, Khronos daily props delivery). Using that channel keeps
+	 * returned message references authoritative even if guild configuration
+	 * changes before delivery. The configured prediction helper remains the
+	 * default for command-driven posting.
 	 */
 	async sendToChannel(
 		channelId: string,
 		options: MessageCreateOptions,
 		expectedGuildId?: string,
 	): Promise<Message> {
+		this.validateSnowflake(channelId, 'target', expectedGuildId ?? 'unknown')
+
 		let channel: Channel | null
 		try {
 			channel = await container.client.channels.fetch(channelId)

--- a/src/utils/api/Khronos/guild/guild-wrapper.ts
+++ b/src/utils/api/Khronos/guild/guild-wrapper.ts
@@ -196,6 +196,43 @@ export default class GuildWrapper {
 	}
 
 	/**
+	 * Sends a message to an explicitly supplied text channel.
+	 *
+	 * This is used by trusted cross-service payloads that carry a channel
+	 * snapshot (for example, the Khronos daily-props delivery contract). The
+	 * configured prediction-channel helper remains the default for commands.
+	 */
+	async sendToChannel(
+		channelId: string,
+		options: MessageCreateOptions,
+		expectedGuildId?: string,
+	): Promise<Message> {
+		let channel: Channel | null
+		try {
+			channel = await container.client.channels.fetch(channelId)
+		} catch (error) {
+			throw new Error(
+				`Failed to fetch target channel ${channelId}: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+
+		if (!channel || channel.type !== ChannelType.GuildText) {
+			throw new Error(
+				`Target channel ${channelId} could not be found or is not a text channel`,
+			)
+		}
+
+		const textChannel = channel as TextChannel
+		if (expectedGuildId && textChannel.guild.id !== expectedGuildId) {
+			throw new Error(
+				`Target channel ${channelId} does not belong to guild ${expectedGuildId}`,
+			)
+		}
+
+		return await textChannel.send(options)
+	}
+
+	/**
 	 * Retrieves the configured betting channel for a guild
 	 * @param guildId - Discord guild ID
 	 * @returns TextChannel for posting bets

--- a/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.test.ts
+++ b/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const fetchApi = vi.fn()
+
+vi.mock('../KhronosInstances.js', () => ({
+	KH_API_CONFIG: {
+		basePath: 'https://khronos.test/',
+		headers: { 'x-api-key': 'test-key' },
+		fetchApi,
+	},
+}))
+
+const { default: LeaderboardWrapper, parseLeaderboardWithStreaks } =
+	await import('./leaderboard-wrapper.js')
+
+describe('parseLeaderboardWithStreaks', () => {
+	it('preserves streak fields from the raw snake-case wire response', () => {
+		expect(
+			parseLeaderboardWithStreaks({
+				entries: [
+					{
+						user_id: 'user-1',
+						total_predictions: 12,
+						correct_predictions: 9,
+						incorrect_predictions: 3,
+						success_rate: 75,
+						current_streak: 4,
+						best_streak: 7,
+						badge_tier: 5,
+					},
+				],
+				total_users: 1,
+			}),
+		).toEqual({
+			entries: [
+				{
+					user_id: 'user-1',
+					total_predictions: 12,
+					correct_predictions: 9,
+					incorrect_predictions: 3,
+					success_rate: 75,
+					current_streak: 4,
+					best_streak: 7,
+					badge_tier: 5,
+				},
+			],
+			total_users: 1,
+		})
+	})
+
+	it('normalizes camel-case fields and missing streak fields', () => {
+		expect(
+			parseLeaderboardWithStreaks({
+				entries: [
+					{
+						userId: 'user-2',
+						totalPredictions: 0,
+						correctPredictions: 0,
+						incorrectPredictions: 0,
+						successRate: 0,
+					},
+				],
+				totalUsers: 1,
+			}),
+		).toMatchObject({
+			entries: [
+				{
+					user_id: 'user-2',
+					current_streak: 0,
+					best_streak: 0,
+					badge_tier: null,
+				},
+			],
+			total_users: 1,
+		})
+	})
+})
+
+describe('LeaderboardWrapper', () => {
+	it('uses the raw transport so generated DTOs cannot drop streak fields', async () => {
+		fetchApi.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				entries: [
+					{
+						user_id: 'user-1',
+						total_predictions: 10,
+						correct_predictions: 8,
+						incorrect_predictions: 2,
+						success_rate: 80,
+						current_streak: 3,
+						best_streak: 5,
+						badge_tier: 3,
+					},
+				],
+				total_users: 1,
+			}),
+		})
+
+		await expect(
+			new LeaderboardWrapper().getLeaderboard({ guildId: 'guild/1' }),
+		).resolves.toMatchObject({
+			entries: [{ current_streak: 3, best_streak: 5, badge_tier: 3 }],
+		})
+		expect(fetchApi).toHaveBeenCalledWith(
+			'https://khronos.test/api/khronos/v1/leaderboard?guild_id=guild%2F1',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'x-api-key': 'test-key',
+					Accept: 'application/json',
+				}),
+			}),
+		)
+	})
+
+	it('surfaces non-success responses instead of returning an empty leaderboard', async () => {
+		fetchApi.mockResolvedValueOnce({ ok: false, status: 503 })
+
+		await expect(
+			new LeaderboardWrapper().getLeaderboard({ guildId: 'guild-1' }),
+		).rejects.toThrow('Khronos leaderboard request failed (503)')
+	})
+})

--- a/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.ts
+++ b/src/utils/api/Khronos/leaderboard/leaderboard-wrapper.ts
@@ -1,17 +1,150 @@
-import type { SimpleLeaderboardResponseDto } from '@pluto-khronos/api-client'
-import {
-	LeaderboardApi,
-	type LeaderboardControllerGetLeaderboardV1Request,
-} from '@pluto-khronos/api-client'
+import type { LeaderboardControllerGetLeaderboardV1Request } from '@pluto-khronos/api-client'
+import type { StreakBadgeTier } from '../../../predictions/streak-display.js'
 import { type IKH_API_CONFIG, KH_API_CONFIG } from '../KhronosInstances.js'
 
-export default class LeaderboardWrapper {
-	private leaderboardsApi: LeaderboardApi
-	private readonly khConfig: IKH_API_CONFIG = KH_API_CONFIG
+export type { StreakBadgeTier }
 
-	constructor() {
-		this.leaderboardsApi = new LeaderboardApi(this.khConfig)
+export interface LeaderboardEntryWithStreaks {
+	user_id: string
+	total_predictions: number
+	correct_predictions: number
+	incorrect_predictions: number
+	success_rate: number
+	current_streak: number
+	best_streak: number
+	badge_tier: StreakBadgeTier
+}
+
+export interface LeaderboardResponseWithStreaks {
+	entries: LeaderboardEntryWithStreaks[]
+	total_users: number
+}
+
+const readField = (
+	value: Record<string, unknown>,
+	snakeCase: string,
+	camelCase: string,
+) =>
+	Object.prototype.hasOwnProperty.call(value, snakeCase)
+		? value[snakeCase]
+		: value[camelCase]
+
+const readRequiredNumber = (
+	value: Record<string, unknown>,
+	snakeCase: string,
+	camelCase: string,
+) => {
+	const field = readField(value, snakeCase, camelCase)
+	if (typeof field !== 'number' || !Number.isFinite(field)) {
+		throw new Error(`Khronos returned an invalid leaderboard ${snakeCase}`)
 	}
+	return field
+}
+
+const readOptionalNumber = (
+	value: Record<string, unknown>,
+	snakeCase: string,
+	camelCase: string,
+) => {
+	const field = readField(value, snakeCase, camelCase)
+	if (field === undefined || field === null) return 0
+	if (typeof field !== 'number' || !Number.isFinite(field)) {
+		throw new Error(`Khronos returned an invalid leaderboard ${snakeCase}`)
+	}
+	return field
+}
+
+/**
+ * Normalize the wire response without going through the generated client DTO.
+ *
+ * The installed Khronos client predates streak fields and its generated
+ * deserializer drops unknown properties before this wrapper can see them.
+ */
+export function parseLeaderboardWithStreaks(
+	payload: unknown,
+): LeaderboardResponseWithStreaks {
+	if (!payload || typeof payload !== 'object') {
+		throw new Error('Khronos returned an invalid leaderboard payload')
+	}
+
+	const response = payload as Record<string, unknown>
+	if (!Array.isArray(response.entries)) {
+		throw new Error(
+			'Khronos returned an invalid leaderboard entries payload',
+		)
+	}
+	const totalUsers = readField(response, 'total_users', 'totalUsers')
+	if (typeof totalUsers !== 'number' || !Number.isFinite(totalUsers)) {
+		throw new Error('Khronos returned an invalid leaderboard total_users')
+	}
+
+	return {
+		total_users: totalUsers,
+		entries: response.entries.map((entry) => {
+			if (!entry || typeof entry !== 'object') {
+				throw new Error('Khronos returned an invalid leaderboard entry')
+			}
+			const value = entry as Record<string, unknown>
+			const userId = readField(value, 'user_id', 'userId')
+			if (typeof userId !== 'string') {
+				throw new Error(
+					'Khronos returned an invalid leaderboard user_id',
+				)
+			}
+			const badgeTier = readField(value, 'badge_tier', 'badgeTier')
+			if (
+				badgeTier !== undefined &&
+				badgeTier !== null &&
+				badgeTier !== 3 &&
+				badgeTier !== 5 &&
+				badgeTier !== 10
+			) {
+				throw new Error(
+					'Khronos returned an invalid leaderboard badge tier',
+				)
+			}
+
+			return {
+				...value,
+				user_id: userId,
+				total_predictions: readRequiredNumber(
+					value,
+					'total_predictions',
+					'totalPredictions',
+				),
+				correct_predictions: readRequiredNumber(
+					value,
+					'correct_predictions',
+					'correctPredictions',
+				),
+				incorrect_predictions: readRequiredNumber(
+					value,
+					'incorrect_predictions',
+					'incorrectPredictions',
+				),
+				success_rate: readRequiredNumber(
+					value,
+					'success_rate',
+					'successRate',
+				),
+				current_streak: readOptionalNumber(
+					value,
+					'current_streak',
+					'currentStreak',
+				),
+				best_streak: readOptionalNumber(
+					value,
+					'best_streak',
+					'bestStreak',
+				),
+				badge_tier: (badgeTier ?? null) as StreakBadgeTier,
+			}
+		}),
+	}
+}
+
+export default class LeaderboardWrapper {
+	private readonly khConfig: IKH_API_CONFIG = KH_API_CONFIG
 
 	/**
 	 * @summary Retrieve leaderboard data based upon provided data
@@ -20,9 +153,27 @@ export default class LeaderboardWrapper {
 	 */
 	async getLeaderboard(
 		params: LeaderboardControllerGetLeaderboardV1Request,
-	): Promise<SimpleLeaderboardResponseDto> {
-		return await this.leaderboardsApi.leaderboardControllerGetLeaderboardV1(
-			params,
+	): Promise<LeaderboardResponseWithStreaks> {
+		const path = '/api/khronos/v1/leaderboard'
+		const query = new URLSearchParams({ guild_id: params.guildId })
+		const fetchApi = this.khConfig.fetchApi ?? fetch
+		const response = await fetchApi(
+			`${this.khConfig.basePath.replace(/\/$/, '')}${path}?${query.toString()}`,
+			{
+				method: 'GET',
+				headers: {
+					...this.khConfig.headers,
+					Accept: 'application/json',
+				},
+			},
 		)
+
+		if (!response.ok) {
+			throw new Error(
+				`Khronos leaderboard request failed (${response.status})`,
+			)
+		}
+
+		return parseLeaderboardWithStreaks(await response.json())
 	}
 }

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -106,15 +106,42 @@ export default class ParlayApiWrapper {
 		return response.data
 	}
 
-	async place(initToken: string): Promise<ParlayResponse> {
+	async place(
+		initToken: string,
+		placementId: string,
+	): Promise<ParlayResponse> {
 		const mock = await this.mockPromise
 		if (mock) return mock.placeParlay(initToken)
 		const response = await AxiosKhronosInstance.post<ParlayResponse>(
 			'/parlays/place',
-			{ init_token: initToken },
+			{ init_token: initToken, placement_id: placementId },
 			this.requestConfig,
 		)
 		return response.data
+	}
+
+	async findByPlacement(placementId: string): Promise<ParlayResponse | null> {
+		const mock = await this.mockPromise
+		if (mock) return null
+		try {
+			const response = await AxiosKhronosInstance.get<ParlayResponse>(
+				`/parlays/placements/${encodeURIComponent(placementId)}`,
+				this.requestConfig,
+			)
+			return response.data
+		} catch (error) {
+			const status =
+				typeof error === 'object' &&
+				error !== null &&
+				'response' in error &&
+				typeof error.response === 'object' &&
+				error.response !== null &&
+				'status' in error.response
+					? error.response.status
+					: undefined
+			if (status === 404) return null
+			throw error
+		}
 	}
 
 	async getUserParlays(

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -135,3 +135,8 @@ export default class ParlayApiWrapper {
 		return response.data
 	}
 }
+
+/** Alias used by mybets surfaces (TF-969). */
+export type UserParlay = ParlayResponse
+/** Alias used by mybets leg formatting (TF-969). */
+export type ParlayLeg = PlacedParlayLeg

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -1,0 +1,137 @@
+import type { AxiosRequestConfig } from 'axios'
+import { AxiosKhronosInstance } from '../../common/axios-config.js'
+
+export type ParlayMarketKey = 'h2h' | 'spreads' | 'totals'
+
+export interface ParlayLegInput {
+	event_id: string
+	outcome_uuid: string
+}
+
+export interface InitParlayRequest {
+	legs: ParlayLegInput[]
+	stake: number
+	guild_id: string
+	user_id: string
+}
+
+export interface ParlayLegPreview {
+	event_id: string
+	outcome_uuid: string
+	market_key: ParlayMarketKey
+	selection_display: string
+	odds_american: number
+	point: number | null
+	commence_time: string
+}
+
+export interface InitParlayResponse {
+	init_token: string
+	combined_odds_american: number
+	potential_payout: number
+	legs: ParlayLegPreview[]
+	expires_at: string
+}
+
+export interface PlacedParlayLeg extends ParlayLegPreview {
+	id: string
+	result: 'pending' | 'won' | 'lost' | 'push' | 'void'
+	settled_at: string | null
+}
+
+export interface ParlayResponse {
+	id: string
+	user_id: string
+	guild_id: string
+	stake: number
+	combined_odds_american: number
+	potential_payout: number
+	actual_payout: number | null
+	status: 'pending' | 'won' | 'lost' | 'push_refunded' | 'cancelled'
+	leg_count: number
+	created_at: string
+	settled_at: string | null
+	legs: PlacedParlayLeg[]
+}
+
+export interface UserParlaysResponse {
+	parlays: ParlayResponse[]
+	page: number
+	limit: number
+	total: number
+	total_pages: number
+}
+
+export interface EventOutcome {
+	uuid?: string
+	event_id?: string
+	market_key?: string
+	name?: string
+	description?: string
+	price?: number
+	point?: number | null
+	position?: string
+	outcome_type?: string
+	event_context?: {
+		commence_time?: string
+		home_team?: string
+		away_team?: string
+	}
+}
+
+export default class ParlayApiWrapper {
+	private readonly requestConfig: AxiosRequestConfig = {
+		validateStatus: (status) => status >= 200 && status < 300,
+	}
+
+	async init(payload: InitParlayRequest): Promise<InitParlayResponse> {
+		const response = await AxiosKhronosInstance.post<InitParlayResponse>(
+			'/parlays/init',
+			payload,
+			this.requestConfig,
+		)
+		return response.data
+	}
+
+	async place(initToken: string): Promise<ParlayResponse> {
+		const response = await AxiosKhronosInstance.post<ParlayResponse>(
+			'/parlays/place',
+			{ init_token: initToken },
+			this.requestConfig,
+		)
+		return response.data
+	}
+
+	async getUserParlays(
+		userId: string,
+		options: { page?: number; limit?: number; status?: string } = {},
+	): Promise<UserParlaysResponse> {
+		const response = await AxiosKhronosInstance.get<UserParlaysResponse>(
+			`/parlays/user/${encodeURIComponent(userId)}`,
+			{ ...this.requestConfig, params: options },
+		)
+		return response.data
+	}
+
+	async cancel(parlayId: string, userId: string): Promise<ParlayResponse> {
+		const response = await AxiosKhronosInstance.delete<ParlayResponse>(
+			`/parlays/${encodeURIComponent(parlayId)}`,
+			{
+				...this.requestConfig,
+				data: { user_id: userId },
+			},
+		)
+		return response.data
+	}
+
+	async getEventOutcomes(
+		sport: string,
+		eventId: string,
+	): Promise<EventOutcome[]> {
+		const response = await AxiosKhronosInstance.get<EventOutcome[]>(
+			`/outcomes/event/${encodeURIComponent(sport)}/${encodeURIComponent(eventId)}`,
+			this.requestConfig,
+		)
+		return response.data
+	}
+}

--- a/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
+++ b/src/utils/api/Khronos/parlays/ParlayApiWrapper.ts
@@ -1,4 +1,5 @@
 import type { AxiosRequestConfig } from 'axios'
+import type { MockBackend } from '../../../dev/mock-backend.js'
 import { AxiosKhronosInstance } from '../../common/axios-config.js'
 
 export type ParlayMarketKey = 'h2h' | 'spreads' | 'totals'
@@ -83,8 +84,20 @@ export default class ParlayApiWrapper {
 	private readonly requestConfig: AxiosRequestConfig = {
 		validateStatus: (status) => status >= 200 && status < 300,
 	}
+	private readonly mockPromise: Promise<MockBackend | undefined>
+
+	constructor() {
+		this.mockPromise =
+			process.env.USE_MOCK_DATA === 'true'
+				? import('../../../dev/index.js').then(({ MockBackend }) =>
+						MockBackend.instance(),
+					)
+				: Promise.resolve(undefined)
+	}
 
 	async init(payload: InitParlayRequest): Promise<InitParlayResponse> {
+		const mock = await this.mockPromise
+		if (mock) return mock.initParlay(payload)
 		const response = await AxiosKhronosInstance.post<InitParlayResponse>(
 			'/parlays/init',
 			payload,
@@ -94,6 +107,8 @@ export default class ParlayApiWrapper {
 	}
 
 	async place(initToken: string): Promise<ParlayResponse> {
+		const mock = await this.mockPromise
+		if (mock) return mock.placeParlay(initToken)
 		const response = await AxiosKhronosInstance.post<ParlayResponse>(
 			'/parlays/place',
 			{ init_token: initToken },
@@ -106,6 +121,8 @@ export default class ParlayApiWrapper {
 		userId: string,
 		options: { page?: number; limit?: number; status?: string } = {},
 	): Promise<UserParlaysResponse> {
+		const mock = await this.mockPromise
+		if (mock) return mock.getUserParlays(userId, options)
 		const response = await AxiosKhronosInstance.get<UserParlaysResponse>(
 			`/parlays/user/${encodeURIComponent(userId)}`,
 			{ ...this.requestConfig, params: options },
@@ -114,6 +131,8 @@ export default class ParlayApiWrapper {
 	}
 
 	async cancel(parlayId: string, userId: string): Promise<ParlayResponse> {
+		const mock = await this.mockPromise
+		if (mock) return mock.cancelParlay(parlayId, userId)
 		const response = await AxiosKhronosInstance.delete<ParlayResponse>(
 			`/parlays/${encodeURIComponent(parlayId)}`,
 			{
@@ -128,6 +147,8 @@ export default class ParlayApiWrapper {
 		sport: string,
 		eventId: string,
 	): Promise<EventOutcome[]> {
+		const mock = await this.mockPromise
+		if (mock) return mock.getEventOutcomes(sport, eventId)
 		const response = await AxiosKhronosInstance.get<EventOutcome[]>(
 			`/outcomes/event/${encodeURIComponent(sport)}/${encodeURIComponent(eventId)}`,
 			this.requestConfig,

--- a/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.mock.test.ts
+++ b/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.mock.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockBackend = {
+	initParlay: vi.fn(),
+	placeParlay: vi.fn(),
+	getUserParlays: vi.fn(),
+	cancelParlay: vi.fn(),
+	getEventOutcomes: vi.fn(),
+}
+
+vi.mock('../../../../dev/index.js', () => ({
+	MockBackend: { instance: () => mockBackend },
+}))
+
+vi.mock('../../../common/axios-config.js', () => ({
+	AxiosKhronosInstance: { post: vi.fn(), get: vi.fn(), delete: vi.fn() },
+}))
+
+const { default: ParlayApiWrapper } = await import('../ParlayApiWrapper.js')
+
+describe('ParlayApiWrapper mock mode', () => {
+	beforeEach(() => {
+		vi.stubEnv('USE_MOCK_DATA', 'true')
+		vi.clearAllMocks()
+	})
+
+	it('routes parlay initialization through MockBackend', async () => {
+		const response = { init_token: 'mock-token' }
+		mockBackend.initParlay.mockReturnValue(response)
+
+		await expect(
+			new ParlayApiWrapper().init({
+				legs: [],
+				stake: 10,
+				guild_id: 'guild-1',
+				user_id: 'user-1',
+			}),
+		).resolves.toBe(response)
+		expect(mockBackend.initParlay).toHaveBeenCalledOnce()
+	})
+
+	it('routes outcome lookup through MockBackend', async () => {
+		const response = [{ uuid: 'outcome-1' }]
+		mockBackend.getEventOutcomes.mockReturnValue(response)
+
+		await expect(
+			new ParlayApiWrapper().getEventOutcomes('nba', 'event-1'),
+		).resolves.toBe(response)
+		expect(mockBackend.getEventOutcomes).toHaveBeenCalledWith(
+			'nba',
+			'event-1',
+		)
+	})
+})

--- a/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
+++ b/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const get = vi.fn()
+const del = vi.fn()
+
+vi.mock('../../../common/axios-config.js', () => ({
+	AxiosKhronosInstance: { get, delete: del },
+}))
+
+const { default: ParlayApiWrapper } = await import('../ParlayApiWrapper.js')
+
+describe('ParlayApiWrapper', () => {
+	it('fetches user parlays with pagination parameters', async () => {
+		get.mockResolvedValueOnce({ data: { parlays: [], page: 2 } })
+
+		const result = await new ParlayApiWrapper().getUserParlays('user/1', {
+			page: 2,
+			limit: 25,
+			status: 'pending',
+		})
+
+		expect(result.parlays).toEqual([])
+		expect(get).toHaveBeenCalledWith(
+			'/parlays/user/user%2F1',
+			expect.objectContaining({
+				params: { page: 2, limit: 25, status: 'pending' },
+			}),
+		)
+	})
+
+	it('cancels a parlay with an ownership payload', async () => {
+		del.mockResolvedValueOnce({
+			data: { id: 'parlay-1', status: 'cancelled' },
+		})
+
+		await new ParlayApiWrapper().cancel('parlay/1', 'user-1')
+
+		expect(del).toHaveBeenCalledWith(
+			'/parlays/parlay%2F1',
+			expect.objectContaining({ data: { user_id: 'user-1' } }),
+		)
+	})
+})

--- a/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
+++ b/src/utils/api/Khronos/parlays/__tests__/ParlayApiWrapper.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 
 const get = vi.fn()
 const del = vi.fn()
+const post = vi.fn()
 
 vi.mock('../../../common/axios-config.js', () => ({
-	AxiosKhronosInstance: { get, delete: del },
+	AxiosKhronosInstance: { get, post, delete: del },
 }))
 
 const { default: ParlayApiWrapper } = await import('../ParlayApiWrapper.js')
@@ -39,5 +40,45 @@ describe('ParlayApiWrapper', () => {
 			'/parlays/parlay%2F1',
 			expect.objectContaining({ data: { user_id: 'user-1' } }),
 		)
+	})
+
+	it('sends the stable placement id and reconciles a committed placement', async () => {
+		post.mockResolvedValueOnce({
+			data: { id: 'parlay-1', status: 'pending' },
+		})
+		get.mockResolvedValueOnce({
+			data: { id: 'parlay-1', status: 'pending' },
+		})
+		const api = new ParlayApiWrapper()
+
+		await expect(
+			api.place('init-token', '00000000-0000-4000-8000-000000000001'),
+		).resolves.toMatchObject({ id: 'parlay-1' })
+		await expect(
+			api.findByPlacement('00000000-0000-4000-8000-000000000001'),
+		).resolves.toMatchObject({ id: 'parlay-1' })
+
+		expect(post).toHaveBeenCalledWith(
+			'/parlays/place',
+			{
+				init_token: 'init-token',
+				placement_id: '00000000-0000-4000-8000-000000000001',
+			},
+			expect.any(Object),
+		)
+		expect(get).toHaveBeenCalledWith(
+			'/parlays/placements/00000000-0000-4000-8000-000000000001',
+			expect.any(Object),
+		)
+	})
+
+	it('treats a missing placement as a completed reconciliation', async () => {
+		get.mockRejectedValueOnce({ response: { status: 404 } })
+
+		await expect(
+			new ParlayApiWrapper().findByPlacement(
+				'00000000-0000-4000-8000-000000000001',
+			),
+		).resolves.toBeNull()
 	})
 })

--- a/src/utils/api/Khronos/prediction/__tests__/predictionApiWrapper.test.ts
+++ b/src/utils/api/Khronos/prediction/__tests__/predictionApiWrapper.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	removePrediction: vi.fn(),
+	removePredictionById: vi.fn(),
+}))
+
+vi.mock('@pluto-khronos/api-client', () => ({
+	AccountsApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	BetslipsApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	ChangelogsApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	Configuration: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	DiscordConfigApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	GuildsApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	MatchesApi: vi.fn().mockImplementation(function () {
+		return {}
+	}),
+	PredictionApi: vi.fn().mockImplementation(function () {
+		return mocks
+	}),
+}))
+
+vi.mock('../../../../../lib/startup/env.js', () => ({
+	default: {
+		KH_API_URL: 'https://khronos.test',
+		KH_PLUTO_CLIENT_KEY: 'test-key',
+	},
+}))
+
+const { default: PredictionApiWrapper } = await import(
+	'../predictionApiWrapper.js'
+)
+
+describe('PredictionApiWrapper deletion routes', () => {
+	beforeEach(() => {
+		mocks.removePrediction.mockReset()
+		mocks.removePredictionById.mockReset()
+	})
+
+	it('uses the event-based DELETE route explicitly', async () => {
+		const wrapper = new PredictionApiWrapper()
+		const params = { id: 'event-1', userId: 'user-1' }
+
+		await wrapper.deletePredictionByEvent(params)
+
+		expect(mocks.removePrediction).toHaveBeenCalledWith(params)
+		expect(mocks.removePredictionById).not.toHaveBeenCalled()
+	})
+
+	it('keeps the deprecated event-based deletion alias compatible', async () => {
+		const wrapper = new PredictionApiWrapper()
+		const params = { id: 'event-1', userId: 'user-1' }
+
+		await wrapper.deletePrediction(params)
+
+		expect(mocks.removePrediction).toHaveBeenCalledWith(params)
+	})
+
+	it('uses the prediction-id DELETE route explicitly', async () => {
+		const wrapper = new PredictionApiWrapper()
+		const params = { predictionId: 'prediction-1', userId: 'user-1' }
+
+		await wrapper.deletePredictionById(params)
+
+		expect(mocks.removePredictionById).toHaveBeenCalledWith(params)
+		expect(mocks.removePrediction).not.toHaveBeenCalled()
+	})
+})

--- a/src/utils/api/Khronos/prediction/predictionApiWrapper.ts
+++ b/src/utils/api/Khronos/prediction/predictionApiWrapper.ts
@@ -44,8 +44,23 @@ export default class PredictionApiWrapper {
 		}
 	}
 
-	async deletePrediction(params: RemovePredictionRequest) {
+	/**
+	 * Delete the user's prediction for an event.
+	 *
+	 * Khronos keeps this event-based DELETE route for callers that only have
+	 * the event ID. Keep the route intent in the wrapper name so callers do
+	 * not accidentally use it when they have a prediction ID.
+	 */
+	async deletePredictionByEvent(params: RemovePredictionRequest) {
 		await this.predictionApi.removePrediction(params)
+	}
+
+	/**
+	 * @deprecated Use deletePredictionByEvent so the event-based route is
+	 * explicit. Keep this alias while downstream consumers migrate.
+	 */
+	async deletePrediction(params: RemovePredictionRequest) {
+		return this.deletePredictionByEvent(params)
 	}
 
 	async getPredictionsFiltered(

--- a/src/utils/api/Khronos/recap/recap-wrapper.ts
+++ b/src/utils/api/Khronos/recap/recap-wrapper.ts
@@ -1,0 +1,107 @@
+import * as KhronosApiClient from '@pluto-khronos/api-client'
+import pTimeout from 'p-timeout'
+import { KH_API_CONFIG } from '../KhronosInstances.js'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+/**
+ * Weekly recap contract exposed by Khronos TF-957.
+ *
+ * Kept local until the generated client release containing RecapApi is
+ * published. The runtime constructor is resolved from that generated client
+ * so this module does not introduce a hand-written HTTP implementation.
+ */
+export interface WeeklyRecapResponse {
+	window: {
+		start_date: string
+		end_date: string
+		week_number?: number
+		season_year?: number
+	}
+	total_predictions: number
+	correct_predictions: number
+	incorrect_predictions: number
+	accuracy: number
+	accuracy_delta: number
+	top_predictors: Array<{
+		user_id: string
+		correct_predictions: number
+		incorrect_predictions: number
+		success_rate: number
+		display_name?: string
+	}>
+	biggest_single_win: {
+		user_id: string
+		payout: number
+		bet_id?: number
+		parlay_id?: string
+	} | null
+	biggest_parlay_win: {
+		user_id: string
+		payout: number
+		bet_id?: number
+		parlay_id?: string
+	} | null
+}
+
+export interface WeeklyRecapRequest {
+	guildId: string
+	weekOffset?: number
+}
+
+export interface RecapApiClient {
+	getWeeklyRecap(
+		guildId: string,
+		weekOffset?: number,
+	): Promise<WeeklyRecapResponse>
+}
+
+interface GeneratedRecapApiClient {
+	getWeeklyRecap(request: WeeklyRecapRequest): Promise<WeeklyRecapResponse>
+}
+
+type RecapApiConstructor = new (
+	config: typeof KH_API_CONFIG,
+) => GeneratedRecapApiClient
+
+const GeneratedRecapApi = (
+	KhronosApiClient as unknown as { RecapApi?: RecapApiConstructor }
+).RecapApi
+
+/**
+ * Generated-client wrapper for Khronos weekly recap data.
+ */
+export default class RecapWrapper implements RecapApiClient {
+	private readonly recapApi: GeneratedRecapApiClient
+
+	constructor(recapApi?: RecapApiClient) {
+		if (recapApi) {
+			this.recapApi = {
+				getWeeklyRecap: (request) =>
+					recapApi.getWeeklyRecap(
+						request.guildId,
+						request.weekOffset,
+					),
+			}
+			return
+		}
+
+		if (!GeneratedRecapApi) {
+			throw new Error(
+				'Khronos RecapApi is unavailable; update @pluto-khronos/api-client to the TF-957 release before enabling weekly recaps',
+			)
+		}
+
+		this.recapApi = new GeneratedRecapApi(KH_API_CONFIG)
+	}
+
+	async getWeeklyRecap(
+		guildId: string,
+		weekOffset = -1,
+	): Promise<WeeklyRecapResponse> {
+		return await pTimeout(
+			this.recapApi.getWeeklyRecap({ guildId, weekOffset }),
+			{ milliseconds: DEFAULT_TIMEOUT_MS },
+		)
+	}
+}

--- a/src/utils/api/Khronos/stats/stats-wrapper.test.ts
+++ b/src/utils/api/Khronos/stats/stats-wrapper.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ fetchApi: vi.fn() }))
+
+vi.mock('../KhronosInstances.js', () => ({
+	KH_API_CONFIG: {
+		basePath: 'https://khronos.test/',
+		headers: { 'x-api-key': 'test-key' },
+		fetchApi: mocks.fetchApi,
+	},
+}))
+
+const { default: StatsWrapper, parsePredictionStats } = await import(
+	'./stats-wrapper.js'
+)
+
+describe('parsePredictionStats', () => {
+	it('accepts both generated camel-case and wire snake-case fields', () => {
+		expect(
+			parsePredictionStats({
+				userId: 'user-1',
+				correctPredictions: 9,
+				incorrectPredictions: 3,
+				totalPredictions: 12,
+				successRate: 75,
+				currentStreak: 4,
+				bestStreak: 7,
+				badgeTier: 3,
+			}),
+		).toEqual({
+			user_id: 'user-1',
+			correct_predictions: 9,
+			incorrect_predictions: 3,
+			total_predictions: 12,
+			success_rate: 75,
+			current_streak: 4,
+			best_streak: 7,
+			badge_tier: 3,
+		})
+
+		expect(
+			parsePredictionStats({
+				user_id: 'user-2',
+				correct_predictions: 0,
+				incorrect_predictions: 0,
+				total_predictions: 0,
+				success_rate: 0,
+				current_streak: 0,
+				best_streak: 0,
+				badge_tier: null,
+			}),
+		).toMatchObject({ user_id: 'user-2', badge_tier: null })
+	})
+
+	it('normalizes a trailing-slash base URL for the raw stats transport', async () => {
+		mocks.fetchApi.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				user_id: 'user-1',
+				correct_predictions: 9,
+				incorrect_predictions: 3,
+				total_predictions: 12,
+				success_rate: 75,
+				current_streak: 4,
+				best_streak: 7,
+				badge_tier: 3,
+			}),
+		})
+
+		await new StatsWrapper().getPredictionStats({
+			userId: 'user-1',
+			guildId: 'guild-1',
+		})
+
+		expect(mocks.fetchApi).toHaveBeenCalledWith(
+			'https://khronos.test/api/khronos/v1/prediction/stats/user-1?guild_id=guild-1',
+			expect.anything(),
+		)
+	})
+})

--- a/src/utils/api/Khronos/stats/stats-wrapper.ts
+++ b/src/utils/api/Khronos/stats/stats-wrapper.ts
@@ -5,7 +5,98 @@ import {
 } from '@pluto-khronos/api-client'
 import { KH_API_CONFIG } from '../KhronosInstances.js'
 
-export default class StatsWraps {
+export interface PredictionStats {
+	user_id: string
+	correct_predictions: number
+	incorrect_predictions: number
+	total_predictions: number
+	success_rate: number
+	current_streak: number
+	best_streak: number
+	badge_tier: 3 | 5 | 10 | null
+}
+
+export interface PredictionStatsRequest {
+	userId: string
+	guildId: string
+}
+
+/**
+ * The generated client predates the F3 stats operation. Keep the temporary
+ * transport shim here until the next Khronos package release adds it.
+ */
+export function parsePredictionStats(payload: unknown): PredictionStats {
+	if (!payload || typeof payload !== 'object') {
+		throw new Error('Khronos returned an invalid prediction stats payload')
+	}
+
+	const value = payload as Record<string, unknown>
+	const readField = (snakeCase: string, camelCase: string) =>
+		Object.prototype.hasOwnProperty.call(value, snakeCase)
+			? value[snakeCase]
+			: value[camelCase]
+	const userId = readField('user_id', 'userId')
+	const numericFields = [
+		['correct_predictions', 'correctPredictions'],
+		['incorrect_predictions', 'incorrectPredictions'],
+		['total_predictions', 'totalPredictions'],
+		['success_rate', 'successRate'],
+		['current_streak', 'currentStreak'],
+		['best_streak', 'bestStreak'],
+	] as const
+	if (
+		typeof userId !== 'string' ||
+		numericFields.some(([snakeCase, camelCase]) => {
+			const field = readField(snakeCase, camelCase)
+			return typeof field !== 'number' || !Number.isFinite(field)
+		})
+	) {
+		throw new Error('Khronos returned an invalid prediction stats payload')
+	}
+
+	const badgeTier = readField(
+		'badge_tier',
+		'badgeTier',
+	) as PredictionStats['badge_tier']
+	if (
+		badgeTier !== null &&
+		badgeTier !== 3 &&
+		badgeTier !== 5 &&
+		badgeTier !== 10
+	) {
+		throw new Error(
+			'Khronos returned an invalid prediction stats badge tier',
+		)
+	}
+	const correctPredictions = readField(
+		'correct_predictions',
+		'correctPredictions',
+	) as number
+	const incorrectPredictions = readField(
+		'incorrect_predictions',
+		'incorrectPredictions',
+	) as number
+	const totalPredictions = readField(
+		'total_predictions',
+		'totalPredictions',
+	) as number
+	const successRate = readField('success_rate', 'successRate') as number
+	const currentStreak = readField('current_streak', 'currentStreak') as number
+	const bestStreak = readField('best_streak', 'bestStreak') as number
+
+	return {
+		user_id: userId,
+		correct_predictions: correctPredictions,
+		incorrect_predictions: incorrectPredictions,
+		total_predictions: totalPredictions,
+		success_rate: successRate,
+		current_streak: currentStreak,
+		best_streak: bestStreak,
+		badge_tier: badgeTier,
+	}
+}
+
+export default class StatsWrapper {
 	private readonly statsApi: StatsApi
 
 	constructor() {
@@ -17,5 +108,31 @@ export default class StatsWraps {
 	): Promise<OverallStatsDto> {
 		const response = await this.statsApi.getOverallH2hBettingStats(params)
 		return response
+	}
+
+	async getPredictionStats(
+		params: PredictionStatsRequest,
+	): Promise<PredictionStats> {
+		const path = `/api/khronos/v1/prediction/stats/${encodeURIComponent(params.userId)}`
+		const query = new URLSearchParams({ guild_id: params.guildId })
+		const fetchApi = KH_API_CONFIG.fetchApi ?? fetch
+		const response = await fetchApi(
+			`${KH_API_CONFIG.basePath.replace(/\/$/, '')}${path}?${query.toString()}`,
+			{
+				method: 'GET',
+				headers: {
+					...KH_API_CONFIG.headers,
+					Accept: 'application/json',
+				},
+			},
+		)
+
+		if (!response.ok) {
+			throw new Error(
+				`Khronos prediction stats request failed (${response.status})`,
+			)
+		}
+
+		return parsePredictionStats(await response.json())
 	}
 }

--- a/src/utils/api/common/endpoints.ts
+++ b/src/utils/api/common/endpoints.ts
@@ -3,6 +3,7 @@ export class Endpoints {
 		bets: {},
 		notifiy: {
 			betResults: '/notifications/bets/results',
+			parlayResults: '/notifications/parlays/results',
 		},
 		channels: {
 			incoming: '/channels/incoming',

--- a/src/utils/api/koa/setup/apiKeyAuth.ts
+++ b/src/utils/api/koa/setup/apiKeyAuth.ts
@@ -44,6 +44,7 @@ export function createApiKeyAuthMiddleware() {
 			return
 		}
 
+		ctx.state.apiKeyAuthenticated = true
 		await next()
 	}
 }

--- a/src/utils/api/koa/setup/health.test.ts
+++ b/src/utils/api/koa/setup/health.test.ts
@@ -1,0 +1,60 @@
+import { createServer, type Server } from 'node:http'
+import Koa from 'koa'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApiKeyAuthMiddleware } from './apiKeyAuth.js'
+import { createHealthMiddleware } from './health.js'
+
+vi.mock('../../../../lib/startup/env.js', () => ({
+	default: { API_KEY: 'system-api-key' },
+}))
+
+vi.mock('../../../logging/WinstonLogger.js', () => ({
+	logger: { warn: vi.fn() },
+}))
+
+describe('Koa health route', () => {
+	let server: Server | undefined
+
+	afterEach(async () => {
+		if (server?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()))
+			})
+		}
+	})
+
+	async function request(path: string, init?: RequestInit) {
+		const app = new Koa()
+		app.use(createHealthMiddleware())
+		app.use(createApiKeyAuthMiddleware())
+		app.use(async (ctx) => {
+			ctx.status = 204
+		})
+		server = createServer(app.callback())
+		await new Promise<void>((resolve) => {
+			server.listen(0, '127.0.0.1', () => resolve())
+		})
+		const address = server.address()
+		if (!address || typeof address === 'string') {
+			throw new Error('Test server did not expose a TCP address')
+		}
+
+		return fetch(`http://127.0.0.1:${address.port}${path}`, init)
+	}
+
+	it('allows unauthenticated GET /health', async () => {
+		const response = await request('/health')
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({ status: 'ok' })
+	})
+
+	it('does not weaken API-key auth for mutation routes', async () => {
+		const response = await request('/props/daily', { method: 'POST' })
+
+		expect(response.status).toBe(401)
+		expect(await response.json()).toMatchObject({
+			code: 'MISSING_API_KEY',
+		})
+	})
+})

--- a/src/utils/api/koa/setup/health.ts
+++ b/src/utils/api/koa/setup/health.ts
@@ -1,0 +1,13 @@
+import type { Context, Next } from 'koa'
+
+export function createHealthMiddleware() {
+	return async (ctx: Context, next: Next) => {
+		if (ctx.method === 'GET' && ctx.path === '/health') {
+			ctx.status = 200
+			ctx.body = { status: 'ok' }
+			return
+		}
+
+		await next()
+	}
+}

--- a/src/utils/api/koa/setup/koaSetup.ts
+++ b/src/utils/api/koa/setup/koaSetup.ts
@@ -7,6 +7,7 @@ import { pageNotFound } from '../../requests/middleware.js'
 import { createApiKeyAuthMiddleware } from './apiKeyAuth.js'
 import { setupBullBoard } from './bullBoard.js'
 import { createErrorHandler } from './errorHandler.js'
+import { createHealthMiddleware } from './health.js'
 import { captureRequestIdentity } from './logging.js'
 import { createRequestIdMiddleware } from './requestId.js'
 
@@ -32,6 +33,9 @@ export async function setupKoaApp(): Promise<Koa> {
 			}),
 		}),
 	)
+
+	// Internal harness readiness endpoint; mutation routes remain API-key protected.
+	app.use(createHealthMiddleware())
 
 	// Add API key authentication middleware
 	app.use(createApiKeyAuthMiddleware())

--- a/src/utils/api/routes/notifications/__tests__/delivery-queue.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/delivery-queue.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RedisCacheClient } from '../../../../cache/redis-instance.js'
+import { deliveryEnvelopeSchema } from '../delivery-contract.js'
+import {
+	type DeliveryDispatcher,
+	type DeliveryQueuePort,
+	NotificationDeliveryQueue,
+	SYSTEM_DISCORD_BASE_URL,
+	SystemDiscordDeliveryDispatcher,
+} from '../delivery-queue.js'
+import { RedisDeliveryStore } from '../delivery-store.js'
+
+const envelope = deliveryEnvelopeSchema.parse({
+	delivery_id: '550e8400-e29b-41d4-a716-446655440002',
+	schema_version: 1,
+	kind: 'prop_settled',
+	occurred_at: '2026-07-14T20:00:00.000Z',
+	payload: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440003',
+		result: 'won',
+		market_key: 'player_points',
+		description: 'Stephen Curry',
+		tallies: { correct: 1, incorrect: 0, total: 1 },
+		messages: [
+			{
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-1',
+			},
+			{
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-2',
+			},
+		],
+	},
+})
+
+const propPostEnvelope = deliveryEnvelopeSchema.parse({
+	delivery_id: '550e8400-e29b-41d4-a716-446655440004',
+	schema_version: 1,
+	kind: 'prop_post',
+	occurred_at: '2026-07-14T20:00:00.000Z',
+	payload: {
+		props: [
+			{
+				event_id: 'event-1',
+				commence_time: '2026-07-14T20:00:00.000Z',
+				home_team: 'Home',
+				away_team: 'Away',
+				sport_title: 'NBA',
+				market_key: 'player_points',
+				bookmaker_key: 'draftkings',
+				description: 'Player',
+				point: 20.5,
+				over: {
+					outcome_uuid: '550e8400-e29b-41d4-a716-446655440005',
+					outcome_name: 'Over',
+					price: -110,
+				},
+				under: {
+					outcome_uuid: '550e8400-e29b-41d4-a716-446655440006',
+					outcome_name: 'Under',
+					price: -110,
+				},
+			},
+		],
+		guilds: [
+			{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' },
+		],
+	},
+})
+
+function fakeRedis(): RedisCacheClient {
+	const values = new Map<string, string>()
+	return {
+		set: async (key, value, ...args) => {
+			if (args.includes('NX') && values.has(key)) return null
+			values.set(key, value)
+			return 'OK'
+		},
+		get: async (key) => values.get(key) ?? null,
+	} as unknown as RedisCacheClient
+}
+
+describe('notification delivery queue', () => {
+	let queue: NotificationDeliveryQueue | undefined
+
+	afterEach(async () => {
+		await queue?.close()
+		vi.unstubAllGlobals()
+	})
+
+	it('tracks destinations independently and retries only transient failures', async () => {
+		const redis = fakeRedis()
+		const store = new RedisDeliveryStore(redis)
+		const attempts = new Map<string, number>()
+		const dispatcher: DeliveryDispatcher = {
+			deliver: vi.fn(async (_payload, destinationId) => {
+				const count = (attempts.get(destinationId) ?? 0) + 1
+				attempts.set(destinationId, count)
+				if (destinationId.endsWith('message-2') && count === 1) {
+					throw new Error('Discord timeout')
+				}
+				return { message_id: destinationId }
+			}),
+		}
+		queue = new NotificationDeliveryQueue({
+			store,
+			dispatcher,
+			queue: {
+				add: vi.fn(async () => undefined),
+				close: vi.fn(async () => undefined),
+			} satisfies DeliveryQueuePort,
+			startWorker: false,
+		})
+		await queue.accept(envelope)
+		const job = { data: envelope } as never
+		await expect(queue.processJob(job)).rejects.toThrow(/retry/)
+		const partial = await store.get(envelope.delivery_id)
+		expect(
+			partial?.destinations.map((destination) => destination.state),
+		).toEqual(['delivered', 'retryable_failed'])
+
+		await queue.processJob(job)
+		const complete = await store.get(envelope.delivery_id)
+		expect(complete?.state).toBe('delivered')
+		expect(
+			complete?.destinations.every(
+				(destination) => destination.state === 'delivered',
+			),
+		).toBe(true)
+	})
+
+	it('does not report prop-post delivery until the complete receipt set exists', async () => {
+		const redis = fakeRedis()
+		const store = new RedisDeliveryStore(redis)
+		const dispatcher: DeliveryDispatcher = {
+			deliver: vi.fn(async () => []),
+		}
+		queue = new NotificationDeliveryQueue({
+			store,
+			dispatcher,
+			queue: {
+				add: vi.fn(async () => undefined),
+				close: vi.fn(async () => undefined),
+			} satisfies DeliveryQueuePort,
+			startWorker: false,
+		})
+
+		await queue.accept(propPostEnvelope)
+		await expect(
+			queue.processJob({ data: propPostEnvelope } as never),
+		).rejects.toThrow(/retry/)
+
+		const record = await store.get(propPostEnvelope.delivery_id)
+		expect(record?.state).toBe('retryable_failed')
+		expect(record?.destinations[0]?.state).toBe('delivered')
+		expect(record?.destinations[0]?.receipt).toEqual([])
+	})
+
+	it('routes system prop-post delivery only to fake-discord', async () => {
+		const fetchMock = vi.fn<typeof fetch>(
+			async () =>
+				new Response(JSON.stringify({ id: 'fake-message-1' }), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}),
+		)
+		vi.stubGlobal('fetch', fetchMock)
+
+		const receipt = await new SystemDiscordDeliveryDispatcher().deliver(
+			propPostEnvelope,
+			'prop-post:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440005:550e8400-e29b-41d4-a716-446655440006',
+		)
+
+		expect(fetchMock).toHaveBeenCalledOnce()
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			`${SYSTEM_DISCORD_BASE_URL}/channels/channel-1/messages`,
+		)
+		expect(receipt).toEqual([
+			{
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440005',
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'fake-message-1',
+			},
+			{
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440006',
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'fake-message-1',
+			},
+		])
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/delivery-store.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/delivery-store.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { RedisCacheClient } from '../../../../cache/redis-instance.js'
+import {
+	classifyDeliveryError,
+	deliveryEnvelopeSchema,
+} from '../delivery-contract.js'
+import { deriveDeliveryState, RedisDeliveryStore } from '../delivery-store.js'
+
+const envelope = {
+	delivery_id: '550e8400-e29b-41d4-a716-446655440000',
+	schema_version: 1 as const,
+	kind: 'prop_settled' as const,
+	occurred_at: '2026-07-14T20:00:00.000Z',
+	payload: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+		result: 'won' as const,
+		winning_side_display: 'Over',
+		actual_value: 37,
+		market_key: 'player_points',
+		description: 'Stephen Curry',
+		point: 35.5,
+		tallies: { correct: 1, incorrect: 0, total: 1 },
+		messages: [
+			{
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				message_id: 'message-1',
+			},
+		],
+	},
+}
+
+function fakeRedis(): RedisCacheClient {
+	const values = new Map<string, string>()
+	return {
+		set: async (key, value, ...args) => {
+			if (args.includes('NX') && values.has(key)) return null
+			values.set(key, value)
+			return 'OK'
+		},
+		get: async (key) => values.get(key) ?? null,
+	} as unknown as RedisCacheClient
+}
+
+describe('durable notification delivery contract', () => {
+	it('accepts once, deduplicates same payload, and rejects changed payload', async () => {
+		const parsed = deliveryEnvelopeSchema.parse(envelope)
+		const store = new RedisDeliveryStore(fakeRedis())
+
+		expect((await store.accept(parsed)).kind).toBe('accepted')
+		expect((await store.accept(parsed)).kind).toBe('duplicate')
+
+		const changed = deliveryEnvelopeSchema.parse({
+			...parsed,
+			payload: { ...parsed.payload, actual_value: 38 },
+		})
+		expect((await store.accept(changed)).kind).toBe('conflict')
+	})
+
+	it('classifies permanent Discord destinations without retrying forever', () => {
+		expect(
+			classifyDeliveryError(
+				Object.assign(new Error('blocked'), { code: 50007 }),
+			),
+		).toMatchObject({
+			classification: 'permanent',
+		})
+		expect(classifyDeliveryError(new Error('timeout'))).toMatchObject({
+			classification: 'transient',
+		})
+	})
+
+	it('derives delivered and permanent terminal states from destinations', async () => {
+		const record = (
+			await new RedisDeliveryStore(fakeRedis()).accept(
+				deliveryEnvelopeSchema.parse(envelope),
+			)
+		).record
+		record.destinations[0].state = 'delivered'
+		expect(deriveDeliveryState(record)).toBe('delivered')
+		record.destinations[0].state = 'permanent_failed'
+		expect(deriveDeliveryState(record)).toBe('permanent_failed')
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+
+import {
+	validateDailyPropsPayload,
+	validateNotifyBetUsers,
+} from '../notification-utils.js'
+
+describe('notification payload validators', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('accepts a typed bet-results payload and preserves result discriminators', () => {
+		const result = validateNotifyBetUsers({
+			winners: [
+				{
+					userId: 'user-1',
+					betId: 101,
+					result: {
+						team: 'Home',
+						betAmount: 10,
+						payout: 20,
+						profit: 10,
+						newBalance: 110,
+						oldBalance: 100,
+					},
+				},
+			],
+			losers: null,
+			pushes: [],
+		})
+
+		expect(result?.winners).toHaveLength(1)
+		expect(result?.winners[0].result.outcome).toBe('won')
+		expect(result?.losers).toEqual([])
+		expect(logger.error).not.toHaveBeenCalled()
+	})
+
+	it('rejects a winner without a bet id and logs the schema issues', () => {
+		const result = validateNotifyBetUsers({
+			winners: [
+				{
+					userId: 'user-1',
+					result: { team: 'Home', betAmount: 10 },
+				},
+			],
+			losers: [],
+		})
+
+		expect(result).toBeNull()
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'push_payload_rejected',
+				schema: 'notificationBetResults',
+			}),
+		)
+	})
+
+	it('normalizes legacy flat push entries from the published package', () => {
+		const result = validateNotifyBetUsers({
+			winners: [],
+			losers: [],
+			pushes: [
+				{ userid: 'user-2', amount: 15, betid: 202, team: 'Away' },
+			],
+		})
+
+		expect(result?.pushes).toEqual([
+			{
+				userId: 'user-2',
+				betId: 202,
+				result: { outcome: 'push', team: 'Away', betAmount: 15 },
+			},
+		])
+	})
+
+	it('accepts a realistic daily props payload', () => {
+		const result = validateDailyPropsPayload({
+			props: [
+				{
+					event_id: 'event-1',
+					commence_time: '2026-07-11T00:00:00Z',
+					home_team: 'Home',
+					away_team: 'Away',
+					sport_title: 'NBA',
+					market_key: 'player_points',
+					bookmaker_key: 'draftkings',
+					description: 'Player',
+					point: 20.5,
+					over: {
+						outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+						outcome_name: 'Over',
+						price: -110,
+					},
+					under: {
+						outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+						outcome_name: 'Under',
+						price: -110,
+					},
+				},
+			],
+			guilds: [
+				{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' },
+			],
+		})
+
+		expect(result?.props).toHaveLength(1)
+		expect(logger.error).not.toHaveBeenCalled()
+	})
+
+	it('rejects a daily props payload with an invalid guild channel', () => {
+		const result = validateDailyPropsPayload({
+			props: [],
+			guilds: [{ guild_id: 42, channel_id: 'channel-1', sport: 'nba' }],
+		})
+
+		expect(result).toBeNull()
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'push_payload_rejected',
+				schema: 'dailyPropsPayload',
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notification-utils.test.ts
@@ -44,7 +44,7 @@ describe('notification payload validators', () => {
 		expect(logger.error).not.toHaveBeenCalled()
 	})
 
-	it('rejects a winner without a bet id and logs the schema issues', () => {
+	it('accepts a winner without a bet id from the current shared contract', () => {
 		const result = validateNotifyBetUsers({
 			winners: [
 				{
@@ -55,13 +55,10 @@ describe('notification payload validators', () => {
 			losers: [],
 		})
 
-		expect(result).toBeNull()
-		expect(logger.error).toHaveBeenCalledWith(
-			expect.objectContaining({
-				event: 'push_payload_rejected',
-				schema: 'notificationBetResults',
-			}),
-		)
+		expect(result?.winners).toHaveLength(1)
+		expect(result?.winners[0].betId).toBeUndefined()
+		expect(result?.winners[0].result.outcome).toBe('won')
+		expect(logger.error).not.toHaveBeenCalled()
 	})
 
 	it('normalizes legacy flat push entries from the published package', () => {

--- a/src/utils/api/routes/notifications/__tests__/notifications.controller.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.controller.parlay.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const processParlayResult = vi.fn()
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../notifications.service.js', () => ({
+	default: class MockNotificationService {
+		processParlayResult = processParlayResult
+	},
+}))
+
+import NotificationRouter from '../notifications.controller.js'
+
+const validPayload = {
+	kind: 'won',
+	parlay_id: '11111111-1111-4111-8111-111111111110',
+	user_id: 'user-1',
+	stake: 10,
+	combined_odds_american: 377,
+	payout: 47.7,
+	actual_payout: 47.7,
+	legs: [
+		{
+			id: 'leg-1',
+			event_id: 'event-1',
+			outcome_uuid: 'outcome-1',
+			market_key: 'h2h',
+			selection_display: 'Lakers',
+			odds_american: -110,
+			point: null,
+			commence_time: '2026-07-11T20:00:00.000Z',
+			result: 'won',
+		},
+		{
+			id: 'leg-2',
+			event_id: 'event-2',
+			outcome_uuid: 'outcome-2',
+			market_key: 'totals',
+			selection_display: 'Over 220.5',
+			odds_american: 105,
+			point: 220.5,
+			commence_time: '2026-07-11T20:00:00.000Z',
+			result: 'won',
+		},
+	],
+}
+
+function getParlayRoute() {
+	const route = NotificationRouter.stack.find(
+		(layer) => layer.path === '/notifications/parlays/results',
+	)
+	if (!route) throw new Error('Parlay notification route not registered')
+	return route.stack[0]
+}
+
+describe('POST /notifications/parlays/results', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns 200 after processing a valid payload', async () => {
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+		}
+
+		await getParlayRoute()(ctx as never, async () => undefined)
+
+		expect(processParlayResult).toHaveBeenCalledOnce()
+		expect(ctx.status).toBe(200)
+		expect(ctx.body).toEqual({ success: true })
+	})
+
+	it('returns 422 and skips delivery for malformed payloads', async () => {
+		const ctx = {
+			request: { body: { ...validPayload, parlay_id: 'not-a-uuid' } },
+			body: undefined as unknown,
+			status: 200,
+		}
+
+		await getParlayRoute()(ctx as never, async () => undefined)
+
+		expect(processParlayResult).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(422)
+		expect(ctx.body).toEqual({
+			success: false,
+			error: 'Invalid parlay notification data. Failed Zod validation.',
+		})
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.controller.prop.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.controller.prop.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const processPropSettled = vi.fn()
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../notifications.service.js', () => ({
+	default: class MockNotificationService {
+		processPropSettled = processPropSettled
+	},
+}))
+
+import NotificationRouter from '../notifications.controller.js'
+
+const validPayload = {
+	outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+	result: 'won',
+	winning_side_display: 'Over',
+	actual_value: 37,
+	market_key: 'player_points',
+	description: 'Stephen Curry',
+	point: 35.5,
+	tallies: { correct: 11, incorrect: 16, total: 27 },
+	messages: [
+		{
+			guild_id: 'guild-1',
+			channel_id: 'channel-1',
+			message_id: 'message-1',
+		},
+	],
+}
+
+function getPropSettlementRoute() {
+	const route = NotificationRouter.stack.find(
+		(layer) => layer.path === '/notifications/props/settled',
+	)
+	if (!route)
+		throw new Error('Prop settlement notification route not registered')
+	return async (ctx: unknown, next: () => Promise<void>) => {
+		let index = -1
+		const dispatch = async (current: number): Promise<void> => {
+			if (current <= index)
+				throw new Error('next() called multiple times')
+			index = current
+			const middleware = route.stack[current]
+			if (!middleware) return await next()
+			await middleware(ctx as never, () => dispatch(current + 1))
+		}
+		await dispatch(0)
+	}
+}
+
+describe('POST /notifications/props/settled', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns 200 after processing a valid payload', async () => {
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+			state: { apiKeyAuthenticated: true },
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(processPropSettled).toHaveBeenCalledOnce()
+		expect(ctx.status).toBe(200)
+		expect(ctx.body).toEqual({ success: true })
+	})
+
+	it('returns 500 when settlement processing fails', async () => {
+		processPropSettled.mockRejectedValueOnce(new Error('delivery failed'))
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+			state: { apiKeyAuthenticated: true },
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(ctx.status).toBe(500)
+		expect(ctx.body).toEqual({
+			success: false,
+			error: 'Failed to process prop settlement notification',
+		})
+	})
+
+	it('returns 422 and skips delivery for malformed payloads', async () => {
+		const ctx = {
+			request: { body: { ...validPayload, outcome_uuid: 'not-a-uuid' } },
+			body: undefined as unknown,
+			status: 200,
+			state: { apiKeyAuthenticated: true },
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(processPropSettled).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(422)
+		expect(ctx.body).toEqual({
+			success: false,
+			error: 'Invalid prop settlement notification data. Failed Zod validation.',
+		})
+	})
+
+	it('rejects mathematically inconsistent settlement tallies', async () => {
+		const ctx = {
+			request: {
+				body: {
+					...validPayload,
+					tallies: { correct: 2, incorrect: 0, total: 1 },
+				},
+			},
+			body: undefined as unknown,
+			status: 200,
+			state: { apiKeyAuthenticated: true },
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(processPropSettled).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(422)
+	})
+
+	it('rejects direct router calls without app-level API authentication', async () => {
+		const ctx = {
+			request: { body: validPayload },
+			body: undefined as unknown,
+			status: 200,
+			state: {},
+		}
+
+		await getPropSettlementRoute()(ctx as never, async () => undefined)
+
+		expect(processPropSettled).not.toHaveBeenCalled()
+		expect(ctx.status).toBe(401)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	send: vi.fn(),
+	fetch: vi.fn(),
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	container: {
+		client: {
+			users: {
+				fetch: mocks.fetch,
+			},
+		},
+	},
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: mocks.logger,
+}))
+
+import NotificationService from '../notifications.service.js'
+
+const baseLeg = {
+	id: '00000000-0000-0000-0000-000000000001',
+	event_id: 'event-1',
+	outcome_uuid: 'outcome-1',
+	market_key: 'h2h' as const,
+	selection_display: 'Lakers',
+	odds_american: 125,
+	point: null,
+	commence_time: new Date('2026-07-11T20:00:00.000Z'),
+	result: 'won' as const,
+}
+
+function makePayload(kind: 'won' | 'busted' | 'push_refunded') {
+	return {
+		kind,
+		parlay_id: '11111111-1111-4111-8111-111111111110',
+		user_id: 'user-1',
+		stake: 10,
+		combined_odds_american: 377,
+		payout: kind === 'won' ? 47.7 : 0,
+		actual_payout:
+			kind === 'won' ? 47.7 : kind === 'push_refunded' ? 10 : 0,
+		refund_amount: kind === 'push_refunded' ? 10 : undefined,
+		old_balance: kind === 'won' ? 100 : undefined,
+		new_balance: kind === 'won' ? 137.7 : undefined,
+		legs: [
+			baseLeg,
+			{
+				...baseLeg,
+				id: '00000000-0000-0000-0000-000000000002',
+				event_id: 'event-2',
+				selection_display: 'Celtics',
+				odds_american: -110,
+				result:
+					kind === 'busted'
+						? ('lost' as const)
+						: kind === 'push_refunded'
+							? ('push' as const)
+							: ('won' as const),
+			},
+		],
+	}
+}
+
+describe('NotificationService.processParlayResult', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.fetch.mockResolvedValue({ send: mocks.send })
+	})
+
+	it.each([
+		['won', '🎉 Parlay Won! 🎉', 0x57f287],
+		['busted', '❌ Parlay Busted', 0xff6961],
+		['push_refunded', '🔄 Parlay Refunded', 0xffa500],
+	] as const)('sends a distinct %s multi-leg embed', async (kind, title, color) => {
+		await new NotificationService().processParlayResult(makePayload(kind))
+
+		expect(mocks.fetch).toHaveBeenCalledWith('user-1')
+		expect(mocks.send).toHaveBeenCalledOnce()
+		const [message] = mocks.send.mock.calls[0] as [
+			{ embeds: Array<{ toJSON: () => Record<string, unknown> }> },
+		]
+		const embed = message.embeds[0].toJSON()
+		expect(embed.title).toBe(title)
+		expect(embed.color).toBe(color)
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: '🧾 Legs' }),
+				expect.objectContaining({
+					name: '📈 Combined Odds',
+					value: '+377',
+				}),
+			]),
+		)
+		const legsField = (
+			embed.fields as Array<{ name: string; value: string }>
+		).find((field) => field.name === '🧾 Legs')
+		expect(legsField?.value).toContain('+125')
+		expect(legsField?.value).toContain('-110')
+	})
+
+	it('logs Discord delivery errors as critical and does not throw', async () => {
+		mocks.fetch.mockRejectedValue(new Error('DMs closed'))
+
+		await expect(
+			new NotificationService().processParlayResult(makePayload('won')),
+		).resolves.toBeUndefined()
+
+		expect(mocks.logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'parlay.notification.delivery_failed',
+				critical: true,
+				parlay_id: '11111111-1111-4111-8111-111111111110',
+			}),
+		)
+	})
+
+	it('falls back to payout and stake when nullable amounts are absent', async () => {
+		const payload = {
+			...makePayload('won'),
+			actual_payout: null,
+			payout: 47.7,
+		}
+		await new NotificationService().processParlayResult(payload)
+		const embed = (
+			mocks.send.mock.calls[0][0].embeds[0] as {
+				toJSON: () => { fields: Array<{ name: string; value: string }> }
+			}
+		).toJSON()
+		expect(embed.fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: '🏆 Payout', value: '$47.70' }),
+			]),
+		)
+	})
+
+	it('keeps every leg field within Discord limits', async () => {
+		const payload = {
+			...makePayload('won'),
+			legs: Array.from({ length: 30 }, (_, index) => ({
+				...baseLeg,
+				id: `leg-${index}`,
+				selection_display: 'A'.repeat(1200),
+			})),
+		}
+		await new NotificationService().processParlayResult(payload)
+		const embed = (
+			mocks.send.mock.calls[0][0].embeds[0] as {
+				toJSON: () => { fields: Array<{ name: string; value: string }> }
+			}
+		).toJSON()
+		for (const field of embed.fields.filter((field) =>
+			field.name.startsWith('🧾 Legs'),
+		)) {
+			expect(field.value.length).toBeLessThanOrEqual(1024)
+		}
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.parlay.test.ts
@@ -164,4 +164,26 @@ describe('NotificationService.processParlayResult', () => {
 			expect(field.value.length).toBeLessThanOrEqual(1024)
 		}
 	})
+
+	it('forwards winning parlays with guild context to big-win announcements', async () => {
+		const announceParlayWin = vi.fn().mockResolvedValue(true)
+		const bigWinService = { announceParlayWin }
+		const payload = {
+			...makePayload('won'),
+			guild_id: 'guild-1',
+		}
+
+		await new NotificationService(
+			bigWinService as never,
+		).processParlayResult(payload)
+
+		expect(announceParlayWin).toHaveBeenCalledWith(
+			expect.objectContaining({
+				parlayId: payload.parlay_id,
+				guildId: 'guild-1',
+				payout: 47.7,
+				legs: 2,
+			}),
+		)
+	})
 })

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.prop.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.prop.test.ts
@@ -1,0 +1,159 @@
+import { EmbedBuilder } from 'discord.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	fetchChannel: vi.fn(),
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+vi.mock('@sapphire/framework', () => ({
+	container: {
+		client: {
+			channels: {
+				fetch: mocks.fetchChannel,
+			},
+		},
+	},
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: mocks.logger,
+}))
+
+import NotificationService from '../notifications.service.js'
+
+const payload = {
+	outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+	result: 'won' as const,
+	winning_side_display: 'Over',
+	actual_value: 37,
+	market_key: 'player_points',
+	description: 'Stephen Curry',
+	point: 35.5,
+	tallies: { correct: 11, incorrect: 16, total: 27 },
+	messages: [
+		{
+			guild_id: 'guild-1',
+			channel_id: 'channel-1',
+			message_id: 'message-1',
+		},
+	],
+}
+
+function createMessage() {
+	const message = {
+		embeds: [
+			new EmbedBuilder().setTitle('🎯 Accuracy Challenge').addFields({
+				name: 'Match',
+				value: 'GSW vs LAL',
+				inline: true,
+			}),
+		],
+		edit: vi.fn(),
+	} as any
+	message.edit.mockImplementation(async (options: { embeds: unknown[] }) => {
+		message.embeds = options.embeds.map((embed) =>
+			EmbedBuilder.from(embed as never).toJSON(),
+		)
+		return message
+	})
+	return message
+}
+
+describe('NotificationService.processPropSettled', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('edits the original embed with result/tallies and removes stale buttons', async () => {
+		const message = createMessage()
+		const channel = {
+			guildId: 'guild-1',
+			isTextBased: () => true,
+			messages: { fetch: vi.fn().mockResolvedValue(message) },
+		}
+		mocks.fetchChannel.mockResolvedValue(channel)
+
+		await new NotificationService().processPropSettled(payload)
+
+		expect(channel.messages.fetch).toHaveBeenCalledWith('message-1')
+		expect(message.edit).toHaveBeenCalledOnce()
+		const edit = message.edit.mock.calls[0][0] as {
+			embeds: Array<{
+				toJSON: () => {
+					fields?: Array<{ name: string; value: string }>
+				}
+			}>
+			components: unknown[]
+		}
+		const fields = edit.embeds[0].toJSON().fields ?? []
+		expect(fields).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: '🎯 Result',
+					value: '**Result: Over ✅ — 37**',
+				}),
+				expect.objectContaining({
+					name: '📊 Prediction results',
+					value: '41% of 27 predictors got it right (11 correct, 16 incorrect).',
+				}),
+			]),
+		)
+		expect(edit.components).toEqual([])
+	})
+
+	it('deduplicates repeated message references and is idempotent on retry', async () => {
+		const message = createMessage()
+		const channel = {
+			guildId: 'guild-1',
+			isTextBased: () => true,
+			messages: { fetch: vi.fn().mockResolvedValue(message) },
+		}
+		mocks.fetchChannel.mockResolvedValue(channel)
+
+		const service = new NotificationService()
+		await service.processPropSettled({
+			...payload,
+			messages: [payload.messages[0], payload.messages[0]],
+		})
+		await service.processPropSettled(payload)
+
+		expect(channel.messages.fetch).toHaveBeenCalledTimes(2)
+		expect(message.edit).toHaveBeenCalledTimes(2)
+		const fields =
+			(message.embeds[0] as { fields?: unknown[] }).fields ?? []
+		expect(
+			fields.filter(
+				(field) => (field as { name?: string }).name === '🎯 Result',
+			),
+		).toHaveLength(1)
+	})
+
+	it('logs missing messages and continues without throwing', async () => {
+		const channel = {
+			guildId: 'guild-1',
+			isTextBased: () => true,
+			messages: {
+				fetch: vi.fn().mockRejectedValue(new Error('Unknown Message')),
+			},
+		}
+		mocks.fetchChannel.mockResolvedValue(channel)
+
+		await expect(
+			new NotificationService().processPropSettled(payload),
+		).resolves.toBeUndefined()
+
+		expect(channel.messages.fetch).toHaveBeenCalledWith('message-1')
+		expect(mocks.logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'prop.notification.message_update_failed',
+				message_id: 'message-1',
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.test.ts
@@ -53,4 +53,40 @@ describe('NotificationService', () => {
 			}),
 		)
 	})
+
+	it('does not forward winners without bet IDs to single-bet announcements', async () => {
+		const service = new NotificationService()
+		const notifyUser = vi
+			.spyOn(service, 'notifyUser')
+			.mockResolvedValue(undefined)
+		const getBigWinAnnouncementService = vi
+			.spyOn(
+				service as unknown as {
+					getBigWinAnnouncementService: () => Promise<unknown>
+				},
+				'getBigWinAnnouncementService',
+			)
+			.mockResolvedValue({})
+
+		await service.processBetResults({
+			winners: [
+				{
+					userId: 'user-1',
+					guildId: 'guild-1',
+					result: {
+						outcome: 'won',
+						team: 'Home',
+						betAmount: 10,
+						payout: 20,
+						profit: 10,
+					},
+				},
+			],
+			losers: [],
+			pushes: [],
+		})
+
+		expect(notifyUser).toHaveBeenCalledOnce()
+		expect(getBigWinAnnouncementService).not.toHaveBeenCalled()
+	})
 })

--- a/src/utils/api/routes/notifications/__tests__/notifications.service.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/notifications.service.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+
+import NotificationService from '../notifications.service.js'
+
+describe('NotificationService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('delivers winners when the wire payload omits optional balances', async () => {
+		const service = new NotificationService()
+		const notifyUser = vi
+			.spyOn(service, 'notifyUser')
+			.mockResolvedValue(undefined)
+
+		await service.processBetResults({
+			winners: [
+				{
+					userId: 'user-1',
+					betId: 101,
+					result: {
+						outcome: 'won',
+						team: 'Home',
+						betAmount: 10,
+						payout: 20,
+						profit: 10,
+					},
+				},
+			],
+			losers: [],
+			pushes: [],
+		})
+
+		expect(notifyUser).toHaveBeenCalledWith(
+			expect.objectContaining({
+				displayResult: expect.objectContaining({
+					displayOldBalance: 'Unavailable',
+					displayNewBalance: 'Unavailable',
+				}),
+			}),
+		)
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'notification_balance_unavailable',
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts
+++ b/src/utils/api/routes/notifications/__tests__/parlay-notification-utils.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({
+	logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+import { validateParlayResultNotification } from '../parlay-notification-utils.js'
+
+const validLeg = {
+	id: '00000000-0000-0000-0000-000000000001',
+	event_id: 'event-1',
+	outcome_uuid: 'outcome-1',
+	market_key: 'h2h' as const,
+	selection_display: 'Lakers',
+	odds_american: -110,
+	point: null,
+	commence_time: '2026-07-11T20:00:00.000Z',
+	result: 'won' as const,
+}
+
+const validPayload = {
+	kind: 'won' as const,
+	parlay_id: '11111111-1111-4111-8111-111111111110',
+	user_id: 'user-1',
+	stake: 10,
+	combined_odds_american: 377,
+	payout: 47.7,
+	actual_payout: 47.7,
+	old_balance: 100,
+	new_balance: 137.7,
+	legs: [validLeg, { ...validLeg, id: 'leg-2', event_id: 'event-2' }],
+}
+
+describe('validateParlayResultNotification', () => {
+	it('accepts a strict won payload', () => {
+		const result = validateParlayResultNotification(validPayload)
+		expect(result).not.toBeNull()
+		expect(result).toMatchObject({
+			parlay_id: validPayload.parlay_id,
+			kind: 'won',
+		})
+		expect(result?.legs[0].commence_time).toEqual(
+			new Date(validLeg.commence_time),
+		)
+	})
+
+	it('rejects malformed payloads', () => {
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				parlay_id: 'not-a-uuid',
+			}),
+		).toBeNull()
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				legs: [
+					{
+						...validLeg,
+						commence_time: 'not-a-date',
+					},
+				],
+			}),
+		).toBeNull()
+		expect(
+			validateParlayResultNotification({
+				...validPayload,
+				payout: undefined,
+				actual_payout: null,
+			}),
+		).toBeNull()
+	})
+})

--- a/src/utils/api/routes/notifications/delivery-contract.ts
+++ b/src/utils/api/routes/notifications/delivery-contract.ts
@@ -1,0 +1,209 @@
+import { createHash } from 'node:crypto'
+import { z } from 'zod'
+import {
+	type DailyPropsPayload,
+	dailyPropsPayloadSchema,
+	type PropSettledNotification,
+	propSettledNotificationSchema,
+} from '../shared-payload-schemas.js'
+import {
+	type ParlayResultNotification,
+	parlayResultNotificationSchema,
+} from './parlay-notification-contract.js'
+
+export const deliveryKindSchema = z.enum([
+	'parlay_result',
+	'prop_settled',
+	'prop_post',
+])
+
+const deliveryEnvelopeBaseSchema = z.object({
+	delivery_id: z.string().uuid(),
+	schema_version: z.literal(1),
+	occurred_at: z.string().datetime({ offset: true }),
+})
+
+export const deliveryEnvelopeSchema = z.discriminatedUnion('kind', [
+	deliveryEnvelopeBaseSchema.extend({
+		kind: z.literal('parlay_result'),
+		payload: parlayResultNotificationSchema,
+	}),
+	deliveryEnvelopeBaseSchema.extend({
+		kind: z.literal('prop_settled'),
+		payload: propSettledNotificationSchema,
+	}),
+	deliveryEnvelopeBaseSchema.extend({
+		kind: z.literal('prop_post'),
+		payload: dailyPropsPayloadSchema,
+	}),
+])
+
+export type DeliveryEnvelope = z.infer<typeof deliveryEnvelopeSchema>
+export type DeliveryPayload =
+	| ParlayResultNotification
+	| PropSettledNotification
+	| DailyPropsPayload
+
+export interface PropPostReceipt {
+	outcome_uuid: string
+	guild_id: string
+	channel_id: string
+	message_id: string
+}
+
+export type DeliveryState =
+	| 'queued'
+	| 'processing'
+	| 'delivered'
+	| 'retryable_failed'
+	| 'permanent_failed'
+
+export type DestinationState =
+	| 'queued'
+	| 'processing'
+	| 'delivered'
+	| 'retryable_failed'
+	| 'permanent_failed'
+
+export interface DeliveryDestination {
+	id: string
+	state: DestinationState
+	attempts: number
+	last_error?: string
+	classification?: 'transient' | 'permanent'
+	receipt?: unknown
+}
+
+export interface DeliveryRecord {
+	delivery_id: string
+	kind: DeliveryEnvelope['kind']
+	schema_version: 1
+	occurred_at: string
+	payload: DeliveryPayload
+	payload_hash: string
+	state: DeliveryState
+	attempts: number
+	destinations: DeliveryDestination[]
+	created_at: string
+	updated_at: string
+	delivered_at?: string
+}
+
+/** Stable JSON is used so retried requests can compare semantic payloads. */
+export function stableJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+	if (value && typeof value === 'object') {
+		return `{${Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(
+				([key, nested]) =>
+					`${JSON.stringify(key)}:${stableJson(nested)}`,
+			)
+			.join(',')}}`
+	}
+	return JSON.stringify(value)
+}
+
+export function deliveryPayloadHash(envelope: DeliveryEnvelope): string {
+	return createHash('sha256')
+		.update(
+			stableJson({
+				schema_version: envelope.schema_version,
+				kind: envelope.kind,
+				occurred_at: envelope.occurred_at,
+				payload: envelope.payload,
+			}),
+		)
+		.digest('hex')
+}
+
+export function destinationIds(envelope: DeliveryEnvelope): string[] {
+	if (envelope.kind === 'parlay_result') {
+		return [`dm:${envelope.payload.user_id}`]
+	}
+	if (envelope.kind === 'prop_post') {
+		return envelope.payload.guilds.flatMap((guild) =>
+			envelope.payload.props.map(
+				(prop) =>
+					`prop-post:${guild.guild_id}:${guild.channel_id}:${prop.over.outcome_uuid}:${prop.under.outcome_uuid}`,
+			),
+		)
+	}
+	return [
+		...new Set(
+			envelope.payload.messages.map(
+				(reference) =>
+					`prop:${reference.guild_id}:${reference.channel_id}:${reference.message_id}`,
+			),
+		),
+	]
+}
+
+/** Flatten durable per-destination receipts for status/reconciliation APIs. */
+export function deliveryReceipts(
+	record: Pick<DeliveryRecord, 'kind' | 'destinations'>,
+): PropPostReceipt[] {
+	if (record.kind !== 'prop_post') return []
+	return record.destinations.flatMap((destination) => {
+		if (!Array.isArray(destination.receipt)) return []
+		return destination.receipt.filter(isPropPostReceipt)
+	})
+}
+
+/** A prop-post is terminally delivered only when every expected receipt exists exactly once. */
+export function hasExactPropPostReceipts(
+	payload: DailyPropsPayload,
+	receipts: readonly PropPostReceipt[],
+): boolean {
+	const expected = new Set<string>()
+	for (const prop of payload.props) {
+		for (const outcomeUuid of [
+			prop.over.outcome_uuid,
+			prop.under.outcome_uuid,
+		]) {
+			for (const guild of payload.guilds) {
+				expected.add(
+					`${outcomeUuid}:${guild.guild_id}:${guild.channel_id}`,
+				)
+			}
+		}
+	}
+	if (receipts.length !== expected.size) return false
+	const actual = new Set<string>()
+	for (const receipt of receipts) {
+		const key = `${receipt.outcome_uuid}:${receipt.guild_id}:${receipt.channel_id}`
+		if (actual.has(key) || !expected.has(key)) return false
+		actual.add(key)
+	}
+	return actual.size === expected.size
+}
+
+function isPropPostReceipt(value: unknown): value is PropPostReceipt {
+	if (!value || typeof value !== 'object') return false
+	const candidate = value as Record<string, unknown>
+	return (
+		typeof candidate.outcome_uuid === 'string' &&
+		typeof candidate.guild_id === 'string' &&
+		typeof candidate.channel_id === 'string' &&
+		typeof candidate.message_id === 'string'
+	)
+}
+
+export function classifyDeliveryError(error: unknown): {
+	classification: 'transient' | 'permanent'
+	message: string
+} {
+	const candidate = error as { code?: number | string; status?: number }
+	const code = String(candidate?.code ?? '')
+	const status = candidate?.status
+	const permanentCodes = new Set(['50007', '10003', '50001', '10004'])
+	const message = error instanceof Error ? error.message : String(error)
+	return {
+		classification:
+			permanentCodes.has(code) ||
+			(status !== undefined && status >= 400 && status < 500)
+				? 'permanent'
+				: 'transient',
+		message: message.slice(0, 500),
+	}
+}

--- a/src/utils/api/routes/notifications/delivery-queue.ts
+++ b/src/utils/api/routes/notifications/delivery-queue.ts
@@ -1,0 +1,524 @@
+import { type Job, Queue, Worker } from 'bullmq'
+import {
+	classifyDeliveryError,
+	type DeliveryEnvelope,
+	type DeliveryRecord,
+	type DestinationState,
+	deliveryReceipts,
+	hasExactPropPostReceipts,
+} from './delivery-contract.js'
+import {
+	type DeliveryStore,
+	deriveDeliveryState,
+	RedisDeliveryStore,
+} from './delivery-store.js'
+import type NotificationService from './notifications.service.js'
+
+export const NOTIFICATION_DELIVERY_QUEUE = 'notification-delivery-v1'
+export const SYSTEM_DISCORD_BASE_URL = 'http://fake-discord:8080'
+
+// Keep queue construction lazy and environment-only. Importing notification
+// routes in unit tests must not force Pluto's full startup env schema.
+const REDIS_CONFIG = {
+	host: process.env.R_HOST ?? '127.0.0.1',
+	port: Number(process.env.R_PORT ?? 6379),
+	password: process.env.R_PASS,
+}
+
+export interface DeliveryDispatcher {
+	deliver(envelope: DeliveryEnvelope, destinationId: string): Promise<unknown>
+}
+
+class DiscordDeliveryDispatcher implements DeliveryDispatcher {
+	private service?: NotificationService
+	private propPostingHandler?: import('../../../props/PropPostingHandler.js').PropPostingHandler
+
+	private async getService(): Promise<NotificationService> {
+		if (!this.service) {
+			const module = await import('./notifications.service.js')
+			this.service = new module.default()
+		}
+		return this.service
+	}
+
+	async deliver(envelope: DeliveryEnvelope, destinationId: string) {
+		if (envelope.kind === 'parlay_result') {
+			if (!destinationId.startsWith('dm:'))
+				throw new Error(`Invalid parlay destination ${destinationId}`)
+			return (await this.getService()).deliverParlayResult(
+				envelope.payload,
+				envelope.delivery_id,
+			)
+		}
+
+		if (envelope.kind === 'prop_post') {
+			const destination = parsePropPostDestination(destinationId)
+			const prop = envelope.payload.props.find(
+				(candidate) =>
+					candidate.over.outcome_uuid ===
+						destination.over_outcome_uuid &&
+					candidate.under.outcome_uuid ===
+						destination.under_outcome_uuid,
+			)
+			if (!prop)
+				throw new Error(
+					`Unknown prop-post destination ${destinationId}`,
+				)
+			if (!this.propPostingHandler) {
+				const module = await import(
+					'../../../props/PropPostingHandler.js'
+				)
+				this.propPostingHandler = new module.PropPostingHandler()
+			}
+			const receipt = await this.propPostingHandler.postPropPair(
+				destination.guild_id,
+				destination.channel_id,
+				prop,
+				prop.sport_title.toLowerCase().includes('nfl') ? 'nfl' : 'nba',
+				envelope.delivery_id,
+				destinationId,
+			)
+			if (
+				receipt.length !== 2 ||
+				receipt.some(
+					(reference) =>
+						reference.guild_id !== destination.guild_id ||
+						reference.channel_id !== destination.channel_id ||
+						![
+							destination.over_outcome_uuid,
+							destination.under_outcome_uuid,
+						].includes(reference.outcome_uuid),
+				)
+			) {
+				throw new Error(
+					'Prop-post destination returned incomplete receipts',
+				)
+			}
+			return receipt
+		}
+
+		const reference = envelope.payload.messages.find(
+			(candidate) =>
+				`prop:${candidate.guild_id}:${candidate.channel_id}:${candidate.message_id}` ===
+				destinationId,
+		)
+		if (!reference)
+			throw new Error(`Unknown prop destination ${destinationId}`)
+		return (await this.getService()).deliverPropSettlementMessage(
+			envelope.payload,
+			reference,
+		)
+	}
+}
+
+export class SystemDiscordDeliveryDispatcher implements DeliveryDispatcher {
+	async deliver(envelope: DeliveryEnvelope, destinationId: string) {
+		if (envelope.kind === 'parlay_result') {
+			if (!destinationId.startsWith('dm:'))
+				throw new Error(`Invalid parlay destination ${destinationId}`)
+			return sendToFakeDiscord(
+				`/users/${encodeURIComponent(envelope.payload.user_id)}/messages`,
+				'POST',
+				{ destination_id: destinationId, envelope },
+			)
+		}
+
+		if (envelope.kind === 'prop_post') {
+			const destination = parsePropPostDestination(destinationId)
+			const prop = envelope.payload.props.find(
+				(candidate) =>
+					candidate.over.outcome_uuid ===
+						destination.over_outcome_uuid &&
+					candidate.under.outcome_uuid ===
+						destination.under_outcome_uuid,
+			)
+			if (!prop)
+				throw new Error(
+					`Unknown prop-post destination ${destinationId}`,
+				)
+			const response = await sendToFakeDiscord(
+				`/channels/${encodeURIComponent(destination.channel_id)}/messages`,
+				'POST',
+				{ destination_id: destinationId, envelope, prop },
+			)
+			const messageId =
+				fakeDiscordMessageId(response) ??
+				`fake-${envelope.delivery_id}-${destination.channel_id}`
+			return [
+				{
+					outcome_uuid: destination.over_outcome_uuid,
+					guild_id: destination.guild_id,
+					channel_id: destination.channel_id,
+					message_id: messageId,
+				},
+				{
+					outcome_uuid: destination.under_outcome_uuid,
+					guild_id: destination.guild_id,
+					channel_id: destination.channel_id,
+					message_id: messageId,
+				},
+			]
+		}
+
+		const reference = envelope.payload.messages.find(
+			(candidate) =>
+				`prop:${candidate.guild_id}:${candidate.channel_id}:${candidate.message_id}` ===
+				destinationId,
+		)
+		if (!reference)
+			throw new Error(`Unknown prop destination ${destinationId}`)
+		return sendToFakeDiscord(
+			`/channels/${encodeURIComponent(reference.channel_id)}/messages/${encodeURIComponent(reference.message_id)}`,
+			'PATCH',
+			{ destination_id: destinationId, envelope },
+		)
+	}
+}
+
+async function sendToFakeDiscord(
+	path: string,
+	method: 'POST' | 'PATCH',
+	body: unknown,
+): Promise<unknown> {
+	const response = await fetch(`${SYSTEM_DISCORD_BASE_URL}${path}`, {
+		method,
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+	const payload = await readJsonResponse(response)
+	if (!response.ok) {
+		const error = new Error(
+			`fake-discord returned ${response.status} for ${method} ${path}`,
+		)
+		Object.assign(error, { status: response.status, payload })
+		throw error
+	}
+	return payload
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+	const text = await response.text()
+	if (!text) return undefined
+	try {
+		return JSON.parse(text)
+	} catch {
+		return text
+	}
+}
+
+function fakeDiscordMessageId(response: unknown): string | undefined {
+	if (!response || typeof response !== 'object') return undefined
+	const candidate = response as Record<string, unknown>
+	if (typeof candidate.id === 'string') return candidate.id
+	if (typeof candidate.message_id === 'string') return candidate.message_id
+	return undefined
+}
+
+class RetryableDeliveryError extends Error {
+	readonly retryable = true
+}
+
+type DeliveryJob = DeliveryEnvelope
+
+export interface NotificationDeliveryQueueOptions {
+	store?: DeliveryStore
+	dispatcher?: DeliveryDispatcher
+	queue?: DeliveryQueuePort
+	startWorker?: boolean
+}
+
+export interface DeliveryQueuePort {
+	add(
+		name: string,
+		data: DeliveryJob,
+		options: { jobId: string },
+	): Promise<unknown>
+	close(): Promise<void>
+}
+
+export class NotificationDeliveryQueue {
+	readonly queue: DeliveryQueuePort
+	private readonly worker?: Worker<DeliveryJob>
+	private readonly store: DeliveryStore
+	private readonly dispatcher: DeliveryDispatcher
+
+	constructor(options: NotificationDeliveryQueueOptions = {}) {
+		this.store = options.store ?? new RedisDeliveryStore()
+		this.dispatcher = options.dispatcher ?? new DiscordDeliveryDispatcher()
+		this.queue =
+			options.queue ??
+			(new Queue<DeliveryJob>(NOTIFICATION_DELIVERY_QUEUE, {
+				connection: REDIS_CONFIG,
+				defaultJobOptions: {
+					attempts: 8,
+					backoff: { type: 'exponential', delay: 60_000 },
+					removeOnComplete: { age: 180 * 24 * 60 * 60 },
+					removeOnFail: false,
+				},
+			}) as unknown as DeliveryQueuePort)
+		if (options.startWorker !== false) {
+			this.worker = new Worker<DeliveryJob>(
+				NOTIFICATION_DELIVERY_QUEUE,
+				async (job) => this.process(job),
+				{
+					connection: REDIS_CONFIG,
+					concurrency: 8,
+					lockDuration: 60_000,
+					stalledInterval: 30_000,
+				},
+			)
+			this.worker.on('failed', (job, error) => {
+				void import('../../../logging/WinstonLogger.js').then(
+					({ logger }) =>
+						logger.error({
+							method: 'NotificationDeliveryQueue',
+							event: 'notification.delivery.job_failed',
+							delivery_id: job?.data.delivery_id,
+							error: error.message.slice(0, 500),
+						}),
+				)
+			})
+		}
+	}
+
+	async accept(envelope: DeliveryEnvelope): Promise<DeliveryRecord> {
+		return (await this.acceptDetailed(envelope)).record
+	}
+
+	async acceptDetailed(
+		envelope: DeliveryEnvelope,
+	): Promise<{ record: DeliveryRecord; duplicate: boolean }> {
+		const accepted = await this.store.accept(envelope)
+		if (accepted.kind === 'conflict') {
+			const error = new Error(
+				'Delivery ID is already used for another payload',
+			)
+			Object.assign(error, { code: 'DELIVERY_PAYLOAD_MISMATCH' })
+			throw error
+		}
+		if (accepted.kind === 'accepted') {
+			try {
+				await this.queue.add('deliver', envelope, {
+					jobId: envelope.delivery_id,
+				})
+			} catch (error) {
+				await this.store.update(envelope.delivery_id, (record) => ({
+					...record,
+					state: 'retryable_failed',
+				}))
+				throw error
+			}
+		} else if (
+			accepted.record.state === 'queued' ||
+			accepted.record.state === 'retryable_failed'
+		) {
+			// Re-enqueue is safe after a worker restart or an ambiguous queue
+			// acknowledgement because delivery_id is BullMQ's stable job ID.
+			try {
+				await this.queue.add('deliver', envelope, {
+					jobId: envelope.delivery_id,
+				})
+			} catch (error) {
+				if (!isDuplicateQueueError(error)) throw error
+			}
+		}
+		return {
+			record: accepted.record,
+			duplicate: accepted.kind === 'duplicate',
+		}
+	}
+
+	async get(deliveryId: string): Promise<DeliveryRecord | null> {
+		return this.store.get(deliveryId)
+	}
+
+	private async process(job: Job<DeliveryJob>): Promise<void> {
+		const { delivery_id: deliveryId } = job.data
+		const record = await this.store.get(deliveryId)
+		if (!record) return
+
+		await this.store.update(deliveryId, (current) => ({
+			...current,
+			state: 'processing',
+			attempts: current.attempts + 1,
+		}))
+		let hasRetryableFailure = false
+
+		for (const destination of record.destinations) {
+			if (
+				(destination.state === 'delivered' &&
+					(record.kind !== 'prop_post' ||
+						hasPropPostReceiptPair(destination))) ||
+				destination.state === 'permanent_failed'
+			)
+				continue
+
+			await this.store.update(deliveryId, (current) =>
+				updateDestination(current, destination.id, {
+					state: 'processing',
+				}),
+			)
+			try {
+				const receipt = await this.dispatcher.deliver(
+					job.data,
+					destination.id,
+				)
+				await this.store.update(deliveryId, (current) =>
+					updateDestination(current, destination.id, {
+						state: 'delivered',
+						receipt,
+					}),
+				)
+			} catch (error) {
+				const classified = classifyDeliveryError(error)
+				const state: DestinationState =
+					classified.classification === 'permanent'
+						? 'permanent_failed'
+						: 'retryable_failed'
+				await this.store.update(deliveryId, (current) =>
+					updateDestination(current, destination.id, {
+						state,
+						last_error: classified.message,
+						classification: classified.classification,
+					}),
+				)
+				if (state === 'retryable_failed') hasRetryableFailure = true
+			}
+		}
+
+		const final = await this.store.update(deliveryId, (current) => {
+			const derivedState = deriveDeliveryState(current)
+			const propPostComplete =
+				current.kind !== 'prop_post' ||
+				hasExactPropPostReceipts(
+					current.payload as Extract<
+						DeliveryEnvelope,
+						{ kind: 'prop_post' }
+					>['payload'],
+					deliveryReceipts(current),
+				)
+			const state =
+				derivedState === 'delivered' && !propPostComplete
+					? 'retryable_failed'
+					: derivedState
+			return {
+				...current,
+				state,
+				delivered_at:
+					state === 'delivered'
+						? (current.delivered_at ?? new Date().toISOString())
+						: current.delivered_at,
+			}
+		})
+		if (hasRetryableFailure || final.state === 'retryable_failed') {
+			throw new RetryableDeliveryError(
+				'One or more notification destinations require retry',
+			)
+		}
+	}
+
+	/** Focused seam for integration tests; BullMQ invokes the same handler. */
+	async processJob(job: Job<DeliveryJob>): Promise<void> {
+		return this.process(job)
+	}
+
+	async close(): Promise<void> {
+		await this.worker?.close()
+		await this.queue.close()
+	}
+}
+
+interface PropPostDestination {
+	guild_id: string
+	channel_id: string
+	over_outcome_uuid: string
+	under_outcome_uuid: string
+}
+
+function parsePropPostDestination(destinationId: string): PropPostDestination {
+	const [
+		prefix,
+		guild_id,
+		channel_id,
+		over_outcome_uuid,
+		under_outcome_uuid,
+	] = destinationId.split(':')
+	if (
+		prefix !== 'prop-post' ||
+		!guild_id ||
+		!channel_id ||
+		!over_outcome_uuid ||
+		!under_outcome_uuid
+	) {
+		throw new Error(`Invalid prop-post destination ${destinationId}`)
+	}
+	return {
+		guild_id,
+		channel_id,
+		over_outcome_uuid,
+		under_outcome_uuid,
+	}
+}
+
+function hasPropPostReceiptPair(
+	destination: DeliveryRecord['destinations'][number],
+): boolean {
+	return (
+		Array.isArray(destination.receipt) && destination.receipt.length === 2
+	)
+}
+
+function isDuplicateQueueError(error: unknown): boolean {
+	const candidate = error as { code?: string; message?: string }
+	return (
+		candidate.code === 'ERR_JOB_EXISTS' ||
+		(candidate.message?.toLowerCase().includes('already exists') ?? false)
+	)
+}
+
+function updateDestination(
+	record: DeliveryRecord,
+	destinationId: string,
+	patch: Partial<DeliveryRecord['destinations'][number]>,
+): DeliveryRecord {
+	return {
+		...record,
+		destinations: record.destinations.map((destination) =>
+			destination.id === destinationId
+				? {
+						...destination,
+						...patch,
+						attempts:
+							patch.state === 'processing'
+								? destination.attempts + 1
+								: destination.attempts,
+					}
+				: destination,
+		),
+	}
+}
+
+let defaultQueue: NotificationDeliveryQueue | undefined
+
+export function setNotificationDeliveryQueue(
+	queue: NotificationDeliveryQueue,
+): void {
+	defaultQueue = queue
+}
+
+export function resetNotificationDeliveryQueue(): void {
+	defaultQueue = undefined
+}
+
+export function configureSystemNotificationDelivery(): NotificationDeliveryQueue {
+	const queue = new NotificationDeliveryQueue({
+		dispatcher: new SystemDiscordDeliveryDispatcher(),
+	})
+	setNotificationDeliveryQueue(queue)
+	return queue
+}
+
+export function getNotificationDeliveryQueue(): NotificationDeliveryQueue {
+	if (!defaultQueue) defaultQueue = new NotificationDeliveryQueue()
+	return defaultQueue
+}

--- a/src/utils/api/routes/notifications/delivery-store.ts
+++ b/src/utils/api/routes/notifications/delivery-store.ts
@@ -1,0 +1,148 @@
+import type { RedisCacheClient } from '../../../cache/redis-instance.js'
+import {
+	type DeliveryEnvelope,
+	type DeliveryRecord,
+	type DeliveryState,
+	deliveryPayloadHash,
+	destinationIds,
+} from './delivery-contract.js'
+
+const KEY_PREFIX = 'pluto:delivery:v1:'
+const RETENTION_SECONDS = 180 * 24 * 60 * 60
+
+export type AcceptDeliveryResult =
+	| { kind: 'accepted'; record: DeliveryRecord }
+	| { kind: 'duplicate'; record: DeliveryRecord }
+	| { kind: 'conflict'; record: DeliveryRecord }
+
+export interface DeliveryStore {
+	accept(envelope: DeliveryEnvelope): Promise<AcceptDeliveryResult>
+	get(deliveryId: string): Promise<DeliveryRecord | null>
+	update(
+		deliveryId: string,
+		update: (record: DeliveryRecord) => DeliveryRecord,
+	): Promise<DeliveryRecord>
+}
+
+function key(deliveryId: string): string {
+	return `${KEY_PREFIX}${deliveryId}`
+}
+
+function parseRecord(raw: string | null): DeliveryRecord | null {
+	if (!raw) return null
+	try {
+		const parsed = JSON.parse(raw) as DeliveryRecord
+		if (
+			typeof parsed.delivery_id !== 'string' ||
+			typeof parsed.payload_hash !== 'string' ||
+			!Array.isArray(parsed.destinations)
+		)
+			return null
+		return parsed
+	} catch {
+		return null
+	}
+}
+
+export class RedisDeliveryStore implements DeliveryStore {
+	private redis?: RedisCacheClient
+
+	constructor(redis?: RedisCacheClient) {
+		this.redis = redis
+	}
+
+	private async client(): Promise<RedisCacheClient> {
+		if (!this.redis) {
+			// Defer env validation/Redis connection until a delivery route is
+			// actually used. This keeps route and contract tests hermetic.
+			this.redis = (
+				await import('../../../cache/redis-instance.js')
+			).default
+		}
+		return this.redis
+	}
+
+	async accept(envelope: DeliveryEnvelope): Promise<AcceptDeliveryResult> {
+		const deliveryKey = key(envelope.delivery_id)
+		const payloadHash = deliveryPayloadHash(envelope)
+		const now = new Date().toISOString()
+		const record: DeliveryRecord = {
+			delivery_id: envelope.delivery_id,
+			kind: envelope.kind,
+			schema_version: 1,
+			occurred_at: envelope.occurred_at,
+			payload: envelope.payload,
+			payload_hash: payloadHash,
+			state: 'queued',
+			attempts: 0,
+			destinations: destinationIds(envelope).map((id) => ({
+				id,
+				state: 'queued',
+				attempts: 0,
+			})),
+			created_at: now,
+			updated_at: now,
+		}
+
+		const redis = await this.client()
+		const created = await redis.set(
+			deliveryKey,
+			JSON.stringify(record),
+			'NX',
+			'EX',
+			RETENTION_SECONDS,
+		)
+		if (created === 'OK') return { kind: 'accepted', record }
+
+		const existing = await this.get(envelope.delivery_id)
+		if (!existing) {
+			// A malformed record must never be overwritten by a callback. Treat it
+			// as a conflict so operators can inspect and repair it explicitly.
+			return { kind: 'conflict', record }
+		}
+		return existing.payload_hash === payloadHash
+			? { kind: 'duplicate', record: existing }
+			: { kind: 'conflict', record: existing }
+	}
+
+	async get(deliveryId: string): Promise<DeliveryRecord | null> {
+		return parseRecord(await (await this.client()).get(key(deliveryId)))
+	}
+
+	async update(
+		deliveryId: string,
+		mutate: (record: DeliveryRecord) => DeliveryRecord,
+	): Promise<DeliveryRecord> {
+		const existing = await this.get(deliveryId)
+		if (!existing) throw new Error(`Delivery ${deliveryId} not found`)
+		const next = mutate(existing)
+		next.updated_at = new Date().toISOString()
+		await (await this.client()).set(
+			key(deliveryId),
+			JSON.stringify(next),
+			'EX',
+			RETENTION_SECONDS,
+		)
+		return next
+	}
+}
+
+export function deriveDeliveryState(record: DeliveryRecord): DeliveryState {
+	const states = record.destinations.map((destination) => destination.state)
+	if (states.every((state) => state === 'delivered')) return 'delivered'
+	if (states.some((state) => state === 'processing')) return 'processing'
+	if (states.some((state) => state === 'retryable_failed')) {
+		return 'retryable_failed'
+	}
+	if (states.every((state) => state === 'permanent_failed')) {
+		return 'permanent_failed'
+	}
+	if (states.some((state) => state === 'permanent_failed')) {
+		return states.every(
+			(state) => state === 'delivered' || state === 'permanent_failed',
+		)
+			? 'permanent_failed'
+			: 'processing'
+	}
+	return 'queued'
+}

--- a/src/utils/api/routes/notifications/notification-utils.ts
+++ b/src/utils/api/routes/notifications/notification-utils.ts
@@ -1,8 +1,9 @@
-import { notificationBetResultsSchema } from '@pluto-khronos/types'
-import type {
-	BetNotificationPush,
-	NotifyBetUsers,
-} from './notifications.interface.js'
+import { logger } from '../../../logging/WinstonLogger.js'
+import {
+	dailyPropsPayloadSchema,
+	notificationBetResultsSchema,
+} from '../shared-payload-schemas.js'
+import type { NotifyBetUsers } from './notifications.interface.js'
 
 export function validateNotifyBetUsers(
 	payload: unknown,
@@ -10,30 +11,57 @@ export function validateNotifyBetUsers(
 	const result = notificationBetResultsSchema.safeParse(payload)
 
 	if (!result.success) {
-		console.error({
+		logger.error({
 			method: 'validateNotifyBetUsers',
-			message: 'Invalid notification payload',
+			event: 'push_payload_rejected',
+			schema: 'notificationBetResults',
 			errors: result.error.issues,
 		})
 		return null
 	}
 
-	// Transform Zod output to match our internal types
-	// Transform pushes from IBetslipPush[] to BetNotificationPush[]
-	const transformedPushes: BetNotificationPush[] | undefined =
-		result.data.pushes?.map((push) => ({
-			userId: push.userid,
-			betId: push.betid,
-			result: {
-				outcome: 'push' as const,
-				team: push.team,
-				betAmount: push.amount,
-			},
-		}))
-
 	return {
-		winners: result.data.winners || [],
-		losers: result.data.losers || [],
-		pushes: transformedPushes || [],
+		winners: (result.data.winners ?? []).map((winner) => ({
+			...winner,
+			result: { ...winner.result, outcome: 'won' as const },
+		})),
+		losers: (result.data.losers ?? []).map((loser) => ({
+			...loser,
+			result: { ...loser.result, outcome: 'lost' as const },
+		})),
+		pushes: (result.data.pushes ?? []).map((push) => {
+			if ('userid' in push) {
+				return {
+					userId: push.userid,
+					betId: push.betid,
+					result: {
+						outcome: 'push' as const,
+						team: push.team,
+						betAmount: push.amount,
+					},
+				}
+			}
+
+			return {
+				...push,
+				result: { ...push.result, outcome: 'push' as const },
+			}
+		}),
 	}
+}
+
+export function validateDailyPropsPayload(payload: unknown) {
+	const result = dailyPropsPayloadSchema.safeParse(payload)
+
+	if (!result.success) {
+		logger.error({
+			method: 'validateDailyPropsPayload',
+			event: 'push_payload_rejected',
+			schema: 'dailyPropsPayload',
+			errors: result.error.issues,
+		})
+		return null
+	}
+
+	return result.data
 }

--- a/src/utils/api/routes/notifications/notification-utils.ts
+++ b/src/utils/api/routes/notifications/notification-utils.ts
@@ -21,14 +21,28 @@ export function validateNotifyBetUsers(
 	}
 
 	return {
-		winners: (result.data.winners ?? []).map((winner) => ({
-			...winner,
-			result: { ...winner.result, outcome: 'won' as const },
-		})),
-		losers: (result.data.losers ?? []).map((loser) => ({
-			...loser,
-			result: { ...loser.result, outcome: 'lost' as const },
-		})),
+		winners: (result.data.winners ?? []).map((winner) => {
+			const withGuild = winner as typeof winner & {
+				guildId?: string
+				guild_id?: string
+			}
+			return {
+				...winner,
+				guildId: withGuild.guildId ?? withGuild.guild_id,
+				result: { ...winner.result, outcome: 'won' as const },
+			}
+		}),
+		losers: (result.data.losers ?? []).map((loser) => {
+			const withGuild = loser as typeof loser & {
+				guildId?: string
+				guild_id?: string
+			}
+			return {
+				...loser,
+				guildId: withGuild.guildId ?? withGuild.guild_id,
+				result: { ...loser.result, outcome: 'lost' as const },
+			}
+		}),
 		pushes: (result.data.pushes ?? []).map((push) => {
 			if ('userid' in push) {
 				return {

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -1,6 +1,12 @@
 import Router from '@koa/router'
 import type { Context, Next } from 'koa'
+import { z } from 'zod'
 import { logger } from '../../../logging/WinstonLogger.js'
+import {
+	deliveryEnvelopeSchema,
+	deliveryReceipts,
+} from './delivery-contract.js'
+import { getNotificationDeliveryQueue } from './delivery-queue.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
 import { validateParlayResultNotification } from './parlay-notification-utils.js'
@@ -67,6 +73,53 @@ NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 
 NotificationRouter.post('/notifications/parlays/results', async (ctx) => {
 	const rawPayload = ctx.request.body || {}
+	const envelope = deliveryEnvelopeSchema.safeParse(rawPayload)
+	if (envelope.success && envelope.data.kind === 'parlay_result') {
+		try {
+			const record = await getNotificationDeliveryQueue().accept(
+				envelope.data,
+			)
+			ctx.status = 202
+			ctx.body = {
+				delivery_id: record.delivery_id,
+				status: record.state,
+			}
+			return
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				(error as Error & { code?: string }).code ===
+					'DELIVERY_PAYLOAD_MISMATCH'
+			) {
+				ctx.status = 409
+				ctx.body = {
+					success: false,
+					code: 'DELIVERY_PAYLOAD_MISMATCH',
+					error: 'delivery_id is already used for another payload',
+				}
+				return
+			}
+			logger.error({
+				method: 'NotificationRouter',
+				event: 'parlay.notification.queue_failed',
+				error: error instanceof Error ? error.message : String(error),
+			})
+			ctx.status = 503
+			ctx.body = {
+				success: false,
+				error: 'Notification queue unavailable',
+			}
+			return
+		}
+	}
+	if ('delivery_id' in (rawPayload as object)) {
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid delivery envelope. Failed Zod validation.',
+		}
+		return
+	}
 	const validatedData = validateParlayResultNotification(rawPayload)
 
 	if (!validatedData) {
@@ -107,6 +160,54 @@ NotificationRouter.post(
 	requireApiKeyAuthentication,
 	async (ctx) => {
 		const rawPayload = ctx.request.body || {}
+		const envelope = deliveryEnvelopeSchema.safeParse(rawPayload)
+		if (envelope.success && envelope.data.kind === 'prop_settled') {
+			try {
+				const record = await getNotificationDeliveryQueue().accept(
+					envelope.data,
+				)
+				ctx.status = 202
+				ctx.body = {
+					delivery_id: record.delivery_id,
+					status: record.state,
+				}
+				return
+			} catch (error) {
+				if (
+					error instanceof Error &&
+					(error as Error & { code?: string }).code ===
+						'DELIVERY_PAYLOAD_MISMATCH'
+				) {
+					ctx.status = 409
+					ctx.body = {
+						success: false,
+						code: 'DELIVERY_PAYLOAD_MISMATCH',
+						error: 'delivery_id is already used for another payload',
+					}
+					return
+				}
+				logger.error({
+					method: 'NotificationRouter',
+					event: 'prop.notification.queue_failed',
+					error:
+						error instanceof Error ? error.message : String(error),
+				})
+				ctx.status = 503
+				ctx.body = {
+					success: false,
+					error: 'Notification queue unavailable',
+				}
+				return
+			}
+		}
+		if ('delivery_id' in (rawPayload as object)) {
+			ctx.status = 422
+			ctx.body = {
+				success: false,
+				error: 'Invalid delivery envelope. Failed Zod validation.',
+			}
+			return
+		}
 		const validatedData = validatePropSettledNotification(rawPayload)
 
 		if (!validatedData) {
@@ -138,6 +239,37 @@ NotificationRouter.post(
 				error: 'Failed to process prop settlement notification',
 			}
 			ctx.status = 500
+		}
+	},
+)
+
+NotificationRouter.get(
+	'/deliveries/:delivery_id',
+	requireApiKeyAuthentication,
+	async (ctx) => {
+		const deliveryId = ctx.params.delivery_id
+		if (!z.string().uuid().safeParse(deliveryId).success) {
+			ctx.status = 422
+			ctx.body = { success: false, error: 'delivery_id is required' }
+			return
+		}
+		const record = await getNotificationDeliveryQueue().get(deliveryId)
+		if (!record) {
+			ctx.status = 404
+			ctx.body = { success: false, error: 'Delivery not found' }
+			return
+		}
+		ctx.status = 200
+		ctx.body = {
+			delivery_id: record.delivery_id,
+			kind: record.kind,
+			status: record.state,
+			attempts: record.attempts,
+			destinations: record.destinations,
+			...(record.kind === 'prop_post'
+				? { receipts: deliveryReceipts(record) }
+				: {}),
+			delivered_at: record.delivered_at,
 		}
 	},
 )

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -7,25 +7,20 @@ const NotificationRouter = new Router()
 
 NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 	const rawPayload = ctx.request.body || {}
-	console.debug({
-		method: 'NotificationRouter',
-		message: 'Notification data received.',
-		data: rawPayload,
-	})
 
 	const validatedData = validateNotifyBetUsers(rawPayload)
 
 	if (!validatedData) {
-		console.debug({
+		logger.warn({
 			method: 'NotificationRouter',
-			message: 'Invalid notification data was received.',
-			data: rawPayload,
+			event: 'push_payload_rejected',
+			schema: 'notificationBetResults',
 		})
 		ctx.body = {
 			success: false,
 			error: 'Invalid notification data. Failed Zod validation.',
 		}
-		ctx.status = 400
+		ctx.status = 422
 		return
 	}
 

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -1,10 +1,30 @@
 import Router from '@koa/router'
+import type { Context, Next } from 'koa'
 import { logger } from '../../../logging/WinstonLogger.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
 import { validateParlayResultNotification } from './parlay-notification-utils.js'
+import { validatePropSettledNotification } from './prop-settled-notification-utils.js'
 
 const NotificationRouter = new Router()
+
+/**
+ * The app-level API-key middleware normally runs before this router. Keep a
+ * route-local guard as defense in depth so mounting the router elsewhere
+ * cannot expose a caller-controlled Discord message edit endpoint.
+ */
+async function requireApiKeyAuthentication(ctx: Context, next: Next) {
+	if (ctx.state.apiKeyAuthenticated !== true) {
+		ctx.status = 401
+		ctx.body = {
+			status: 'error',
+			code: 'UNAUTHENTICATED_NOTIFICATION_CALLBACK',
+			message: 'Authenticated service credentials are required',
+		}
+		return
+	}
+	await next()
+}
 
 NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 	const rawPayload = ctx.request.body || {}
@@ -81,5 +101,45 @@ NotificationRouter.post('/notifications/parlays/results', async (ctx) => {
 		ctx.status = 500
 	}
 })
+
+NotificationRouter.post(
+	'/notifications/props/settled',
+	requireApiKeyAuthentication,
+	async (ctx) => {
+		const rawPayload = ctx.request.body || {}
+		const validatedData = validatePropSettledNotification(rawPayload)
+
+		if (!validatedData) {
+			ctx.body = {
+				success: false,
+				error: 'Invalid prop settlement notification data. Failed Zod validation.',
+			}
+			ctx.status = 422
+			return
+		}
+
+		try {
+			await new NotificationService().processPropSettled(validatedData)
+			ctx.body = {
+				success: true,
+			}
+		} catch (error) {
+			logger.error({
+				method: 'NotificationRouter',
+				event: 'prop.notification.processing_failed',
+				message:
+					'CRITICAL: Failed to process prop settlement notification',
+				error: error instanceof Error ? error.message : error,
+				critical: true,
+				outcome_uuid: validatedData.outcome_uuid,
+			})
+			ctx.body = {
+				success: false,
+				error: 'Failed to process prop settlement notification',
+			}
+			ctx.status = 500
+		}
+	},
+)
 
 export default NotificationRouter

--- a/src/utils/api/routes/notifications/notifications.controller.ts
+++ b/src/utils/api/routes/notifications/notifications.controller.ts
@@ -2,6 +2,7 @@ import Router from '@koa/router'
 import { logger } from '../../../logging/WinstonLogger.js'
 import { validateNotifyBetUsers } from './notification-utils.js'
 import NotificationService from './notifications.service.js'
+import { validateParlayResultNotification } from './parlay-notification-utils.js'
 
 const NotificationRouter = new Router()
 
@@ -39,6 +40,43 @@ NotificationRouter.post('/notifications/bets/results', async (ctx) => {
 		ctx.body = {
 			success: false,
 			error: 'Failed to process notifications',
+		}
+		ctx.status = 500
+	}
+})
+
+NotificationRouter.post('/notifications/parlays/results', async (ctx) => {
+	const rawPayload = ctx.request.body || {}
+	const validatedData = validateParlayResultNotification(rawPayload)
+
+	if (!validatedData) {
+		ctx.body = {
+			success: false,
+			error: 'Invalid parlay notification data. Failed Zod validation.',
+		}
+		ctx.status = 422
+		return
+	}
+
+	try {
+		await new NotificationService().processParlayResult(validatedData)
+		ctx.body = {
+			success: true,
+		}
+	} catch (error) {
+		logger.error({
+			method: 'NotificationRouter',
+			event: 'parlay.notification.processing_failed',
+			message: 'CRITICAL: Failed to process parlay result notification',
+			error: error instanceof Error ? error.message : error,
+			critical: true,
+			parlay_id: validatedData.parlay_id,
+			user_id: validatedData.user_id,
+			kind: validatedData.kind,
+		})
+		ctx.body = {
+			success: false,
+			error: 'Failed to process parlay notifications',
 		}
 		ctx.status = 500
 	}

--- a/src/utils/api/routes/notifications/notifications.interface.ts
+++ b/src/utils/api/routes/notifications/notifications.interface.ts
@@ -28,7 +28,8 @@ export interface ResultPush {
 
 export interface BetNotificationBase {
 	userId: string
-	betId: number
+	/** Optional for shared-contract winners that are not tied to a single bet. */
+	betId?: number
 	/** Optional until Khronos includes guild context in bet-result callbacks. */
 	guildId?: string
 }

--- a/src/utils/api/routes/notifications/notifications.interface.ts
+++ b/src/utils/api/routes/notifications/notifications.interface.ts
@@ -29,6 +29,8 @@ export interface ResultPush {
 export interface BetNotificationBase {
 	userId: string
 	betId: number
+	/** Optional until Khronos includes guild context in bet-result callbacks. */
+	guildId?: string
 }
 
 export interface BetNotificationWon extends BetNotificationBase {

--- a/src/utils/api/routes/notifications/notifications.interface.ts
+++ b/src/utils/api/routes/notifications/notifications.interface.ts
@@ -10,8 +10,8 @@ export interface ResultWon {
 	betAmount: number
 	payout: number
 	profit: number
-	newBalance: number
-	oldBalance: number
+	newBalance?: number
+	oldBalance?: number
 }
 
 export interface ResultLost {

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 // Import interfaces and potentially the Discord client type
 import { container } from '@sapphire/framework'
 import { EmbedBuilder, type Message } from 'discord.js'
@@ -21,6 +22,16 @@ import type {
 	NotifyBetUsers,
 } from './notifications.interface.js'
 import type { ParlayResultNotification } from './parlay-notification-contract.js'
+
+function createDeliveryNonce(
+	deliveryId: string,
+	destinationIndex: number,
+): string {
+	return createHash('sha256')
+		.update(`${deliveryId}:${destinationIndex}`)
+		.digest('hex')
+		.slice(0, 25)
+}
 
 export default class NotificationService {
 	private bigWinAnnouncementService?: BigWinAnnouncementService
@@ -142,67 +153,47 @@ export default class NotificationService {
 	}
 
 	/**
+	 * Queue worker entrypoint. Unlike the legacy callback method, Discord
+	 * failures propagate so BullMQ can retain and retry the destination.
+	 */
+	async deliverParlayResult(
+		data: ParlayResultNotification,
+		deliveryId?: string,
+	): Promise<void> {
+		const embeds = this.buildParlayEmbeds(data)
+		await this.sendParlayEmbeds(
+			data.user_id,
+			data,
+			embeds,
+			true,
+			deliveryId,
+		)
+		try {
+			await this.announceParlayWin(data)
+		} catch (error) {
+			logger.warn({
+				method: this.deliverParlayResult.name,
+				event: 'parlay.notification.announcement_failed',
+				parlay_id: data.parlay_id,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	/**
 	 * Apply one Khronos prop settlement to every original Discord post in the
 	 * posting ledger. A missing/deleted message is a delivery warning, not a
 	 * failed settlement: Khronos has already committed the outcome and can
 	 * safely retry the callback later.
 	 */
 	async processPropSettled(data: PropSettledNotification): Promise<void> {
-		const client = container.client
-		if (!client) {
-			logger.error({
-				method: this.processPropSettled.name,
-				event: 'prop.notification.delivery_failed',
-				message:
-					'Discord client not available for prop settlement update',
-				critical: true,
-				outcome_uuid: data.outcome_uuid,
-			})
-			return
-		}
-
 		const processedMessages = new Set<string>()
 		for (const reference of data.messages) {
 			const messageKey = `${reference.guild_id}:${reference.channel_id}:${reference.message_id}`
 			if (processedMessages.has(messageKey)) continue
 			processedMessages.add(messageKey)
-
 			try {
-				const channel = await client.channels.fetch(
-					reference.channel_id,
-				)
-				if (
-					!channel ||
-					!channel.isTextBased() ||
-					!('guildId' in channel) ||
-					channel.guildId !== reference.guild_id
-				) {
-					throw new Error(
-						`Channel ${reference.channel_id} is missing, not text-based, or belongs to another guild`,
-					)
-				}
-
-				const message = await channel.messages.fetch(
-					reference.message_id,
-				)
-				const updatedEmbeds = message.embeds.map((embed, index) =>
-					index === 0
-						? this.buildPropSettlementEmbed(message, data)
-						: EmbedBuilder.from(embed),
-				)
-
-				if (updatedEmbeds.length === 0) {
-					throw new Error(
-						'Original prop message has no embed to update',
-					)
-				}
-
-				await message.edit({
-					embeds: updatedEmbeds,
-					// The settlement is terminal. Removing components prevents stale
-					// buttons from being clicked while keeping the edit idempotent.
-					components: [],
-				})
+				await this.deliverPropSettlementMessage(data, reference)
 			} catch (error) {
 				logger.warn({
 					method: this.processPropSettled.name,
@@ -218,6 +209,47 @@ export default class NotificationService {
 				})
 			}
 		}
+	}
+
+	/** Deliver exactly one prop message, allowing the durable worker to retry it. */
+	async deliverPropSettlementMessage(
+		data: PropSettledNotification,
+		reference: PropSettledNotification['messages'][number],
+	): Promise<void> {
+		const client = container.client
+		if (!client) {
+			throw new Error(
+				'Discord client not available for prop settlement update',
+			)
+		}
+		const channel = await client.channels.fetch(reference.channel_id)
+		if (
+			!channel ||
+			!channel.isTextBased() ||
+			!('guildId' in channel) ||
+			channel.guildId !== reference.guild_id
+		) {
+			const error = new Error(
+				`Channel ${reference.channel_id} is missing, not text-based, or belongs to another guild`,
+			)
+			Object.assign(error, { code: '10003' })
+			throw error
+		}
+
+		const message = await channel.messages.fetch(reference.message_id)
+		const updatedEmbeds = message.embeds.map((embed, index) =>
+			index === 0
+				? this.buildPropSettlementEmbed(message, data)
+				: EmbedBuilder.from(embed),
+		)
+		if (updatedEmbeds.length === 0) {
+			const error = new Error(
+				'Original prop message has no embed to update',
+			)
+			Object.assign(error, { code: '10003' })
+			throw error
+		}
+		await message.edit({ embeds: updatedEmbeds, components: [] })
 	}
 
 	private buildPropSettlementEmbed(
@@ -527,6 +559,8 @@ export default class NotificationService {
 		userId: string,
 		data: ParlayResultNotification,
 		embeds: EmbedBuilder[],
+		throwOnFailure = false,
+		deliveryId?: string,
 	): Promise<void> {
 		const client = container.client
 
@@ -540,13 +574,22 @@ export default class NotificationService {
 				parlay_id: data.parlay_id,
 				user_id: userId,
 			})
+			if (throwOnFailure) throw new Error('Discord client not available')
 			return
 		}
 
 		try {
 			const user = await client.users.fetch(userId)
-			for (const embed of embeds) {
-				await user.send({ embeds: [embed] })
+			for (const [index, embed] of embeds.entries()) {
+				await user.send({
+					embeds: [embed],
+					...(deliveryId
+						? {
+								nonce: createDeliveryNonce(deliveryId, index),
+								enforceNonce: true,
+							}
+						: {}),
+				})
 			}
 		} catch (error) {
 			logger.error({
@@ -560,6 +603,7 @@ export default class NotificationService {
 				error: error instanceof Error ? error.message : String(error),
 				stack: error instanceof Error ? error.stack : undefined,
 			})
+			if (throwOnFailure) throw error
 		}
 	}
 

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -1,9 +1,15 @@
 // Import interfaces and potentially the Discord client type
 import { container } from '@sapphire/framework'
 import { EmbedBuilder } from 'discord.js'
+import type {
+	BigWinAnnouncementService,
+	BigWinParlayInput,
+	BigWinSingleBetInput,
+} from '../../../../services/engagement/BigWinAnnouncementService.js'
 import { logger } from '../../../logging/WinstonLogger.js'
 import MoneyFormatter from '../../common/money-formatting/money-format.js'
 import type {
+	BetNotificationWon,
 	DisplayBetNotification,
 	DisplayBetNotificationLost,
 	DisplayBetNotificationPush,
@@ -16,6 +22,12 @@ import type {
 import type { ParlayResultNotification } from './parlay-notification-contract.js'
 
 export default class NotificationService {
+	private bigWinAnnouncementService?: BigWinAnnouncementService
+
+	constructor(bigWinAnnouncementService?: BigWinAnnouncementService) {
+		this.bigWinAnnouncementService = bigWinAnnouncementService
+	}
+
 	async processBetResults(data: NotifyBetUsers): Promise<void> {
 		const hasWinners = data.winners && data.winners.length > 0
 		const hasLosers = data.losers && data.losers.length > 0
@@ -71,6 +83,7 @@ export default class NotificationService {
 
 				// Use displayWinner for user notifications
 				await this.notifyUser(displayWinner)
+				await this.announceSingleBetWin(winner)
 			}
 		}
 
@@ -124,6 +137,55 @@ export default class NotificationService {
 	async processParlayResult(data: ParlayResultNotification): Promise<void> {
 		const embeds = this.buildParlayEmbeds(data)
 		await this.sendParlayEmbeds(data.user_id, data, embeds)
+		await this.announceParlayWin(data)
+	}
+
+	private async announceParlayWin(
+		data: ParlayResultNotification,
+	): Promise<void> {
+		if (data.kind !== 'won' || !data.guild_id) return
+
+		const payout = data.actual_payout ?? data.payout
+		if (payout === undefined) return
+
+		const input: BigWinParlayInput = {
+			parlayId: data.parlay_id,
+			guildId: data.guild_id,
+			userId: data.user_id,
+			payout,
+			stake: data.stake,
+			combinedOddsAmerican: data.combined_odds_american,
+			legs: data.legs.length,
+		}
+		const service = await this.getBigWinAnnouncementService()
+		await service.announceParlayWin(input)
+	}
+
+	private async announceSingleBetWin(
+		winner: BetNotificationWon,
+	): Promise<void> {
+		if (!winner.guildId) return
+
+		const input: BigWinSingleBetInput = {
+			betId: winner.betId,
+			guildId: winner.guildId,
+			userId: winner.userId,
+			payout: winner.result.payout,
+			betAmount: winner.result.betAmount,
+			team: winner.result.team,
+		}
+		const service = await this.getBigWinAnnouncementService()
+		await service.announceSingleBetWin(input)
+	}
+
+	private async getBigWinAnnouncementService(): Promise<BigWinAnnouncementService> {
+		if (!this.bigWinAnnouncementService) {
+			const module = await import(
+				'../../../../services/engagement/BigWinAnnouncementService.js'
+			)
+			this.bigWinAnnouncementService = new module.default()
+		}
+		return this.bigWinAnnouncementService
 	}
 
 	private buildParlayEmbeds(data: ParlayResultNotification): EmbedBuilder[] {

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -13,6 +13,7 @@ import type {
 	DisplayResultWon,
 	NotifyBetUsers,
 } from './notifications.interface.js'
+import type { ParlayResultNotification } from './parlay-notification-contract.js'
 
 export default class NotificationService {
 	async processBetResults(data: NotifyBetUsers): Promise<void> {
@@ -109,6 +110,242 @@ export default class NotificationService {
 
 				await this.notifyUser(displayPush)
 			}
+		}
+	}
+
+	/**
+	 * Deliver one multi-leg parlay resolution to its owner.
+	 *
+	 * Discord delivery failures are intentionally swallowed after structured
+	 * logging, matching the singles notification route's no-retry-storm
+	 * behavior. Khronos still receives a successful HTTP response when Discord
+	 * is unavailable.
+	 */
+	async processParlayResult(data: ParlayResultNotification): Promise<void> {
+		const embeds = this.buildParlayEmbeds(data)
+		await this.sendParlayEmbeds(data.user_id, data, embeds)
+	}
+
+	private buildParlayEmbeds(data: ParlayResultNotification): EmbedBuilder[] {
+		const combinedOdds = this.formatAmericanOdds(
+			data.combined_odds_american,
+		)
+
+		const baseEmbed = new EmbedBuilder()
+			.setTimestamp()
+			.setFooter({ text: `Pluto | Parlay ID: ${data.parlay_id}` })
+			.addFields({
+				name: '📈 Combined Odds',
+				value: combinedOdds,
+				inline: true,
+			})
+
+		switch (data.kind) {
+			case 'won': {
+				baseEmbed
+					.setTitle('🎉 Parlay Won! 🎉')
+					.setColor('#57f287')
+					.addFields(
+						{
+							name: '💰 Stake',
+							value: MoneyFormatter.toUSD(data.stake),
+							inline: true,
+						},
+						{
+							name: '🏆 Payout',
+							value: MoneyFormatter.toUSD(
+								data.actual_payout ?? data.payout ?? 0,
+							),
+							inline: true,
+						},
+					)
+				if (
+					data.old_balance !== undefined &&
+					data.new_balance !== undefined
+				) {
+					baseEmbed.addFields({
+						name: '📊 Balance Update',
+						value: `${MoneyFormatter.toUSD(data.old_balance)} → ${MoneyFormatter.toUSD(data.new_balance)}`,
+						inline: false,
+					})
+				}
+				break
+			}
+			case 'busted':
+			case 'lost':
+				baseEmbed
+					.setTitle('❌ Parlay Busted')
+					.setColor('#ff6961')
+					.addFields({
+						name: '💸 Lost',
+						value: MoneyFormatter.toUSD(data.stake),
+						inline: true,
+					})
+				break
+			case 'push_refunded':
+				baseEmbed
+					.setTitle('🔄 Parlay Refunded')
+					.setColor('#ffa500')
+					.addFields({
+						name: '💵 Refunded Amount',
+						value: MoneyFormatter.toUSD(
+							data.refund_amount ??
+								data.actual_payout ??
+								data.stake,
+						),
+						inline: true,
+					})
+					.addFields({
+						name: 'ℹ️ Reason',
+						value: 'All eligible legs pushed or were voided. Your stake has been refunded.',
+						inline: false,
+					})
+				break
+		}
+
+		const groups = this.buildParlayLegFieldGroups(data)
+		if (groups.length === 0) return [baseEmbed]
+		return groups.map((fields, index) => {
+			const embed =
+				index === 0
+					? baseEmbed
+					: new EmbedBuilder()
+							.setTitle('🧾 Parlay Legs (continued)')
+							.setTimestamp()
+							.setFooter({
+								text: `Pluto | Parlay ID: ${data.parlay_id}`,
+							})
+			embed.addFields(...fields)
+			return embed
+		})
+	}
+
+	private buildParlayLegFieldGroups(
+		data: ParlayResultNotification,
+	): Array<Array<{ name: string; value: string; inline: false }>> {
+		const maxFieldLength = 800
+		const maxFieldsPerEmbed = 20
+		const maxLegCharactersPerEmbed = 4500
+		const groups: Array<
+			Array<{ name: string; value: string; inline: false }>
+		> = []
+		let currentGroup: Array<{
+			name: string
+			value: string
+			inline: false
+		}> = []
+		let currentLines: string[] = []
+		let currentFieldLength = 0
+		let currentGroupLength = 0
+
+		const flushField = () => {
+			if (currentLines.length === 0) return
+			currentGroup.push({
+				name:
+					currentGroup.length === 0
+						? '🧾 Legs'
+						: `🧾 Legs (${currentGroup.length + 1})`,
+				value: currentLines.join('\n'),
+				inline: false,
+			})
+			currentLines = []
+			currentFieldLength = 0
+		}
+		const flushGroup = () => {
+			flushField()
+			if (currentGroup.length === 0) return
+			groups.push(currentGroup)
+			currentGroup = []
+			currentGroupLength = 0
+		}
+
+		for (const leg of data.legs) {
+			const selection = leg.selection_display
+			const shortenedSelection =
+				selection.length > 350
+					? `${selection.slice(0, 349)}…`
+					: selection
+			const line = `${this.parlayLegGlyph(leg.result)} ${shortenedSelection} (${this.formatAmericanOdds(leg.odds_american)})`
+			if (
+				currentLines.length > 0 &&
+				currentFieldLength + line.length + 1 > maxFieldLength
+			) {
+				flushField()
+			}
+			if (
+				currentGroup.length >= maxFieldsPerEmbed ||
+				(currentGroupLength > 0 &&
+					currentGroupLength + line.length + 1 >
+						maxLegCharactersPerEmbed)
+			) {
+				flushGroup()
+			}
+			currentLines.push(line)
+			currentFieldLength += line.length + 1
+			currentGroupLength += line.length + 1
+		}
+		flushGroup()
+
+		return groups
+	}
+
+	private parlayLegGlyph(
+		result: ParlayResultNotification['legs'][number]['result'],
+	): string {
+		switch (result) {
+			case 'won':
+				return '✅'
+			case 'lost':
+				return '❌'
+			case 'pending':
+				return '⏳'
+			case 'push':
+			case 'void':
+				return '➖'
+		}
+	}
+
+	private formatAmericanOdds(odds: number): string {
+		return odds > 0 ? `+${odds}` : `${odds}`
+	}
+
+	private async sendParlayEmbeds(
+		userId: string,
+		data: ParlayResultNotification,
+		embeds: EmbedBuilder[],
+	): Promise<void> {
+		const client = container.client
+
+		if (!client) {
+			logger.error({
+				method: this.sendParlayEmbeds.name,
+				event: 'parlay.notification.delivery_failed',
+				message: 'Discord client not available for parlay notification',
+				critical: true,
+				kind: data.kind,
+				parlay_id: data.parlay_id,
+				user_id: userId,
+			})
+			return
+		}
+
+		try {
+			const user = await client.users.fetch(userId)
+			for (const embed of embeds) {
+				await user.send({ embeds: [embed] })
+			}
+		} catch (error) {
+			logger.error({
+				method: this.sendParlayEmbeds.name,
+				event: 'parlay.notification.delivery_failed',
+				message: 'Unable to send parlay result Discord DM',
+				critical: true,
+				kind: data.kind,
+				parlay_id: data.parlay_id,
+				user_id: userId,
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			})
 		}
 	}
 

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -28,12 +28,15 @@ export default class NotificationService {
 		// Process winners (only if not null and has items)
 		if (hasWinners) {
 			for (const winner of data.winners!) {
-				if (!winner.result.oldBalance || !winner.result.newBalance) {
-					logger.error({
+				if (
+					winner.result.oldBalance === undefined ||
+					winner.result.newBalance === undefined
+				) {
+					logger.warn({
 						method: this.processBetResults.name,
-						message: `Missing balance data for user ${winner.userId}`,
+						event: 'notification_balance_unavailable',
+						message: `Missing balance data for user ${winner.userId}; sending notification without balance delta`,
 					})
-					continue
 				}
 
 				const formattedAmounts = await MoneyFormatter.formatAmounts({
@@ -51,12 +54,14 @@ export default class NotificationService {
 					displayBetAmount,
 					displayPayout,
 					displayProfit,
-					displayNewBalance: MoneyFormatter.toUSD(
-						winner.result.newBalance,
-					),
-					displayOldBalance: MoneyFormatter.toUSD(
-						winner.result.oldBalance,
-					),
+					displayNewBalance:
+						winner.result.newBalance === undefined
+							? 'Unavailable'
+							: MoneyFormatter.toUSD(winner.result.newBalance),
+					displayOldBalance:
+						winner.result.oldBalance === undefined
+							? 'Unavailable'
+							: MoneyFormatter.toUSD(winner.result.oldBalance),
 				}
 				const displayWinner: DisplayBetNotificationWon = {
 					...winner,

--- a/src/utils/api/routes/notifications/notifications.service.ts
+++ b/src/utils/api/routes/notifications/notifications.service.ts
@@ -1,6 +1,6 @@
 // Import interfaces and potentially the Discord client type
 import { container } from '@sapphire/framework'
-import { EmbedBuilder } from 'discord.js'
+import { EmbedBuilder, type Message } from 'discord.js'
 import type {
 	BigWinAnnouncementService,
 	BigWinParlayInput,
@@ -8,6 +8,7 @@ import type {
 } from '../../../../services/engagement/BigWinAnnouncementService.js'
 import { logger } from '../../../logging/WinstonLogger.js'
 import MoneyFormatter from '../../common/money-formatting/money-format.js'
+import type { PropSettledNotification } from '../shared-payload-schemas.js'
 import type {
 	BetNotificationWon,
 	DisplayBetNotification,
@@ -140,6 +141,157 @@ export default class NotificationService {
 		await this.announceParlayWin(data)
 	}
 
+	/**
+	 * Apply one Khronos prop settlement to every original Discord post in the
+	 * posting ledger. A missing/deleted message is a delivery warning, not a
+	 * failed settlement: Khronos has already committed the outcome and can
+	 * safely retry the callback later.
+	 */
+	async processPropSettled(data: PropSettledNotification): Promise<void> {
+		const client = container.client
+		if (!client) {
+			logger.error({
+				method: this.processPropSettled.name,
+				event: 'prop.notification.delivery_failed',
+				message:
+					'Discord client not available for prop settlement update',
+				critical: true,
+				outcome_uuid: data.outcome_uuid,
+			})
+			return
+		}
+
+		const processedMessages = new Set<string>()
+		for (const reference of data.messages) {
+			const messageKey = `${reference.guild_id}:${reference.channel_id}:${reference.message_id}`
+			if (processedMessages.has(messageKey)) continue
+			processedMessages.add(messageKey)
+
+			try {
+				const channel = await client.channels.fetch(
+					reference.channel_id,
+				)
+				if (
+					!channel ||
+					!channel.isTextBased() ||
+					!('guildId' in channel) ||
+					channel.guildId !== reference.guild_id
+				) {
+					throw new Error(
+						`Channel ${reference.channel_id} is missing, not text-based, or belongs to another guild`,
+					)
+				}
+
+				const message = await channel.messages.fetch(
+					reference.message_id,
+				)
+				const updatedEmbeds = message.embeds.map((embed, index) =>
+					index === 0
+						? this.buildPropSettlementEmbed(message, data)
+						: EmbedBuilder.from(embed),
+				)
+
+				if (updatedEmbeds.length === 0) {
+					throw new Error(
+						'Original prop message has no embed to update',
+					)
+				}
+
+				await message.edit({
+					embeds: updatedEmbeds,
+					// The settlement is terminal. Removing components prevents stale
+					// buttons from being clicked while keeping the edit idempotent.
+					components: [],
+				})
+			} catch (error) {
+				logger.warn({
+					method: this.processPropSettled.name,
+					event: 'prop.notification.message_update_failed',
+					message:
+						'Unable to update original prop message after settlement',
+					guild_id: reference.guild_id,
+					channel_id: reference.channel_id,
+					message_id: reference.message_id,
+					outcome_uuid: data.outcome_uuid,
+					error:
+						error instanceof Error ? error.message : String(error),
+				})
+			}
+		}
+	}
+
+	private buildPropSettlementEmbed(
+		message: Message,
+		data: PropSettledNotification,
+	): EmbedBuilder {
+		const originalEmbed = message.embeds[0]
+		if (!originalEmbed) {
+			throw new Error('Original prop message has no embed to update')
+		}
+
+		const embed = EmbedBuilder.from(originalEmbed)
+		const fields = [...(embed.data.fields ?? [])]
+		const resultFieldName = '🎯 Result'
+		const tallyFieldName = '📊 Prediction results'
+		const resultField = {
+			name: resultFieldName,
+			value: this.formatPropResult(data),
+			inline: false,
+		}
+		const tallyField = {
+			name: tallyFieldName,
+			value: this.formatPropTallies(data),
+			inline: false,
+		}
+
+		const resultIndex = fields.findIndex(
+			(field) => field.name === resultFieldName,
+		)
+		if (resultIndex === -1) fields.push(resultField)
+		else fields[resultIndex] = resultField
+
+		const tallyIndex = fields.findIndex(
+			(field) => field.name === tallyFieldName,
+		)
+		if (tallyIndex === -1) fields.push(tallyField)
+		else fields[tallyIndex] = tallyField
+
+		return embed.setFields(fields)
+	}
+
+	private formatPropResult(data: PropSettledNotification): string {
+		const iconByResult: Record<PropSettledNotification['result'], string> =
+			{
+				won: '✅',
+				lost: '❌',
+				push: '➖',
+				void: '🚫',
+			}
+		const label =
+			data.winning_side_display?.trim() ||
+			(
+				{
+					won: 'Won',
+					lost: 'Lost',
+					push: 'Push',
+					void: 'Voided',
+				} satisfies Record<PropSettledNotification['result'], string>
+			)[data.result]
+		const actualValue =
+			data.actual_value === null || data.actual_value === undefined
+				? ''
+				: ` — ${data.actual_value}`
+
+		return `**Result: ${label} ${iconByResult[data.result]}${actualValue}**`
+	}
+
+	private formatPropTallies(data: PropSettledNotification): string {
+		const { correct, incorrect, total } = data.tallies
+		const percentage = total === 0 ? 0 : Math.round((correct / total) * 100)
+		const predictorLabel = total === 1 ? 'predictor' : 'predictors'
+		return `${percentage}% of ${total} ${predictorLabel} got it right (${correct} correct, ${incorrect} incorrect).`
+	}
+
 	private async announceParlayWin(
 		data: ParlayResultNotification,
 	): Promise<void> {
@@ -164,7 +316,7 @@ export default class NotificationService {
 	private async announceSingleBetWin(
 		winner: BetNotificationWon,
 	): Promise<void> {
-		if (!winner.guildId) return
+		if (!winner.guildId || winner.betId === undefined) return
 
 		const input: BigWinSingleBetInput = {
 			betId: winner.betId,
@@ -413,6 +565,8 @@ export default class NotificationService {
 
 	async notifyUser(betData: DisplayBetNotification) {
 		const { userId, betId, result, displayResult } = betData
+		const betIdLabel =
+			betId === undefined ? 'Bet ID unavailable' : `Bet ID: ${betId}`
 
 		switch (result.outcome) {
 			case 'won': {
@@ -453,7 +607,7 @@ export default class NotificationService {
 					)
 					.setTimestamp()
 					.setFooter({
-						text: `Pluto | Bet ID: ${betId}`,
+						text: `Pluto | ${betIdLabel}`,
 					})
 
 				await this.sendEmbed(userId, betId, embed)
@@ -482,7 +636,7 @@ export default class NotificationService {
 					)
 					.setTimestamp()
 					.setFooter({
-						text: `Pluto | Bet ID: ${betId}`,
+						text: `Pluto | ${betIdLabel}`,
 					})
 
 				await this.sendEmbed(userId, betId, embed)
@@ -506,7 +660,7 @@ export default class NotificationService {
 					)
 					.setTimestamp()
 					.setFooter({
-						text: `Pluto | Bet ID: ${betId}`,
+						text: `Pluto | ${betIdLabel}`,
 					})
 
 				await this.sendEmbed(userId, betId, embed)
@@ -517,7 +671,7 @@ export default class NotificationService {
 
 	private async sendEmbed(
 		userId: string,
-		betId: number,
+		betId: number | undefined,
 		embed: EmbedBuilder,
 	): Promise<void> {
 		const client = container.client

--- a/src/utils/api/routes/notifications/parlay-notification-contract.ts
+++ b/src/utils/api/routes/notifications/parlay-notification-contract.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+
+/**
+ * Temporary compatibility contract for TF-967.
+ *
+ * @pluto-khronos/types@3.4.3 does not export the C5 parlay notification
+ * schema yet. Keep this shape aligned with TF-949's
+ * `parlayResultNotificationSchema`; replace this module import with the
+ * published package export when the paired Khronos release lands.
+ */
+export const parlayResultNotificationSchema = z
+	.object({
+		kind: z.enum(['won', 'lost', 'push_refunded', 'busted']),
+		parlay_id: z.string().uuid(),
+		user_id: z.string().min(1),
+		guild_id: z.string().min(1).optional(),
+		stake: z.number().finite().nonnegative(),
+		combined_odds_american: z.number().int(),
+		payout: z.number().finite().nonnegative().optional(),
+		actual_payout: z.number().finite().nonnegative().nullable(),
+		refund_amount: z.number().finite().nonnegative().optional(),
+		old_balance: z.number().finite().optional(),
+		new_balance: z.number().finite().optional(),
+		legs: z
+			.array(
+				z.object({
+					id: z.string().min(1),
+					event_id: z.string().min(1),
+					outcome_uuid: z.string().min(1),
+					selection_display: z.string().min(1),
+					market_key: z.string().min(1),
+					odds_american: z.number().int(),
+					point: z.number().finite().nullable(),
+					commence_time: z.coerce.date(),
+					result: z.enum(['pending', 'won', 'lost', 'push', 'void']),
+					home_team: z.string().min(1).optional(),
+					away_team: z.string().min(1).optional(),
+				}),
+			)
+			.min(1),
+	})
+	.superRefine((payload, context) => {
+		if (
+			payload.kind === 'won' &&
+			payload.actual_payout === null &&
+			payload.payout === undefined
+		) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['payout'],
+				message: 'won notifications require payout or actual_payout',
+			})
+		}
+	})
+
+export type ParlayResultNotification = z.infer<
+	typeof parlayResultNotificationSchema
+>

--- a/src/utils/api/routes/notifications/parlay-notification-utils.ts
+++ b/src/utils/api/routes/notifications/parlay-notification-utils.ts
@@ -1,0 +1,24 @@
+import { logger } from '../../../logging/WinstonLogger.js'
+import {
+	type ParlayResultNotification,
+	parlayResultNotificationSchema,
+} from './parlay-notification-contract.js'
+
+/** Parse and strictly validate the Khronos parlay result notification. */
+export function validateParlayResultNotification(
+	payload: unknown,
+): ParlayResultNotification | null {
+	const result = parlayResultNotificationSchema.safeParse(payload)
+
+	if (!result.success) {
+		logger.warn({
+			method: 'validateParlayResultNotification',
+			event: 'parlay.notification.validation_failed',
+			message: 'Invalid parlay result notification payload',
+			errors: result.error.issues,
+		})
+		return null
+	}
+
+	return result.data
+}

--- a/src/utils/api/routes/notifications/prop-settled-notification-utils.ts
+++ b/src/utils/api/routes/notifications/prop-settled-notification-utils.ts
@@ -1,0 +1,37 @@
+import { logger } from '../../../logging/WinstonLogger.js'
+import {
+	type PropSettledNotification,
+	propSettledNotificationSchema,
+} from '../shared-payload-schemas.js'
+
+/** Parse and strictly validate a Khronos prop settlement callback. */
+export function validatePropSettledNotification(
+	payload: unknown,
+): PropSettledNotification | null {
+	const result = propSettledNotificationSchema.safeParse(payload)
+
+	if (!result.success) {
+		logger.warn({
+			method: 'validatePropSettledNotification',
+			event: 'prop.notification.validation_failed',
+			message: 'Invalid prop settlement notification payload',
+			errors: result.error.issues,
+		})
+		return null
+	}
+
+	const { correct, incorrect, total } = result.data.tallies
+	if (correct + incorrect !== total) {
+		logger.warn({
+			method: 'validatePropSettledNotification',
+			event: 'prop.notification.tally_invariant_failed',
+			message: 'Prop settlement tallies must sum to total',
+			correct,
+			incorrect,
+			total,
+		})
+		return null
+	}
+
+	return result.data
+}

--- a/src/utils/api/routes/props/__tests__/props-router.test.ts
+++ b/src/utils/api/routes/props/__tests__/props-router.test.ts
@@ -8,18 +8,12 @@ const logger = vi.hoisted(() => ({
 	warn: vi.fn(),
 	info: vi.fn(),
 }))
-const postPropsToChannel = vi.hoisted(() => vi.fn())
+const acceptDetailed = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
-vi.mock('../../../../props/PropPostingHandler.js', () => {
-	function MockPropPostingHandler(this: {
-		postPropsToChannel: typeof postPropsToChannel
-	}) {
-		this.postPropsToChannel = postPropsToChannel
-	}
-
-	return { PropPostingHandler: MockPropPostingHandler }
-})
+vi.mock('../../notifications/delivery-queue.js', () => ({
+	getNotificationDeliveryQueue: () => ({ acceptDetailed }),
+}))
 
 import PropsRouter from '../props-router.js'
 
@@ -50,33 +44,36 @@ const validPayload = {
 	guilds: [{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' }],
 }
 
-const refs = [
-	{
-		outcome_uuid: validPayload.props[0].over.outcome_uuid,
-		guild_id: 'guild-1',
-		channel_id: 'channel-1',
-		message_id: 'message-1',
-	},
-	{
-		outcome_uuid: validPayload.props[0].under.outcome_uuid,
-		guild_id: 'guild-1',
-		channel_id: 'channel-1',
-		message_id: 'message-1',
-	},
-]
+const validEnvelope = {
+	delivery_id: '550e8400-e29b-41d4-a716-446655440010',
+	schema_version: 1,
+	kind: 'prop_post',
+	occurred_at: '2026-07-14T20:00:00.000Z',
+	payload: validPayload,
+}
+
+const queuedRecord = {
+	delivery_id: validEnvelope.delivery_id,
+	kind: 'prop_post',
+	schema_version: 1,
+	occurred_at: validEnvelope.occurred_at,
+	payload: validPayload,
+	payload_hash: 'hash',
+	state: 'queued',
+	attempts: 0,
+	destinations: [],
+	created_at: validEnvelope.occurred_at,
+	updated_at: validEnvelope.occurred_at,
+} as const
 
 describe('POST /props/daily', () => {
 	let server: Server | undefined
 
 	beforeEach(() => {
 		vi.clearAllMocks()
-		postPropsToChannel.mockResolvedValue({
-			posted: 1,
-			filtered: 0,
-			failed: 0,
-			total: 1,
-			results: refs,
-			failures: [],
+		acceptDetailed.mockResolvedValue({
+			record: queuedRecord,
+			duplicate: false,
 		})
 	})
 
@@ -109,17 +106,18 @@ describe('POST /props/daily', () => {
 		})
 	}
 
-	it('passes validated compact props to the posting handler and returns outcome refs', async () => {
-		const response = await request(validPayload)
+	it('durably accepts a validated prop-post envelope before Discord delivery', async () => {
+		const response = await request(validEnvelope)
 
-		expect(response.status).toBe(200)
-		expect(await response.json()).toEqual(refs)
-		expect(postPropsToChannel).toHaveBeenCalledWith(
-			'guild-1',
-			validPayload.props,
-			'nba',
-			'channel-1',
-		)
+		expect(response.status).toBe(202)
+		expect(await response.json()).toMatchObject({
+			accepted: true,
+			duplicate: false,
+			delivery_id: validEnvelope.delivery_id,
+			kind: 'prop_post',
+			status: 'queued',
+		})
+		expect(acceptDetailed).toHaveBeenCalledWith(validEnvelope)
 	})
 
 	it('rejects malformed payloads with structured 422 errors', async () => {
@@ -129,22 +127,29 @@ describe('POST /props/daily', () => {
 		const body = await response.json()
 		expect(body).toMatchObject({
 			success: false,
-			error: 'Invalid props payload. Failed Zod validation.',
+			error: 'Invalid prop-post delivery envelope. Failed Zod validation.',
 		})
 		expect(body.issues).toEqual(expect.any(Array))
-		expect(postPropsToChannel).not.toHaveBeenCalled()
+		expect(acceptDetailed).not.toHaveBeenCalled()
 	})
 
 	it('rejects unsupported guild sports with 422', async () => {
 		const response = await request({
-			...validPayload,
-			guilds: [
-				{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'mlb' },
-			],
+			...validEnvelope,
+			payload: {
+				...validPayload,
+				guilds: [
+					{
+						guild_id: 'guild-1',
+						channel_id: 'channel-1',
+						sport: 'mlb',
+					},
+				],
+			},
 		})
 
 		expect(response.status).toBe(422)
-		expect(postPropsToChannel).not.toHaveBeenCalled()
+		expect(acceptDetailed).not.toHaveBeenCalled()
 		expect(logger.warn).toHaveBeenCalledWith(
 			expect.objectContaining({
 				event: 'push_payload_rejected',
@@ -153,81 +158,32 @@ describe('POST /props/daily', () => {
 		)
 	})
 
-	it('returns 500 when a guild cannot receive props', async () => {
-		postPropsToChannel.mockResolvedValue({
-			posted: 0,
-			filtered: 0,
-			failed: 1,
-			total: 1,
-			results: [],
-			failures: [
-				{
-					guild_id: 'guild-1',
-					channel_id: 'channel-1',
-					outcome_uuids: refs.map((ref) => ref.outcome_uuid),
-					error: 'Discord unavailable',
-				},
-			],
-		})
+	it('returns 503 when durable queue acceptance fails', async () => {
+		acceptDetailed.mockRejectedValueOnce(new Error('Redis unavailable'))
 
-		const response = await request(validPayload)
+		const response = await request(validEnvelope)
 
-		expect(response.status).toBe(500)
-		expect(response.headers.get('x-props-failed')).toBe('1')
+		expect(response.status).toBe(503)
 		expect(await response.json()).toEqual({
 			success: false,
-			error: 'Failed to deliver one or more daily props.',
-			posted: [],
-			failures: [
-				{
-					guild_id: 'guild-1',
-					channel_id: 'channel-1',
-					outcome_uuids: refs.map((ref) => ref.outcome_uuid),
-					error: 'Discord unavailable',
-				},
-			],
+			error: 'Prop-post delivery queue unavailable.',
 		})
 		expect(logger.error).toHaveBeenCalledWith(
-			expect.objectContaining({
-				event: 'props_daily_delivery_failed',
-				failed_count: 1,
-			}),
+			expect.objectContaining({ event: 'props_daily_queue_failed' }),
 		)
 	})
 
-	it('returns posted refs alongside failure details when delivery is partial', async () => {
-		postPropsToChannel.mockResolvedValue({
-			posted: 1,
-			filtered: 0,
-			failed: 1,
-			total: 2,
-			results: refs,
-			failures: [
-				{
-					guild_id: 'guild-1',
-					channel_id: 'channel-1',
-					outcome_uuids: ['550e8400-e29b-41d4-a716-446655440002'],
-					error: 'Discord unavailable',
-				},
-			],
+	it('returns 409 when delivery ID is reused with a different payload', async () => {
+		const error = Object.assign(new Error('mismatch'), {
+			code: 'DELIVERY_PAYLOAD_MISMATCH',
 		})
+		acceptDetailed.mockRejectedValueOnce(error)
 
-		const response = await request(validPayload)
+		const response = await request(validEnvelope)
 
-		expect(response.status).toBe(500)
-		expect(response.headers.get('x-props-failed')).toBe('1')
-		expect(await response.json()).toEqual({
-			success: false,
-			error: 'Failed to deliver one or more daily props.',
-			posted: refs,
-			failures: [
-				{
-					guild_id: 'guild-1',
-					channel_id: 'channel-1',
-					outcome_uuids: ['550e8400-e29b-41d4-a716-446655440002'],
-					error: 'Discord unavailable',
-				},
-			],
+		expect(response.status).toBe(409)
+		expect(await response.json()).toMatchObject({
+			code: 'DELIVERY_PAYLOAD_MISMATCH',
 		})
 	})
 })

--- a/src/utils/api/routes/props/__tests__/props-router.test.ts
+++ b/src/utils/api/routes/props/__tests__/props-router.test.ts
@@ -1,0 +1,152 @@
+import { createServer, type Server } from 'node:http'
+import Koa from 'koa'
+import bodyParser from 'koa-bodyparser'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+const postPropsToChannel = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+vi.mock('../../../../props/PropPostingHandler.js', () => {
+	function MockPropPostingHandler(this: {
+		postPropsToChannel: typeof postPropsToChannel
+	}) {
+		this.postPropsToChannel = postPropsToChannel
+	}
+
+	return { PropPostingHandler: MockPropPostingHandler }
+})
+
+import PropsRouter from '../props-router.js'
+
+const validPayload = {
+	props: [
+		{
+			event_id: 'event-1',
+			commence_time: '2026-07-11T00:00:00Z',
+			home_team: 'Home',
+			away_team: 'Away',
+			sport_title: 'NBA',
+			market_key: 'player_points',
+			bookmaker_key: 'draftkings',
+			description: 'Player',
+			point: 20.5,
+			over: {
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+				outcome_name: 'Over',
+				price: -110,
+			},
+			under: {
+				outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+				outcome_name: 'Under',
+				price: -110,
+			},
+		},
+	],
+	guilds: [{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' }],
+}
+
+describe('POST /props/daily', () => {
+	let server: Server | undefined
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		postPropsToChannel.mockResolvedValue({
+			posted: 1,
+			filtered: 0,
+			failed: 0,
+			total: 1,
+		})
+	})
+
+	afterEach(async () => {
+		if (server?.listening) {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()))
+			})
+		}
+	})
+
+	async function request(payload: unknown) {
+		const app = new Koa()
+		app.use(bodyParser())
+		app.use(PropsRouter.routes())
+		server = createServer(app.callback())
+
+		await new Promise<void>((resolve) => {
+			server.listen(0, '127.0.0.1', () => resolve())
+		})
+		const address = server.address()
+		if (!address || typeof address === 'string') {
+			throw new Error('Test server did not expose a TCP address')
+		}
+
+		return fetch(`http://127.0.0.1:${address.port}/props/daily`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(payload),
+		})
+	}
+
+	it('passes validated compact props to the posting handler', async () => {
+		const response = await request(validPayload)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			success: true,
+			results: [{ posted: 1, filtered: 0, failed: 0, total: 1 }],
+		})
+		expect(postPropsToChannel).toHaveBeenCalledWith(
+			'guild-1',
+			validPayload.props,
+			'nba',
+			'channel-1',
+		)
+	})
+
+	it('rejects unsupported guild sports with 422', async () => {
+		const response = await request({
+			...validPayload,
+			guilds: [
+				{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'mlb' },
+			],
+		})
+
+		expect(response.status).toBe(422)
+		expect(postPropsToChannel).not.toHaveBeenCalled()
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'push_payload_rejected',
+				schema: 'dailyPropsPayload',
+			}),
+		)
+	})
+
+	it('returns a retryable failure when a guild cannot receive props', async () => {
+		postPropsToChannel.mockResolvedValue({
+			posted: 0,
+			filtered: 0,
+			failed: 1,
+			total: 1,
+		})
+
+		const response = await request(validPayload)
+
+		expect(response.status).toBe(500)
+		expect(await response.json()).toEqual({
+			success: false,
+			error: 'Failed to deliver one or more daily props.',
+			results: [{ posted: 0, filtered: 0, failed: 1, total: 1 }],
+		})
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'props_daily_delivery_failed',
+				failed: 1,
+			}),
+		)
+	})
+})

--- a/src/utils/api/routes/props/__tests__/props-router.test.ts
+++ b/src/utils/api/routes/props/__tests__/props-router.test.ts
@@ -50,6 +50,21 @@ const validPayload = {
 	guilds: [{ guild_id: 'guild-1', channel_id: 'channel-1', sport: 'nba' }],
 }
 
+const refs = [
+	{
+		outcome_uuid: validPayload.props[0].over.outcome_uuid,
+		guild_id: 'guild-1',
+		channel_id: 'channel-1',
+		message_id: 'message-1',
+	},
+	{
+		outcome_uuid: validPayload.props[0].under.outcome_uuid,
+		guild_id: 'guild-1',
+		channel_id: 'channel-1',
+		message_id: 'message-1',
+	},
+]
+
 describe('POST /props/daily', () => {
 	let server: Server | undefined
 
@@ -60,6 +75,8 @@ describe('POST /props/daily', () => {
 			filtered: 0,
 			failed: 0,
 			total: 1,
+			results: refs,
+			failures: [],
 		})
 	})
 
@@ -92,20 +109,30 @@ describe('POST /props/daily', () => {
 		})
 	}
 
-	it('passes validated compact props to the posting handler', async () => {
+	it('passes validated compact props to the posting handler and returns outcome refs', async () => {
 		const response = await request(validPayload)
 
 		expect(response.status).toBe(200)
-		expect(await response.json()).toEqual({
-			success: true,
-			results: [{ posted: 1, filtered: 0, failed: 0, total: 1 }],
-		})
+		expect(await response.json()).toEqual(refs)
 		expect(postPropsToChannel).toHaveBeenCalledWith(
 			'guild-1',
 			validPayload.props,
 			'nba',
 			'channel-1',
 		)
+	})
+
+	it('rejects malformed payloads with structured 422 errors', async () => {
+		const response = await request({ props: [] })
+
+		expect(response.status).toBe(422)
+		const body = await response.json()
+		expect(body).toMatchObject({
+			success: false,
+			error: 'Invalid props payload. Failed Zod validation.',
+		})
+		expect(body.issues).toEqual(expect.any(Array))
+		expect(postPropsToChannel).not.toHaveBeenCalled()
 	})
 
 	it('rejects unsupported guild sports with 422', async () => {
@@ -126,27 +153,81 @@ describe('POST /props/daily', () => {
 		)
 	})
 
-	it('returns a retryable failure when a guild cannot receive props', async () => {
+	it('returns 500 when a guild cannot receive props', async () => {
 		postPropsToChannel.mockResolvedValue({
 			posted: 0,
 			filtered: 0,
 			failed: 1,
 			total: 1,
+			results: [],
+			failures: [
+				{
+					guild_id: 'guild-1',
+					channel_id: 'channel-1',
+					outcome_uuids: refs.map((ref) => ref.outcome_uuid),
+					error: 'Discord unavailable',
+				},
+			],
 		})
 
 		const response = await request(validPayload)
 
 		expect(response.status).toBe(500)
+		expect(response.headers.get('x-props-failed')).toBe('1')
 		expect(await response.json()).toEqual({
 			success: false,
 			error: 'Failed to deliver one or more daily props.',
-			results: [{ posted: 0, filtered: 0, failed: 1, total: 1 }],
+			posted: [],
+			failures: [
+				{
+					guild_id: 'guild-1',
+					channel_id: 'channel-1',
+					outcome_uuids: refs.map((ref) => ref.outcome_uuid),
+					error: 'Discord unavailable',
+				},
+			],
 		})
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.objectContaining({
 				event: 'props_daily_delivery_failed',
-				failed: 1,
+				failed_count: 1,
 			}),
 		)
+	})
+
+	it('returns posted refs alongside failure details when delivery is partial', async () => {
+		postPropsToChannel.mockResolvedValue({
+			posted: 1,
+			filtered: 0,
+			failed: 1,
+			total: 2,
+			results: refs,
+			failures: [
+				{
+					guild_id: 'guild-1',
+					channel_id: 'channel-1',
+					outcome_uuids: ['550e8400-e29b-41d4-a716-446655440002'],
+					error: 'Discord unavailable',
+				},
+			],
+		})
+
+		const response = await request(validPayload)
+
+		expect(response.status).toBe(500)
+		expect(response.headers.get('x-props-failed')).toBe('1')
+		expect(await response.json()).toEqual({
+			success: false,
+			error: 'Failed to deliver one or more daily props.',
+			posted: refs,
+			failures: [
+				{
+					guild_id: 'guild-1',
+					channel_id: 'channel-1',
+					outcome_uuids: ['550e8400-e29b-41d4-a716-446655440002'],
+					error: 'Discord unavailable',
+				},
+			],
+		})
 	})
 })

--- a/src/utils/api/routes/props/__tests__/props-validation.test.ts
+++ b/src/utils/api/routes/props/__tests__/props-validation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const logger = vi.hoisted(() => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+}))
+
+vi.mock('../../../../logging/WinstonLogger.js', () => ({ logger }))
+
+import { validateDailyPropsPayload } from '../../notifications/notification-utils.js'
+
+describe('daily props validation', () => {
+	it('returns an empty valid batch without treating it as malformed', () => {
+		expect(validateDailyPropsPayload({ props: [], guilds: [] })).toEqual({
+			props: [],
+			guilds: [],
+		})
+	})
+})

--- a/src/utils/api/routes/props/props-router.ts
+++ b/src/utils/api/routes/props/props-router.ts
@@ -1,16 +1,95 @@
 import Router from '@koa/router'
-import { PropsController } from '../../controllers/props.controller.js'
-import type { ReqBodyPropsEmbedsData } from './props-route.interface.js'
+import { logger } from '../../../logging/WinstonLogger.js'
+import { PropPostingHandler } from '../../../props/PropPostingHandler.js'
+import { validateDailyPropsPayload } from '../notifications/notification-utils.js'
 
 const PropsRouter = new Router()
-const propsController = new PropsController()
+const propPostingHandler = new PropPostingHandler()
+
+const supportedSports = new Set(['nba', 'nfl'])
 
 PropsRouter.post('/props/daily', async (ctx) => {
-	ctx.status = 200
-	ctx.body = { message: 'Received req to process props for embed generation' }
-	await propsController.processPropsForPredictionEmbeds(
-		ctx.request.body as ReqBodyPropsEmbedsData,
+	const validatedPayload = validateDailyPropsPayload(ctx.request.body || {})
+	if (!validatedPayload) {
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid props payload. Failed Zod validation.',
+		}
+		return
+	}
+
+	const unsupportedSport = validatedPayload.guilds.find(
+		(guild) => !supportedSports.has(guild.sport.toLowerCase()),
 	)
+	if (unsupportedSport) {
+		logger.warn({
+			method: 'PropsRouter',
+			event: 'push_payload_rejected',
+			schema: 'dailyPropsPayload',
+			issues: [
+				{
+					path: ['guilds', 'sport'],
+					message: `Unsupported sport: ${unsupportedSport.sport}`,
+				},
+			],
+		})
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid props payload. Unsupported sport.',
+		}
+		return
+	}
+
+	try {
+		const results = await Promise.all(
+			validatedPayload.guilds.map((guild) =>
+				propPostingHandler.postPropsToChannel(
+					guild.guild_id,
+					validatedPayload.props,
+					guild.sport.toLowerCase() as 'nba' | 'nfl',
+					guild.channel_id,
+				),
+			),
+		)
+		const failed = results.reduce(
+			(total, result) => total + result.failed,
+			0,
+		)
+		if (failed > 0) {
+			logger.error({
+				method: 'PropsRouter',
+				event: 'props_daily_delivery_failed',
+				failed,
+				results,
+			})
+			ctx.status = 500
+			ctx.body = {
+				success: false,
+				error: 'Failed to deliver one or more daily props.',
+				results,
+			}
+			return
+		}
+
+		ctx.status = 200
+		ctx.body = {
+			success: true,
+			results,
+		}
+	} catch (error) {
+		logger.error({
+			method: 'PropsRouter',
+			event: 'props_daily_processing_failed',
+			error: error instanceof Error ? error.message : String(error),
+		})
+		ctx.status = 500
+		ctx.body = {
+			success: false,
+			error: 'Failed to process daily props.',
+		}
+	}
 })
 
 PropsRouter.post('/props/stats/post-start', async (ctx) => {

--- a/src/utils/api/routes/props/props-router.ts
+++ b/src/utils/api/routes/props/props-router.ts
@@ -1,16 +1,40 @@
 import Router from '@koa/router'
 import { logger } from '../../../logging/WinstonLogger.js'
-import { PropPostingHandler } from '../../../props/PropPostingHandler.js'
+import {
+	deliveryEnvelopeSchema,
+	deliveryReceipts,
+} from '../notifications/delivery-contract.js'
+import { getNotificationDeliveryQueue } from '../notifications/delivery-queue.js'
 import { dailyPropsPayloadSchema } from '../shared-payload-schemas.js'
 
 const PropsRouter = new Router()
-const propPostingHandler = new PropPostingHandler()
 
 const supportedSports = new Set(['nba', 'nfl'])
 
 PropsRouter.post('/props/daily', async (ctx) => {
+	const envelope = deliveryEnvelopeSchema.safeParse(ctx.request.body ?? {})
+	if (!envelope.success || envelope.data.kind !== 'prop_post') {
+		logger.warn({
+			method: 'PropsRouter',
+			event: 'push_payload_rejected',
+			schema: 'deliveryEnvelope.prop_post',
+			issues: envelope.success
+				? [{ message: 'Expected prop_post delivery envelope' }]
+				: envelope.error.issues,
+		})
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Invalid prop-post delivery envelope. Failed Zod validation.',
+			issues: envelope.success
+				? [{ message: 'Expected prop_post delivery envelope' }]
+				: envelope.error.issues,
+		}
+		return
+	}
+
 	const parsedPayload = dailyPropsPayloadSchema.safeParse(
-		ctx.request.body ?? {},
+		envelope.data.payload,
 	)
 
 	if (!parsedPayload.success) {
@@ -23,8 +47,19 @@ PropsRouter.post('/props/daily', async (ctx) => {
 		ctx.status = 422
 		ctx.body = {
 			success: false,
-			error: 'Invalid props payload. Failed Zod validation.',
+			error: 'Invalid prop-post delivery envelope. Failed Zod validation.',
 			issues: parsedPayload.error.issues,
+		}
+		return
+	}
+	if (
+		parsedPayload.data.props.length === 0 ||
+		parsedPayload.data.guilds.length === 0
+	) {
+		ctx.status = 422
+		ctx.body = {
+			success: false,
+			error: 'Prop-post delivery must include at least one prop and guild.',
 		}
 		return
 	}
@@ -53,55 +88,42 @@ PropsRouter.post('/props/daily', async (ctx) => {
 	}
 
 	try {
-		const postingResults = await Promise.all(
-			parsedPayload.data.guilds.map((guild) =>
-				propPostingHandler.postPropsToChannel(
-					guild.guild_id,
-					parsedPayload.data.props,
-					guild.sport.toLowerCase() as 'nba' | 'nfl',
-					guild.channel_id,
-				),
-			),
-		)
-		const references = postingResults.flatMap((result) => result.results)
-		const failures = postingResults.flatMap((result) => result.failures)
-		const failed = postingResults.reduce(
-			(total, result) => total + result.failed,
-			0,
-		)
-
-		if (failed > 0) {
-			logger.error({
-				method: 'PropsRouter',
-				event: 'props_daily_delivery_failed',
-				posted_count: references.length,
-				failed_count: failed,
-				failures,
-				results: postingResults,
-			})
-			ctx.set('X-Props-Failed', String(failed))
-			ctx.status = 500
+		const { record, duplicate } =
+			await getNotificationDeliveryQueue().acceptDetailed(envelope.data)
+		ctx.status = 202
+		ctx.body = {
+			accepted: true,
+			duplicate,
+			delivery_id: record.delivery_id,
+			kind: record.kind,
+			status: record.state,
+			...(record.kind === 'prop_post'
+				? { receipts: deliveryReceipts(record) }
+				: {}),
+		}
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			(error as Error & { code?: string }).code ===
+				'DELIVERY_PAYLOAD_MISMATCH'
+		) {
+			ctx.status = 409
 			ctx.body = {
 				success: false,
-				error: 'Failed to deliver one or more daily props.',
-				posted: references,
-				failures,
+				code: 'DELIVERY_PAYLOAD_MISMATCH',
+				error: 'delivery_id is already used for another payload',
 			}
 			return
 		}
-
-		ctx.status = 200
-		ctx.body = references
-	} catch (error) {
 		logger.error({
 			method: 'PropsRouter',
-			event: 'props_daily_processing_failed',
+			event: 'props_daily_queue_failed',
 			error: error instanceof Error ? error.message : String(error),
 		})
-		ctx.status = 500
+		ctx.status = 503
 		ctx.body = {
 			success: false,
-			error: 'Failed to process daily props.',
+			error: 'Prop-post delivery queue unavailable.',
 		}
 	}
 })

--- a/src/utils/api/routes/props/props-router.ts
+++ b/src/utils/api/routes/props/props-router.ts
@@ -1,7 +1,7 @@
 import Router from '@koa/router'
 import { logger } from '../../../logging/WinstonLogger.js'
 import { PropPostingHandler } from '../../../props/PropPostingHandler.js'
-import { validateDailyPropsPayload } from '../notifications/notification-utils.js'
+import { dailyPropsPayloadSchema } from '../shared-payload-schemas.js'
 
 const PropsRouter = new Router()
 const propPostingHandler = new PropPostingHandler()
@@ -9,17 +9,27 @@ const propPostingHandler = new PropPostingHandler()
 const supportedSports = new Set(['nba', 'nfl'])
 
 PropsRouter.post('/props/daily', async (ctx) => {
-	const validatedPayload = validateDailyPropsPayload(ctx.request.body || {})
-	if (!validatedPayload) {
+	const parsedPayload = dailyPropsPayloadSchema.safeParse(
+		ctx.request.body ?? {},
+	)
+
+	if (!parsedPayload.success) {
+		logger.warn({
+			method: 'PropsRouter',
+			event: 'push_payload_rejected',
+			schema: 'dailyPropsPayload',
+			issues: parsedPayload.error.issues,
+		})
 		ctx.status = 422
 		ctx.body = {
 			success: false,
 			error: 'Invalid props payload. Failed Zod validation.',
+			issues: parsedPayload.error.issues,
 		}
 		return
 	}
 
-	const unsupportedSport = validatedPayload.guilds.find(
+	const unsupportedSport = parsedPayload.data.guilds.find(
 		(guild) => !supportedSports.has(guild.sport.toLowerCase()),
 	)
 	if (unsupportedSport) {
@@ -43,41 +53,45 @@ PropsRouter.post('/props/daily', async (ctx) => {
 	}
 
 	try {
-		const results = await Promise.all(
-			validatedPayload.guilds.map((guild) =>
+		const postingResults = await Promise.all(
+			parsedPayload.data.guilds.map((guild) =>
 				propPostingHandler.postPropsToChannel(
 					guild.guild_id,
-					validatedPayload.props,
+					parsedPayload.data.props,
 					guild.sport.toLowerCase() as 'nba' | 'nfl',
 					guild.channel_id,
 				),
 			),
 		)
-		const failed = results.reduce(
+		const references = postingResults.flatMap((result) => result.results)
+		const failures = postingResults.flatMap((result) => result.failures)
+		const failed = postingResults.reduce(
 			(total, result) => total + result.failed,
 			0,
 		)
+
 		if (failed > 0) {
 			logger.error({
 				method: 'PropsRouter',
 				event: 'props_daily_delivery_failed',
-				failed,
-				results,
+				posted_count: references.length,
+				failed_count: failed,
+				failures,
+				results: postingResults,
 			})
+			ctx.set('X-Props-Failed', String(failed))
 			ctx.status = 500
 			ctx.body = {
 				success: false,
 				error: 'Failed to deliver one or more daily props.',
-				results,
+				posted: references,
+				failures,
 			}
 			return
 		}
 
 		ctx.status = 200
-		ctx.body = {
-			success: true,
-			results,
-		}
+		ctx.body = references
 	} catch (error) {
 		logger.error({
 			method: 'PropsRouter',

--- a/src/utils/api/routes/shared-payload-schemas.ts
+++ b/src/utils/api/routes/shared-payload-schemas.ts
@@ -80,31 +80,86 @@ const fallbackDailyPropsPayloadSchema = z.object({
 	),
 })
 
+const fallbackPropSettledNotificationSchema = z.object({
+	outcome_uuid: z.string().uuid(),
+	result: z.enum(['won', 'lost', 'push', 'void']),
+	winning_side_display: z.string().optional(),
+	actual_value: z.number().finite().nullable().optional(),
+	market_key: z.string().min(1),
+	description: z.string().min(1),
+	point: z.number().finite().nullable().optional(),
+	tallies: z.object({
+		correct: z.number().int().nonnegative(),
+		incorrect: z.number().int().nonnegative(),
+		total: z.number().int().nonnegative(),
+	}),
+	messages: z
+		.array(
+			z.object({
+				guild_id: z.string().min(1),
+				channel_id: z.string().min(1),
+				message_id: z.string().min(1),
+			}),
+		)
+		.min(1),
+})
+
 export type NotificationBetResults = z.infer<
 	typeof fallbackNotificationBetResultsSchema
 >
 export type DailyPropsPayload = z.infer<typeof fallbackDailyPropsPayloadSchema>
+export type PropSettledNotification = z.infer<
+	typeof fallbackPropSettledNotificationSchema
+>
 
 type SharedPayloadExports = {
-	betNotificationWonSchema?: unknown
 	notificationBetResultsSchema?: z.ZodType<NotificationBetResults>
 	dailyPropsPayloadSchema?: z.ZodType<DailyPropsPayload>
+	propSettledNotificationSchema?: z.ZodType<PropSettledNotification>
 }
 
 const sharedPayloadExports = KhronosTypes as unknown as SharedPayloadExports
 
-/**
- * Use the published shared schemas when available. The fallback is a strict
- * compatibility bridge for deployments whose package bump precedes TF-939's
- * schema release; it can be removed once all supported versions export the
- * new contracts.
- */
-export const notificationBetResultsSchema =
-	(sharedPayloadExports.betNotificationWonSchema
-		? sharedPayloadExports.notificationBetResultsSchema
-		: fallbackNotificationBetResultsSchema) ??
-	fallbackNotificationBetResultsSchema
+const legacyNotificationBetResultsProbe: NotificationBetResults = {
+	winners: [],
+	losers: [],
+	pushes: [{ userid: 'probe', amount: 1, betid: 1, team: 'probe-team' }],
+}
 
-export const dailyPropsPayloadSchema =
-	sharedPayloadExports.dailyPropsPayloadSchema ??
-	fallbackDailyPropsPayloadSchema
+function isUsableSchema<T>(
+	schema: z.ZodType<T> | undefined,
+): schema is z.ZodType<T> {
+	return schema !== undefined && schema._def?.type !== 'never'
+}
+
+function supportsLegacyNotificationPushes(
+	schema: z.ZodType<NotificationBetResults> | undefined,
+): schema is z.ZodType<NotificationBetResults> {
+	return (
+		isUsableSchema(schema) &&
+		schema.safeParse(legacyNotificationBetResultsProbe).success
+	)
+}
+
+/**
+ * Consume the published Khronos contracts when available while keeping strict
+ * compatibility bridges for deployments that have not yet received the schema
+ * releases backing these payloads.
+ */
+export const notificationBetResultsSchema = supportsLegacyNotificationPushes(
+	sharedPayloadExports.notificationBetResultsSchema,
+)
+	? sharedPayloadExports.notificationBetResultsSchema
+	: fallbackNotificationBetResultsSchema
+
+export const dailyPropsPayloadSchema = isUsableSchema(
+	sharedPayloadExports.dailyPropsPayloadSchema,
+)
+	? sharedPayloadExports.dailyPropsPayloadSchema
+	: fallbackDailyPropsPayloadSchema
+
+export const propSettledNotificationSchema = isUsableSchema(
+	sharedPayloadExports.propSettledNotificationSchema,
+)
+	? sharedPayloadExports.propSettledNotificationSchema
+	: fallbackPropSettledNotificationSchema

--- a/src/utils/api/routes/shared-payload-schemas.ts
+++ b/src/utils/api/routes/shared-payload-schemas.ts
@@ -4,6 +4,9 @@ import { z } from 'zod'
 const notificationEntryBaseSchema = z.object({
 	userId: z.string().min(1),
 	betId: z.number().int().nonnegative(),
+	/** Optional until Khronos includes guild context on bet-result callbacks. */
+	guildId: z.string().min(1).optional(),
+	guild_id: z.string().min(1).optional(),
 })
 
 const legacyPushSchema = z.object({

--- a/src/utils/api/routes/shared-payload-schemas.ts
+++ b/src/utils/api/routes/shared-payload-schemas.ts
@@ -1,0 +1,110 @@
+import * as KhronosTypes from '@pluto-khronos/types'
+import { z } from 'zod'
+
+const notificationEntryBaseSchema = z.object({
+	userId: z.string().min(1),
+	betId: z.number().int().nonnegative(),
+})
+
+const legacyPushSchema = z.object({
+	userid: z.string().min(1),
+	amount: z.number().nonnegative(),
+	betid: z.number().int().nonnegative(),
+	team: z.string().min(1),
+})
+
+const typedPushSchema = notificationEntryBaseSchema.extend({
+	result: z.object({
+		team: z.string().min(1),
+		betAmount: z.number().nonnegative(),
+		refunded: z.number().finite().nonnegative(),
+	}),
+})
+
+const fallbackNotificationBetResultsSchema = z.object({
+	winners: z
+		.array(
+			notificationEntryBaseSchema.extend({
+				result: z.object({
+					team: z.string().min(1),
+					betAmount: z.number().nonnegative(),
+					payout: z.number().finite().nonnegative(),
+					profit: z.number().finite(),
+					newBalance: z.number().finite().optional(),
+					oldBalance: z.number().finite().optional(),
+				}),
+			}),
+		)
+		.nullable(),
+	losers: z
+		.array(
+			notificationEntryBaseSchema.extend({
+				result: z.object({
+					team: z.string().min(1),
+					betAmount: z.number().nonnegative(),
+				}),
+			}),
+		)
+		.nullable(),
+	pushes: z.array(z.union([typedPushSchema, legacyPushSchema])).optional(),
+})
+
+const dailyPropOutcomeSchema = z.object({
+	outcome_uuid: z.string().uuid(),
+	outcome_name: z.string().min(1),
+	price: z.number().int(),
+})
+
+const fallbackDailyPropsPayloadSchema = z.object({
+	props: z.array(
+		z.object({
+			event_id: z.string().min(1),
+			commence_time: z.string().min(1),
+			home_team: z.string().min(1),
+			away_team: z.string().min(1),
+			sport_title: z.string().min(1),
+			market_key: z.string().min(1),
+			bookmaker_key: z.string().min(1),
+			description: z.string().min(1),
+			point: z.number(),
+			over: dailyPropOutcomeSchema,
+			under: dailyPropOutcomeSchema,
+		}),
+	),
+	guilds: z.array(
+		z.object({
+			guild_id: z.string().min(1),
+			channel_id: z.string().min(1),
+			sport: z.string().min(1),
+		}),
+	),
+})
+
+export type NotificationBetResults = z.infer<
+	typeof fallbackNotificationBetResultsSchema
+>
+export type DailyPropsPayload = z.infer<typeof fallbackDailyPropsPayloadSchema>
+
+type SharedPayloadExports = {
+	betNotificationWonSchema?: unknown
+	notificationBetResultsSchema?: z.ZodType<NotificationBetResults>
+	dailyPropsPayloadSchema?: z.ZodType<DailyPropsPayload>
+}
+
+const sharedPayloadExports = KhronosTypes as unknown as SharedPayloadExports
+
+/**
+ * Use the published shared schemas when available. The fallback is a strict
+ * compatibility bridge for deployments whose package bump precedes TF-939's
+ * schema release; it can be removed once all supported versions export the
+ * new contracts.
+ */
+export const notificationBetResultsSchema =
+	(sharedPayloadExports.betNotificationWonSchema
+		? sharedPayloadExports.notificationBetResultsSchema
+		: fallbackNotificationBetResultsSchema) ??
+	fallbackNotificationBetResultsSchema
+
+export const dailyPropsPayloadSchema =
+	sharedPayloadExports.dailyPropsPayloadSchema ??
+	fallbackDailyPropsPayloadSchema

--- a/src/utils/betting/american-odds.ts
+++ b/src/utils/betting/american-odds.ts
@@ -1,0 +1,43 @@
+/**
+ * American odds helpers used while the parlay builder is running locally.
+ *
+ * Khronos remains the source of truth at init/place time. Keeping the
+ * conversion here only lets the card show a useful running estimate before
+ * the server snapshots the leg prices.
+ */
+export function americanToDecimal(american: number): number {
+	if (!Number.isFinite(american) || american === 0) {
+		throw new Error('American odds must be a non-zero finite number')
+	}
+
+	return american > 0 ? 1 + american / 100 : 1 + 100 / Math.abs(american)
+}
+
+export function decimalToAmerican(decimal: number): number {
+	if (!Number.isFinite(decimal) || decimal <= 1) {
+		throw new Error('Decimal odds must be greater than 1')
+	}
+
+	return decimal >= 2
+		? Math.round((decimal - 1) * 100)
+		: Math.round(-100 / (decimal - 1))
+}
+
+export function combineAmericanOdds(legs: number[]): {
+	american: number
+	decimal: number
+} {
+	if (legs.length === 0) {
+		throw new Error('At least one odds leg is required')
+	}
+
+	const decimal = legs.reduce(
+		(combined, leg) => combined * americanToDecimal(leg),
+		1,
+	)
+
+	return {
+		american: decimalToAmerican(decimal),
+		decimal,
+	}
+}

--- a/src/utils/cache/__tests__/cache-manager.test.ts
+++ b/src/utils/cache/__tests__/cache-manager.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const evalRedis = vi.fn()
+
+vi.mock('../redis-instance.js', () => ({
+	default: { eval: evalRedis },
+}))
+
+const { CacheManager } = await import('../cache-manager.js')
+
+describe('CacheManager lock ownership', () => {
+	it('compares the serialized token written by setIfAbsent', async () => {
+		evalRedis.mockResolvedValueOnce(1)
+		const cache = new CacheManager()
+
+		await expect(
+			cache.compareAndRemove('lock-key', 'owner-token'),
+		).resolves.toBe(true)
+		expect(evalRedis).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('get', KEYS[1])"),
+			1,
+			'lock-key',
+			JSON.stringify('owner-token'),
+		)
+	})
+
+	it('refreshes a reservation only while the serialized owner token matches', async () => {
+		evalRedis.mockResolvedValueOnce(1)
+		const cache = new CacheManager()
+
+		await expect(
+			cache.refreshIfOwned('placement-key', 'owner-token', 120),
+		).resolves.toBe(true)
+		expect(evalRedis).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('expire', KEYS[1], ARGV[2])"),
+			1,
+			'placement-key',
+			JSON.stringify('owner-token'),
+			120,
+		)
+	})
+})

--- a/src/utils/cache/__tests__/cache-manager.test.ts
+++ b/src/utils/cache/__tests__/cache-manager.test.ts
@@ -1,42 +1,62 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const evalRedis = vi.fn()
+const atomicRedis = {
+	compareAndRemove: vi.fn(),
+	refreshIfOwned: vi.fn(),
+	transitionIfValue: vi.fn(),
+}
 
 vi.mock('../redis-instance.js', () => ({
-	default: { eval: evalRedis },
+	default: atomicRedis,
 }))
 
 const { CacheManager } = await import('../cache-manager.js')
 
 describe('CacheManager lock ownership', () => {
 	it('compares the serialized token written by setIfAbsent', async () => {
-		evalRedis.mockResolvedValueOnce(1)
+		atomicRedis.compareAndRemove.mockResolvedValueOnce(true)
 		const cache = new CacheManager()
 
 		await expect(
 			cache.compareAndRemove('lock-key', 'owner-token'),
 		).resolves.toBe(true)
-		expect(evalRedis).toHaveBeenCalledWith(
-			expect.stringContaining("redis.call('get', KEYS[1])"),
-			1,
+		expect(atomicRedis.compareAndRemove).toHaveBeenCalledWith(
 			'lock-key',
 			JSON.stringify('owner-token'),
 		)
 	})
 
 	it('refreshes a reservation only while the serialized owner token matches', async () => {
-		evalRedis.mockResolvedValueOnce(1)
+		atomicRedis.refreshIfOwned.mockResolvedValueOnce(true)
 		const cache = new CacheManager()
 
 		await expect(
 			cache.refreshIfOwned('placement-key', 'owner-token', 120),
 		).resolves.toBe(true)
-		expect(evalRedis).toHaveBeenCalledWith(
-			expect.stringContaining("redis.call('expire', KEYS[1], ARGV[2])"),
-			1,
+		expect(atomicRedis.refreshIfOwned).toHaveBeenCalledWith(
 			'placement-key',
 			JSON.stringify('owner-token'),
 			120,
+		)
+	})
+
+	it('transitions serialized values through the typed atomic port', async () => {
+		atomicRedis.transitionIfValue.mockResolvedValueOnce(true)
+		const cache = new CacheManager()
+
+		await expect(
+			cache.transitionIfValue(
+				'delivery-key',
+				{ status: 'pending' },
+				{ status: 'processing' },
+				60,
+			),
+		).resolves.toBe(true)
+		expect(atomicRedis.transitionIfValue).toHaveBeenCalledWith(
+			'delivery-key',
+			JSON.stringify({ status: 'pending' }),
+			JSON.stringify({ status: 'processing' }),
+			60,
 		)
 	})
 })

--- a/src/utils/cache/__tests__/redis-atomic-contract.ts
+++ b/src/utils/cache/__tests__/redis-atomic-contract.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AtomicCacheOperations } from '../redis-instance.js'
+
+export interface AtomicContractClient extends AtomicCacheOperations {
+	set(
+		key: string,
+		value: string,
+		...args: Array<string | number>
+	): Promise<unknown>
+	get(key: string): Promise<string | null>
+	del(...keys: string[]): Promise<unknown>
+	ttl(key: string): Promise<number>
+}
+
+export function runAtomicCacheContract(
+	name: string,
+	getClient: () => AtomicContractClient,
+	namespace: string,
+): void {
+	describe(name, () => {
+		const keys = ['lock', 'lease', 'delivery'].map(
+			(key) => `${namespace}:${key}`,
+		)
+		const [lockKey, leaseKey, deliveryKey] = keys as [
+			string,
+			string,
+			string,
+		]
+
+		beforeEach(async () => {
+			await getClient().del(...keys)
+		})
+
+		afterEach(async () => {
+			await getClient().del(...keys)
+		})
+
+		it('removes a value only for its current owner', async () => {
+			const client = getClient()
+			await client.set(lockKey, 'owner-a')
+
+			await expect(
+				client.compareAndRemove(lockKey, 'owner-b'),
+			).resolves.toBe(false)
+			await expect(client.get(lockKey)).resolves.toBe('owner-a')
+			await expect(
+				client.compareAndRemove(lockKey, 'owner-a'),
+			).resolves.toBe(true)
+			await expect(client.get(lockKey)).resolves.toBeNull()
+		})
+
+		it('refreshes and replaces expiry only for the current owner', async () => {
+			const client = getClient()
+			await client.set(leaseKey, 'owner-a', 'EX', 2)
+
+			await expect(
+				client.refreshIfOwned(leaseKey, 'owner-b', 30),
+			).resolves.toBe(false)
+			const unchangedTtl = await client.ttl(leaseKey)
+			expect(unchangedTtl).toBeGreaterThan(0)
+			expect(unchangedTtl).toBeLessThanOrEqual(2)
+			await expect(
+				client.refreshIfOwned(leaseKey, 'owner-a', 30),
+			).resolves.toBe(true)
+			await expect(client.ttl(leaseKey)).resolves.toBeGreaterThan(20)
+		})
+
+		it('transitions values while preserving or explicitly replacing TTL', async () => {
+			const client = getClient()
+			await client.set(deliveryKey, 'pending', 'EX', 20)
+			const originalTtl = await client.ttl(deliveryKey)
+
+			await expect(
+				client.transitionIfValue(
+					deliveryKey,
+					'processing',
+					'delivered',
+				),
+			).resolves.toBe(false)
+			await expect(
+				client.transitionIfValue(deliveryKey, 'pending', 'processing'),
+			).resolves.toBe(true)
+			const preservedTtl = await client.ttl(deliveryKey)
+			expect(preservedTtl).toBeGreaterThan(0)
+			expect(preservedTtl).toBeLessThanOrEqual(originalTtl)
+			await expect(
+				client.transitionIfValue(
+					deliveryKey,
+					'processing',
+					'delivered',
+					30,
+				),
+			).resolves.toBe(true)
+			await expect(client.ttl(deliveryKey)).resolves.toBeGreaterThan(20)
+			await expect(client.get(deliveryKey)).resolves.toBe('delivered')
+		})
+	})
+}

--- a/src/utils/cache/__tests__/redis-atomic.integration.test.ts
+++ b/src/utils/cache/__tests__/redis-atomic.integration.test.ts
@@ -1,0 +1,43 @@
+import Redis, { type Redis as RedisClient } from 'ioredis'
+import { afterAll, beforeAll, describe, vi } from 'vitest'
+import type { RedisCacheClient } from '../redis-instance.js'
+import { runAtomicCacheContract } from './redis-atomic-contract.js'
+
+vi.mock('../../../lib/startup/env.js', () => ({
+	default: { USE_MOCK_DATA: true },
+}))
+
+vi.mock('../../logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const { createAtomicRedisClient } = await import('../redis-instance.js')
+const RedisConstructor = Redis as unknown as {
+	new (url: string): RedisClient
+}
+
+const redisUrl = process.env.PLUTO_TEST_REDIS_URL
+if (process.env.PLUTO_REQUIRE_REDIS_TESTS === '1' && !redisUrl) {
+	throw new Error(
+		'PLUTO_TEST_REDIS_URL is required when PLUTO_REQUIRE_REDIS_TESTS=1.',
+	)
+}
+const describeWithRedis = redisUrl ? describe : describe.skip
+
+describeWithRedis('real Redis atomic adapter', () => {
+	let redis: RedisCacheClient
+
+	beforeAll(() => {
+		redis = createAtomicRedisClient(new RedisConstructor(redisUrl!))
+	})
+
+	afterAll(async () => {
+		await redis.quit()
+	})
+
+	runAtomicCacheContract(
+		'shared behavior',
+		() => redis,
+		`pluto:test:atomic:${process.pid}:${Date.now()}`,
+	)
+})

--- a/src/utils/cache/__tests__/redis-instance.test.ts
+++ b/src/utils/cache/__tests__/redis-instance.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runAtomicCacheContract } from './redis-atomic-contract.js'
+
+vi.mock('../../../lib/startup/env.js', () => ({
+	default: { USE_MOCK_DATA: true },
+}))
+
+vi.mock('../../logging/WinstonLogger.js', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const { InMemoryRedis } = await import('../redis-instance.js')
+
+let now = 0
+let redis: InstanceType<typeof InMemoryRedis>
+
+beforeEach(() => {
+	now = 0
+	redis = new InMemoryRedis(() => now)
+})
+
+runAtomicCacheContract(
+	'InMemoryRedis atomic contract',
+	() => redis,
+	'pluto:test:atomic:memory',
+)
+
+describe('InMemoryRedis expiry parity', () => {
+	it('expires EX values at the exact boundary for get and exists', async () => {
+		await redis.set('builder', 'value', 'EX', 15)
+
+		now = 14_999
+		await expect(redis.get('builder')).resolves.toBe('value')
+		await expect(redis.exists('builder')).resolves.toBe(1)
+		now = 15_000
+		await expect(redis.get('builder')).resolves.toBeNull()
+		await expect(redis.exists('builder')).resolves.toBe(0)
+	})
+
+	it('allows NX after expiration but not before it', async () => {
+		await expect(redis.set('lock', 'owner-a', 'EX', 5, 'NX')).resolves.toBe(
+			'OK',
+		)
+		await expect(
+			redis.set('lock', 'owner-b', 'EX', 5, 'NX'),
+		).resolves.toBeNull()
+
+		now = 5_000
+		await expect(redis.set('lock', 'owner-b', 'EX', 5, 'NX')).resolves.toBe(
+			'OK',
+		)
+	})
+
+	it('implements setex and expire with the injected clock', async () => {
+		await redis.setex('one', 10, 'value')
+		now = 4_000
+		await expect(redis.expire('one', 2)).resolves.toBe(1)
+		now = 5_999
+		await expect(redis.get('one')).resolves.toBe('value')
+		now = 6_000
+		await expect(redis.get('one')).resolves.toBeNull()
+		await expect(redis.expire('missing', 2)).resolves.toBe(0)
+	})
+
+	it('reports Redis-compatible TTL states and boundaries', async () => {
+		await expect(redis.ttl('missing')).resolves.toBe(-2)
+		await redis.set('persistent', 'value')
+		await expect(redis.ttl('persistent')).resolves.toBe(-1)
+		await redis.set('expiring', 'value', 'EX', 15)
+		await expect(redis.ttl('expiring')).resolves.toBe(15)
+
+		now = 14_001
+		await expect(redis.ttl('expiring')).resolves.toBe(1)
+		now = 14_501
+		await expect(redis.ttl('expiring')).resolves.toBe(0)
+		now = 15_000
+		await expect(redis.ttl('expiring')).resolves.toBe(-2)
+	})
+
+	it('rejects fractional expiry arguments', async () => {
+		await expect(
+			redis.set('fractional', 'value', 'EX', 1.5),
+		).rejects.toThrow('positive integer')
+		await redis.set('existing', 'value')
+		await expect(redis.expire('existing', 1.5)).rejects.toThrow('integer')
+		await expect(redis.expire('missing', 1.5)).rejects.toThrow('integer')
+	})
+
+	it('fails visibly when raw Lua bypasses the typed operation port', async () => {
+		await expect(redis.eval('return 1', 0)).rejects.toThrow(
+			'Raw Redis eval is unsupported',
+		)
+	})
+})

--- a/src/utils/cache/cache-manager.ts
+++ b/src/utils/cache/cache-manager.ts
@@ -23,6 +23,21 @@ export class CacheManager {
 		return true
 	}
 
+	/** Atomically claims a key when it is absent, with a bounded TTL. */
+	async setIfAbsent(key: string, data: unknown, TTL?: number) {
+		if (!key) {
+			throw new Error('No key was provided to save into cache')
+		}
+		const result = await this.cache.set(
+			key,
+			JSON.stringify(data),
+			'EX',
+			TTL || 1800,
+			'NX',
+		)
+		return result === 'OK'
+	}
+
 	async get(key: string) {
 		if (!key) {
 			throw new Error('No key was provided to save into cache')

--- a/src/utils/cache/cache-manager.ts
+++ b/src/utils/cache/cache-manager.ts
@@ -1,12 +1,12 @@
 import { format } from 'date-fns'
-import type { ChainableCommander, Redis } from 'ioredis'
-import redisCache from './redis-instance.js'
+import type { ChainableCommander } from 'ioredis'
+import redisCache, { type RedisCacheClient } from './redis-instance.js'
 
 export class CacheManager {
-	cache: Redis
+	cache: RedisCacheClient
 
-	constructor() {
-		this.cache = redisCache
+	constructor(cache: RedisCacheClient = redisCache) {
+		this.cache = cache
 	}
 
 	async set(key: string, data: unknown, TTL?: number) {
@@ -40,13 +40,7 @@ export class CacheManager {
 
 	/** Remove a lock only when it is still owned by the caller. */
 	async compareAndRemove(key: string, value: string): Promise<boolean> {
-		const result = await this.cache.eval(
-			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end`,
-			1,
-			key,
-			JSON.stringify(value),
-		)
-		return result === 1
+		return this.cache.compareAndRemove(key, JSON.stringify(value))
 	}
 
 	/** Extend a lock or reservation only while the caller still owns it. */
@@ -55,14 +49,21 @@ export class CacheManager {
 		value: string,
 		seconds: number,
 	): Promise<boolean> {
-		const result = await this.cache.eval(
-			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end`,
-			1,
+		return this.cache.refreshIfOwned(key, JSON.stringify(value), seconds)
+	}
+
+	async transitionIfValue(
+		key: string,
+		expectedValue: unknown,
+		nextValue: unknown,
+		seconds?: number,
+	): Promise<boolean> {
+		return this.cache.transitionIfValue(
 			key,
-			JSON.stringify(value),
+			JSON.stringify(expectedValue),
+			JSON.stringify(nextValue),
 			seconds,
 		)
-		return result === 1
 	}
 
 	async get(key: string) {

--- a/src/utils/cache/cache-manager.ts
+++ b/src/utils/cache/cache-manager.ts
@@ -38,6 +38,33 @@ export class CacheManager {
 		return result === 'OK'
 	}
 
+	/** Remove a lock only when it is still owned by the caller. */
+	async compareAndRemove(key: string, value: string): Promise<boolean> {
+		const result = await this.cache.eval(
+			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end`,
+			1,
+			key,
+			JSON.stringify(value),
+		)
+		return result === 1
+	}
+
+	/** Extend a lock or reservation only while the caller still owns it. */
+	async refreshIfOwned(
+		key: string,
+		value: string,
+		seconds: number,
+	): Promise<boolean> {
+		const result = await this.cache.eval(
+			`if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end`,
+			1,
+			key,
+			JSON.stringify(value),
+			seconds,
+		)
+		return result === 1
+	}
+
 	async get(key: string) {
 		if (!key) {
 			throw new Error('No key was provided to save into cache')

--- a/src/utils/cache/redis-instance.ts
+++ b/src/utils/cache/redis-instance.ts
@@ -57,6 +57,12 @@ class InMemoryRedis {
 		return next
 	}
 
+	async decr(key: string) {
+		const next = Number(this.values.get(key) ?? 0) - 1
+		this.values.set(key, String(next))
+		return next
+	}
+
 	async expire(_key: string, _seconds: number) {
 		// Stub for testing: always returns 1, does not actually expire keys
 		return 1

--- a/src/utils/cache/redis-instance.ts
+++ b/src/utils/cache/redis-instance.ts
@@ -11,7 +11,13 @@ class InMemoryRedis {
 	private readonly hashes = new Map<string, Map<string, string>>()
 	private readonly sets = new Map<string, Set<string>>()
 
-	async set(key: string, value: string, ..._rest: unknown[]) {
+	async set(key: string, value: string, ...rest: unknown[]) {
+		if (
+			rest.includes('NX') &&
+			(this.values.has(key) || this.hashes.has(key) || this.sets.has(key))
+		) {
+			return null
+		}
 		this.values.set(key, value)
 		return 'OK'
 	}

--- a/src/utils/cache/redis-instance.ts
+++ b/src/utils/cache/redis-instance.ts
@@ -1,79 +1,256 @@
-import { default as Redis, type Redis as RedisClient } from 'ioredis' // Issue from https://github.com/redis/ioredis/issues/1624
+import {
+	type ChainableCommander,
+	default as Redis,
+	type Redis as RedisClient,
+	type RedisOptions,
+} from 'ioredis' // Issue from https://github.com/redis/ioredis/issues/1624
 import env from '../../lib/startup/env.js'
 import { logger } from '../logging/WinstonLogger.js'
 
 const { R_HOST, R_PORT, R_PASS, R_DB } = process.env
 
-// InMemoryRedis is a mock Redis client for testing. Note: expire() is a stub
-// that always returns 1 and does not enforce TTL on keys.
-class InMemoryRedis {
+const RedisConstructor = Redis as unknown as {
+	new (options: RedisOptions): RedisClient
+}
+
+export interface AtomicCacheOperations {
+	compareAndRemove(key: string, expectedValue: string): Promise<boolean>
+	refreshIfOwned(
+		key: string,
+		expectedValue: string,
+		seconds: number,
+	): Promise<boolean>
+	transitionIfValue(
+		key: string,
+		expectedValue: string,
+		nextValue: string,
+		seconds?: number,
+	): Promise<boolean>
+}
+
+export interface RedisCacheClient extends AtomicCacheOperations {
+	set(
+		key: string,
+		value: string,
+		...args: Array<string | number>
+	): Promise<'OK' | null>
+	get(key: string): Promise<string | null>
+	del(...keys: string[]): Promise<number>
+	flushall(): Promise<'OK'>
+	exists(key: string): Promise<number>
+	incr(key: string): Promise<number>
+	decr(key: string): Promise<number>
+	expire(key: string, seconds: number): Promise<number>
+	setex(key: string, seconds: number, value: string): Promise<'OK'>
+	ttl(key: string): Promise<number>
+	hset(key: string, field: string, value: string): Promise<number>
+	hgetall(key: string): Promise<Record<string, string>>
+	sadd(key: string, ...members: string[]): Promise<number>
+	smembers(key: string): Promise<string[]>
+	pipeline(): ChainableCommander
+	on(event: 'error', listener: (error: Error) => void): RedisCacheClient
+	quit(): Promise<string>
+}
+
+const COMPARE_AND_REMOVE_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('del', KEYS[1])
+end
+return 0`
+
+const REFRESH_IF_OWNED_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('expire', KEYS[1], ARGV[2])
+end
+return 0`
+
+const TRANSITION_IF_VALUE_SCRIPT = `
+if redis.call('get', KEYS[1]) ~= ARGV[1] then
+  return 0
+end
+if ARGV[3] == '' then
+  redis.call('set', KEYS[1], ARGV[2], 'KEEPTTL')
+else
+  redis.call('set', KEYS[1], ARGV[2], 'EX', ARGV[3])
+end
+return 1`
+
+const requirePositiveSeconds = (seconds: number): void => {
+	if (!Number.isSafeInteger(seconds) || seconds <= 0) {
+		throw new RangeError('Redis expiry must be a positive integer.')
+	}
+}
+
+export function createAtomicRedisClient(client: RedisClient): RedisCacheClient {
+	return Object.assign(client, {
+		async compareAndRemove(key: string, expectedValue: string) {
+			const result = await client.eval(
+				COMPARE_AND_REMOVE_SCRIPT,
+				1,
+				key,
+				expectedValue,
+			)
+			return Number(result) === 1
+		},
+		async refreshIfOwned(
+			key: string,
+			expectedValue: string,
+			seconds: number,
+		) {
+			requirePositiveSeconds(seconds)
+			const result = await client.eval(
+				REFRESH_IF_OWNED_SCRIPT,
+				1,
+				key,
+				expectedValue,
+				seconds,
+			)
+			return Number(result) === 1
+		},
+		async transitionIfValue(
+			key: string,
+			expectedValue: string,
+			nextValue: string,
+			seconds?: number,
+		) {
+			if (seconds !== undefined) requirePositiveSeconds(seconds)
+			const result = await client.eval(
+				TRANSITION_IF_VALUE_SCRIPT,
+				1,
+				key,
+				expectedValue,
+				nextValue,
+				seconds ?? '',
+			)
+			return Number(result) === 1
+		},
+	}) as unknown as RedisCacheClient
+}
+
+type Clock = () => number
+
+export class InMemoryRedis implements RedisCacheClient {
 	private readonly values = new Map<string, string>()
 	private readonly hashes = new Map<string, Map<string, string>>()
 	private readonly sets = new Map<string, Set<string>>()
+	private readonly expiresAt = new Map<string, number>()
 
-	async set(key: string, value: string, ...rest: unknown[]) {
-		if (
-			rest.includes('NX') &&
-			(this.values.has(key) || this.hashes.has(key) || this.sets.has(key))
-		) {
-			return null
+	constructor(private readonly now: Clock = Date.now) {}
+
+	async set(
+		key: string,
+		value: string,
+		...rest: Array<string | number>
+	): Promise<'OK' | null> {
+		let ttlMs: number | undefined
+		let onlyIfAbsent = false
+		let keepTtl = false
+		for (let index = 0; index < rest.length; index++) {
+			const option = String(rest[index]).toUpperCase()
+			if (option === 'NX') {
+				onlyIfAbsent = true
+				continue
+			}
+			if (option === 'KEEPTTL') {
+				keepTtl = true
+				continue
+			}
+			if (option === 'EX' || option === 'PX') {
+				const amount = Number(rest[++index])
+				if (!Number.isSafeInteger(amount) || amount <= 0) {
+					throw new RangeError(
+						'Redis expiry must be a positive integer.',
+					)
+				}
+				ttlMs = option === 'EX' ? amount * 1000 : amount
+				continue
+			}
+			throw new Error(`Unsupported in-memory Redis SET option: ${option}`)
 		}
+		this.purgeExpired(key)
+		if (onlyIfAbsent && this.hasKey(key)) return null
+		const previousExpiry = this.expiresAt.get(key)
+		this.hashes.delete(key)
+		this.sets.delete(key)
 		this.values.set(key, value)
+		if (ttlMs !== undefined) {
+			this.expiresAt.set(key, this.now() + ttlMs)
+		} else if (keepTtl && previousExpiry !== undefined) {
+			this.expiresAt.set(key, previousExpiry)
+		} else {
+			this.expiresAt.delete(key)
+		}
 		return 'OK'
 	}
 
 	async get(key: string) {
+		this.purgeExpired(key)
 		return this.values.get(key) ?? null
 	}
 
 	async del(...keys: string[]) {
 		let deleted = 0
 		for (const key of keys) {
-			if (this.values.delete(key)) deleted++
-			if (this.hashes.delete(key)) deleted++
-			if (this.sets.delete(key)) deleted++
+			this.purgeExpired(key)
+			if (this.removeKey(key)) deleted++
 		}
 		return deleted
 	}
 
-	async flushall() {
+	async flushall(): Promise<'OK'> {
 		this.values.clear()
 		this.hashes.clear()
 		this.sets.clear()
+		this.expiresAt.clear()
 		return 'OK'
 	}
 
 	async exists(key: string) {
-		return this.values.has(key) ||
-			this.hashes.has(key) ||
-			this.sets.has(key)
-			? 1
-			: 0
+		return this.hasKey(key) ? 1 : 0
 	}
 
 	async incr(key: string) {
+		this.purgeExpired(key)
 		const next = Number(this.values.get(key) ?? 0) + 1
 		this.values.set(key, String(next))
 		return next
 	}
 
 	async decr(key: string) {
+		this.purgeExpired(key)
 		const next = Number(this.values.get(key) ?? 0) - 1
 		this.values.set(key, String(next))
 		return next
 	}
 
-	async expire(_key: string, _seconds: number) {
-		// Stub for testing: always returns 1, does not actually expire keys
+	async expire(key: string, seconds: number) {
+		if (!Number.isSafeInteger(seconds)) {
+			throw new RangeError('Redis expiry must be an integer.')
+		}
+		if (!this.hasKey(key)) return 0
+		if (seconds <= 0) {
+			this.removeKey(key)
+			return 1
+		}
+		this.expiresAt.set(key, this.now() + seconds * 1000)
 		return 1
 	}
 
-	async setex(key: string, _seconds: number, value: string) {
-		this.values.set(key, value)
+	async setex(key: string, seconds: number, value: string): Promise<'OK'> {
+		await this.set(key, value, 'EX', seconds)
 		return 'OK'
 	}
 
+	async ttl(key: string): Promise<number> {
+		this.purgeExpired(key)
+		if (!this.hasKey(key)) return -2
+		const expiresAt = this.expiresAt.get(key)
+		if (expiresAt === undefined) return -1
+		return Math.round((expiresAt - this.now()) / 1000)
+	}
+
 	async hset(key: string, field: string, value: string) {
+		this.purgeExpired(key)
 		const hash = this.hashes.get(key) ?? new Map<string, string>()
 		const isNew = hash.has(field) ? 0 : 1
 		hash.set(field, value)
@@ -82,10 +259,12 @@ class InMemoryRedis {
 	}
 
 	async hgetall(key: string) {
+		this.purgeExpired(key)
 		return Object.fromEntries(this.hashes.get(key) ?? [])
 	}
 
 	async sadd(key: string, ...members: string[]) {
+		this.purgeExpired(key)
 		const set = this.sets.get(key) ?? new Set<string>()
 		let added = 0
 		for (const member of members) {
@@ -97,10 +276,55 @@ class InMemoryRedis {
 	}
 
 	async smembers(key: string) {
+		this.purgeExpired(key)
 		return [...(this.sets.get(key) ?? [])]
 	}
 
-	pipeline() {
+	async compareAndRemove(
+		key: string,
+		expectedValue: string,
+	): Promise<boolean> {
+		this.purgeExpired(key)
+		if (this.values.get(key) !== expectedValue) return false
+		this.removeKey(key)
+		return true
+	}
+
+	async refreshIfOwned(
+		key: string,
+		expectedValue: string,
+		seconds: number,
+	): Promise<boolean> {
+		requirePositiveSeconds(seconds)
+		this.purgeExpired(key)
+		if (this.values.get(key) !== expectedValue) return false
+		this.expiresAt.set(key, this.now() + seconds * 1000)
+		return true
+	}
+
+	async transitionIfValue(
+		key: string,
+		expectedValue: string,
+		nextValue: string,
+		seconds?: number,
+	): Promise<boolean> {
+		if (seconds !== undefined) requirePositiveSeconds(seconds)
+		this.purgeExpired(key)
+		if (this.values.get(key) !== expectedValue) return false
+		this.values.set(key, nextValue)
+		if (seconds !== undefined) {
+			this.expiresAt.set(key, this.now() + seconds * 1000)
+		}
+		return true
+	}
+
+	async eval(..._args: unknown[]): Promise<never> {
+		throw new Error(
+			'Raw Redis eval is unsupported in mock mode; use typed atomic operations.',
+		)
+	}
+
+	pipeline(): ChainableCommander {
 		const commands: Array<() => Promise<unknown>> = []
 		const pipeline = {
 			set: (key: string, value: string) => {
@@ -131,27 +355,60 @@ class InMemoryRedis {
 					}),
 				),
 		}
-		return pipeline
+		return pipeline as unknown as ChainableCommander
+	}
+
+	on(_event: 'error', _listener: (error: Error) => void): RedisCacheClient {
+		return this
+	}
+
+	async quit(): Promise<string> {
+		return 'OK'
+	}
+
+	private hasKey(key: string): boolean {
+		this.purgeExpired(key)
+		return (
+			this.values.has(key) || this.hashes.has(key) || this.sets.has(key)
+		)
+	}
+
+	private purgeExpired(key: string): void {
+		const expiresAt = this.expiresAt.get(key)
+		if (expiresAt !== undefined && expiresAt <= this.now()) {
+			this.removeKey(key)
+		}
+	}
+
+	private removeKey(key: string): boolean {
+		const existed =
+			this.values.has(key) || this.hashes.has(key) || this.sets.has(key)
+		this.values.delete(key)
+		this.hashes.delete(key)
+		this.sets.delete(key)
+		this.expiresAt.delete(key)
+		return existed
 	}
 }
 
-const redisCache = env.USE_MOCK_DATA
-	? (new InMemoryRedis() as unknown as RedisClient)
-	: // @ts-ignore - ioredis default export is constructable at runtime.
-		new Redis({
-			host: R_HOST,
-			port: Number(R_PORT),
-			password: R_PASS,
-			connectTimeout: 10000,
-			retryStrategy: (times) => {
-				const MAX_RETRY_ATTEMPTS = 3
-				if (times >= MAX_RETRY_ATTEMPTS) {
-					throw new Error('Max retry attempts reached')
-				}
-				return Math.min(2 ** times * 1000, 60000)
-			},
-			db: Number(R_DB),
-		})
+const redisCache: RedisCacheClient = env.USE_MOCK_DATA
+	? new InMemoryRedis()
+	: createAtomicRedisClient(
+			new RedisConstructor({
+				host: R_HOST,
+				port: Number(R_PORT),
+				password: R_PASS,
+				connectTimeout: 10000,
+				retryStrategy: (times) => {
+					const MAX_RETRY_ATTEMPTS = 3
+					if (times >= MAX_RETRY_ATTEMPTS) {
+						throw new Error('Max retry attempts reached')
+					}
+					return Math.min(2 ** times * 1000, 60000)
+				},
+				db: Number(R_DB),
+			}),
+		)
 
 if (env.USE_MOCK_DATA) {
 	logger.info({

--- a/src/utils/commands/prediction-deprecation.ts
+++ b/src/utils/commands/prediction-deprecation.ts
@@ -1,0 +1,25 @@
+import { type ChatInputCommandInteraction, EmbedBuilder } from 'discord.js'
+import embedColors from '../../lib/colorsConfig.js'
+
+/**
+ * Keep legacy prediction commands discoverable while the consolidated command
+ * rolls out. The aliases can be removed after one release cycle.
+ */
+export async function sendPredictionCommandDeprecation(
+	interaction: ChatInputCommandInteraction,
+	replacement: string,
+) {
+	await interaction.deferReply({ ephemeral: true })
+
+	const embed = new EmbedBuilder()
+		.setColor(embedColors.info)
+		.setTitle('Prediction command moved')
+		.setDescription(
+			`This command is kept for one release as an alias. Use **${replacement}** instead.`,
+		)
+		.setFooter({
+			text: 'Legacy aliases will be removed after the migration window.',
+		})
+
+	return interaction.editReply({ embeds: [embed] })
+}

--- a/src/utils/cron/RecapCronScheduler.ts
+++ b/src/utils/cron/RecapCronScheduler.ts
@@ -1,0 +1,208 @@
+import { logger } from '../logging/WinstonLogger.js'
+import type { RecapCronService } from './RecapCronService.js'
+
+const POLL_INTERVAL_MS = 30_000
+
+/**
+ * Minimal UTC cron matcher for the five-field expression used by RECAP_CRON.
+ * Supports literals, comma lists, ranges, and wildcard step values.
+ */
+export function matchesCronExpression(expression: string, date: Date): boolean {
+	const fields = expression.trim().split(/\s+/)
+	if (fields.length !== 5) return false
+
+	const [minute, hour, dayOfMonth, month, dayOfWeek] = fields
+	return (
+		matchesCronField(minute, date.getUTCMinutes(), 0, 59) &&
+		matchesCronField(hour, date.getUTCHours(), 0, 23) &&
+		matchesCronField(dayOfMonth, date.getUTCDate(), 1, 31) &&
+		matchesCronField(month, date.getUTCMonth() + 1, 1, 12) &&
+		matchesCronField(dayOfWeek, date.getUTCDay(), 0, 6)
+	)
+}
+
+export function isValidCronExpression(expression: string): boolean {
+	const fields = expression.trim().split(/\s+/)
+	if (fields.length !== 5) return false
+	return fields.every((field, index) =>
+		isValidCronField(
+			field,
+			index === 0
+				? 0
+				: index === 1
+					? 0
+					: index === 2
+						? 1
+						: index === 3
+							? 1
+							: 0,
+			index === 0
+				? 59
+				: index === 1
+					? 23
+					: index === 2
+						? 31
+						: index === 3
+							? 12
+							: 6,
+		),
+	)
+}
+
+function isValidCronField(
+	field: string,
+	minimum: number,
+	maximum: number,
+): boolean {
+	return field.split(',').every((part) => {
+		const [rangePart, stepPart] = part.split('/')
+		const step = stepPart ? Number.parseInt(stepPart, 10) : 1
+		if (
+			!Number.isInteger(step) ||
+			step < 1 ||
+			(stepPart && !/^\d+$/.test(stepPart))
+		)
+			return false
+		if (rangePart === '*') return true
+		const [startText, endText] = rangePart.includes('-')
+			? rangePart.split('-')
+			: [rangePart, rangePart]
+		const start = Number.parseInt(startText, 10)
+		const end = Number.parseInt(endText, 10)
+		return (
+			Number.isInteger(start) &&
+			Number.isInteger(end) &&
+			start >= minimum &&
+			end <= maximum &&
+			start <= end
+		)
+	})
+}
+
+function matchesCronField(
+	field: string,
+	value: number,
+	minimum: number,
+	maximum: number,
+): boolean {
+	return field.split(',').some((part) => {
+		const [rangePart, stepPart] = part.split('/')
+		const step = stepPart ? Number.parseInt(stepPart, 10) : 1
+		if (!Number.isInteger(step) || step < 1) return false
+
+		const range = rangePart === '*' ? `${minimum}-${maximum}` : rangePart
+		const [startText, endText] = range.includes('-')
+			? range.split('-')
+			: [range, range]
+		const start = Number.parseInt(startText, 10)
+		const end = Number.parseInt(endText, 10)
+		if (
+			!Number.isInteger(start) ||
+			!Number.isInteger(end) ||
+			start < minimum ||
+			end > maximum ||
+			start > end
+		) {
+			return false
+		}
+
+		return value >= start && value <= end && (value - start) % step === 0
+	})
+}
+
+/**
+ * Polls the configured UTC cron expression and runs one recap per matching
+ * minute. In-memory minute tracking handles the duplicate ticks caused by the
+ * 30-second poll interval; Redis deduplication handles process restarts.
+ */
+export class RecapCronScheduler {
+	private interval: NodeJS.Timeout | null = null
+	private lastRunMinute: string | null = null
+	private readonly validExpression: boolean
+
+	constructor(
+		private readonly recapService: Pick<RecapCronService, 'runWeeklyRecap'>,
+		private readonly expression: string,
+		private readonly pollIntervalMs = POLL_INTERVAL_MS,
+	) {
+		this.validExpression = isValidCronExpression(expression)
+		if (!this.validExpression) {
+			logger.error({
+				message: 'Weekly recap scheduler disabled: invalid RECAP_CRON',
+				metadata: { expression },
+			})
+		}
+	}
+
+	start(): void {
+		if (this.interval || !this.validExpression) return
+		this.tick(new Date(), true).catch((error) => {
+			logger.error({
+				message: 'Weekly recap scheduler startup tick failed',
+				metadata: {
+					error:
+						error instanceof Error ? error.message : String(error),
+				},
+			})
+		})
+		this.interval = setInterval(() => {
+			this.tick().catch((error) => {
+				logger.error({
+					message: 'Weekly recap scheduler tick failed',
+					metadata: {
+						error:
+							error instanceof Error
+								? error.message
+								: String(error),
+					},
+				})
+			})
+		}, this.pollIntervalMs)
+	}
+
+	async tick(now = new Date(), allowCatchUp = false): Promise<boolean> {
+		if (!this.validExpression) return false
+		if (
+			!matchesCronExpression(this.expression, now) &&
+			!(allowCatchUp && isCronDueToday(this.expression, now))
+		) {
+			return false
+		}
+		const minuteKey = now.toISOString().slice(0, 16)
+		if (this.lastRunMinute === minuteKey) return false
+
+		this.lastRunMinute = minuteKey
+		await this.recapService.runWeeklyRecap(now, allowCatchUp)
+		return true
+	}
+
+	stop(): void {
+		if (!this.interval) return
+		clearInterval(this.interval)
+		this.interval = null
+	}
+
+	getStatus(): boolean {
+		return this.interval !== null
+	}
+}
+
+/**
+ * Treat a bot restart later on the scheduled UTC day as a missed-run catch-up.
+ * This keeps the default Monday digest reliable without posting on other days.
+ */
+function isCronDueToday(expression: string, now: Date): boolean {
+	const minute = now.getUTCMinutes()
+	const hour = now.getUTCHours()
+	for (let candidate = 0; candidate <= hour * 60 + minute; candidate++) {
+		const candidateDate = new Date(now)
+		candidateDate.setUTCHours(
+			Math.floor(candidate / 60),
+			candidate % 60,
+			0,
+			0,
+		)
+		if (matchesCronExpression(expression, candidateDate)) return true
+	}
+	return false
+}

--- a/src/utils/cron/RecapCronService.ts
+++ b/src/utils/cron/RecapCronService.ts
@@ -1,0 +1,282 @@
+import { container } from '@sapphire/framework'
+import { getISOWeek, getISOWeekYear } from 'date-fns'
+import { ChannelType, type TextChannel } from 'discord.js'
+import type RecapWrapper from '../api/Khronos/recap/recap-wrapper.js'
+import type { WeeklyRecapResponse } from '../api/Khronos/recap/recap-wrapper.js'
+import type { CacheManager } from '../cache/cache-manager.js'
+import { buildWeeklyRecapEmbeds } from '../embeds/weekly-recap.embed.js'
+import { logger } from '../logging/WinstonLogger.js'
+
+const RECAP_DEDUP_TTL_SECONDS = 8 * 24 * 60 * 60
+const RECAP_CLAIM_TTL_SECONDS = 5 * 60
+
+export interface RecapChannelResolver {
+	getBettingChannel(guildId: string): Promise<TextChannel>
+}
+
+export interface RecapCronOptions {
+	guildIds: string[]
+	enabled?: boolean
+	channelId?: string
+	weekOffset?: number
+}
+
+interface RecapCache {
+	get(key: string): Promise<unknown>
+	set(key: string, value: unknown, ttl?: number): Promise<unknown>
+	setIfAbsent?(key: string, value: unknown, ttl?: number): Promise<boolean>
+	del?(key: string): Promise<unknown>
+}
+
+export interface RecapRunResult {
+	posted: number
+	skipped: number
+	failed: number
+}
+
+function resolveWeekIdentity(
+	data: WeeklyRecapResponse,
+	now: Date,
+): { seasonYear: number; weekNumber: number } {
+	const startDate = new Date(data.window.start_date)
+	const fallbackDate = Number.isNaN(startDate.valueOf()) ? now : startDate
+	return {
+		seasonYear: data.window.season_year ?? getISOWeekYear(fallbackDate),
+		weekNumber: data.window.week_number ?? getISOWeek(fallbackDate),
+	}
+}
+
+function dedupKey(
+	guildId: string,
+	data: WeeklyRecapResponse,
+	now: Date,
+): string {
+	const { seasonYear, weekNumber } = resolveWeekIdentity(data, now)
+	return `recap:posted:${guildId}:${seasonYear}:${weekNumber}`
+}
+
+/**
+ * Pulls a weekly recap from Khronos and delivers one digest per configured
+ * guild. The service owns idempotency and failure isolation; the scheduler
+ * only decides when this method runs.
+ */
+export class RecapCronService {
+	private readonly recapApi: Pick<RecapWrapper, 'getWeeklyRecap'>
+	private readonly cache: RecapCache
+	private readonly channelResolver: RecapChannelResolver
+	private readonly options: Required<
+		Pick<RecapCronOptions, 'guildIds' | 'enabled' | 'weekOffset'>
+	> &
+		Pick<RecapCronOptions, 'channelId'>
+
+	constructor(
+		recapApi: Pick<RecapWrapper, 'getWeeklyRecap'>,
+		cache: Pick<CacheManager, 'get' | 'set'>,
+		channelResolver: RecapChannelResolver,
+		options: RecapCronOptions,
+	) {
+		this.recapApi = recapApi
+		this.cache = cache
+		this.channelResolver = channelResolver
+		this.options = {
+			guildIds: options.guildIds.filter(Boolean),
+			enabled: options.enabled ?? true,
+			channelId: options.channelId,
+			weekOffset: options.weekOffset ?? -1,
+		}
+	}
+
+	async runWeeklyRecap(
+		now = new Date(),
+		allowProcessingReclaim = false,
+	): Promise<RecapRunResult> {
+		const result: RecapRunResult = { posted: 0, skipped: 0, failed: 0 }
+
+		if (!this.options.enabled) {
+			await logger.info({
+				message: 'weekly_recap_skipped',
+				metadata: { reason: 'disabled' },
+			})
+			return result
+		}
+
+		for (const guildId of this.options.guildIds) {
+			try {
+				const recap = await this.recapApi.getWeeklyRecap(
+					guildId,
+					this.options.weekOffset,
+				)
+				const key = dedupKey(guildId, recap, now)
+
+				const claimed = await this.claimDelivery(
+					key,
+					allowProcessingReclaim,
+				)
+				if (!claimed) {
+					result.skipped++
+					await logger.info({
+						message: 'weekly_recap_skipped',
+						metadata: { reason: 'dedup', guild_id: guildId, key },
+					})
+					continue
+				}
+
+				let channel: TextChannel
+				try {
+					channel = await this.getRecapChannel(guildId)
+					await channel.send({
+						embeds: buildWeeklyRecapEmbeds(recap),
+					})
+				} catch (error) {
+					await this.releaseDeliveryClaim(key)
+					throw error
+				}
+				try {
+					await this.cache.set(key, true, RECAP_DEDUP_TTL_SECONDS)
+				} catch (error) {
+					await logger.warn({
+						message: 'weekly_recap_dedup_persist_failed',
+						metadata: {
+							guild_id: guildId,
+							key,
+							error:
+								error instanceof Error
+									? error.message
+									: String(error),
+						},
+					})
+					try {
+						// Keep a durable sent marker lease when the first marker write
+						// fails. This closes the post-send crash/retry window without
+						// ever treating a failed Discord send as delivered.
+						await this.cache.set(
+							key,
+							{ status: 'sent' },
+							RECAP_DEDUP_TTL_SECONDS,
+						)
+					} catch (fallbackError) {
+						await logger.error({
+							message: 'weekly_recap_dedup_fallback_failed',
+							metadata: {
+								guild_id: guildId,
+								key,
+								error:
+									fallbackError instanceof Error
+										? fallbackError.message
+										: String(fallbackError),
+							},
+						})
+					}
+				}
+				result.posted++
+
+				await logger.info({
+					message: 'weekly_recap_posted',
+					metadata: {
+						guild_id: guildId,
+						week_number: recap.window.week_number,
+						channel_id: channel.id,
+					},
+				})
+			} catch (error) {
+				result.failed++
+				await logger.error({
+					message: 'weekly_recap_skipped',
+					metadata: {
+						reason: 'error',
+						guild_id: guildId,
+						status: this.getErrorStatus(error),
+						error:
+							error instanceof Error
+								? error.message
+								: String(error),
+					},
+				})
+			}
+		}
+
+		return result
+	}
+
+	private async getRecapChannel(guildId: string): Promise<TextChannel> {
+		if (!this.options.channelId) {
+			return await this.channelResolver.getBettingChannel(guildId)
+		}
+
+		const channel = await container.client.channels.fetch(
+			this.options.channelId,
+		)
+		if (!channel || channel.type !== ChannelType.GuildText) {
+			throw new Error(
+				`Recap channel ${this.options.channelId} is missing or not a text channel`,
+			)
+		}
+		if (channel.guild.id !== guildId) {
+			await logger.warn({
+				message: 'weekly_recap_channel_override_mismatch',
+				metadata: {
+					guild_id: guildId,
+					channel_id: this.options.channelId,
+					channel_guild_id: channel.guild.id,
+				},
+			})
+			return await this.channelResolver.getBettingChannel(guildId)
+		}
+		return channel
+	}
+
+	private async claimDelivery(
+		key: string,
+		allowProcessingReclaim: boolean,
+	): Promise<boolean> {
+		if (allowProcessingReclaim) {
+			const existing = await this.cache.get(key)
+			const isProcessing =
+				typeof existing === 'object' &&
+				existing !== null &&
+				(existing as { status?: unknown }).status === 'processing'
+			if (isProcessing) {
+				if (!this.cache.del) return false
+				await this.cache.del(key)
+			}
+		}
+
+		if (this.cache.setIfAbsent) {
+			return await this.cache.setIfAbsent(
+				key,
+				{ status: 'processing' },
+				RECAP_CLAIM_TTL_SECONDS,
+			)
+		}
+		if (await this.cache.get(key)) return false
+		await this.cache.set(
+			key,
+			{ status: 'processing' },
+			RECAP_CLAIM_TTL_SECONDS,
+		)
+		return true
+	}
+
+	private async releaseDeliveryClaim(key: string): Promise<void> {
+		try {
+			if (this.cache.del) await this.cache.del(key)
+		} catch (error) {
+			await logger.warn({
+				message: 'weekly_recap_claim_release_failed',
+				metadata: {
+					key,
+					error:
+						error instanceof Error ? error.message : String(error),
+				},
+			})
+		}
+	}
+
+	private getErrorStatus(error: unknown): number | undefined {
+		if (!error || typeof error !== 'object') return undefined
+		const response = (error as { response?: { status?: unknown } }).response
+		return typeof response?.status === 'number'
+			? response.status
+			: undefined
+	}
+}

--- a/src/utils/cron/__tests__/RecapCronScheduler.test.ts
+++ b/src/utils/cron/__tests__/RecapCronScheduler.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../logging/WinstonLogger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+import {
+	matchesCronExpression,
+	RecapCronScheduler,
+} from '../RecapCronScheduler.js'
+
+describe('matchesCronExpression', () => {
+	it('matches the Monday 09:00 UTC default', () => {
+		expect(
+			matchesCronExpression(
+				'0 9 * * 1',
+				new Date('2026-07-13T09:00:00.000Z'),
+			),
+		).toBe(true)
+		expect(
+			matchesCronExpression(
+				'0 9 * * 1',
+				new Date('2026-07-13T09:01:00.000Z'),
+			),
+		).toBe(false)
+	})
+})
+
+describe('RecapCronScheduler', () => {
+	it('runs once for a matching minute despite duplicate polls', async () => {
+		const runWeeklyRecap = vi.fn(async () => ({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		}))
+		const scheduler = new RecapCronScheduler(
+			{ runWeeklyRecap },
+			'0 9 * * 1',
+		)
+		const now = new Date('2026-07-13T09:00:15.000Z')
+
+		expect(await scheduler.tick(now)).toBe(true)
+		expect(await scheduler.tick(new Date('2026-07-13T09:00:45.000Z'))).toBe(
+			false,
+		)
+		expect(runWeeklyRecap).toHaveBeenCalledTimes(1)
+	})
+
+	it('catches up when the bot starts after the scheduled minute', async () => {
+		const runWeeklyRecap = vi.fn(async () => ({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		}))
+		const scheduler = new RecapCronScheduler(
+			{ runWeeklyRecap },
+			'0 9 * * 1',
+		)
+
+		expect(
+			await scheduler.tick(new Date('2026-07-13T10:15:00.000Z'), true),
+		).toBe(true)
+		expect(runWeeklyRecap).toHaveBeenCalledTimes(1)
+		expect(runWeeklyRecap).toHaveBeenCalledWith(
+			new Date('2026-07-13T10:15:00.000Z'),
+			true,
+		)
+	})
+})

--- a/src/utils/cron/__tests__/RecapCronService.test.ts
+++ b/src/utils/cron/__tests__/RecapCronService.test.ts
@@ -1,0 +1,179 @@
+import type { TextChannel } from 'discord.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../logging/WinstonLogger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}))
+
+import type { WeeklyRecapResponse } from '../../api/Khronos/recap/recap-wrapper.js'
+import { RecapCronService } from '../RecapCronService.js'
+
+const recap: WeeklyRecapResponse = {
+	window: {
+		start_date: '2026-07-06T00:00:00.000Z',
+		end_date: '2026-07-12T23:59:59.999Z',
+		week_number: 19,
+		season_year: 2026,
+	},
+	total_predictions: 1,
+	correct_predictions: 1,
+	incorrect_predictions: 0,
+	accuracy: 100,
+	accuracy_delta: 10,
+	top_predictors: [],
+	biggest_single_win: null,
+	biggest_parlay_win: null,
+}
+
+function makeHarness() {
+	const values = new Map<string, unknown>()
+	const cache = {
+		get: vi.fn(async (key: string) => values.get(key) ?? false),
+		set: vi.fn(async (key: string, value: unknown) => {
+			values.set(key, value)
+			return true
+		}),
+		del: vi.fn(async (key: string) => {
+			values.delete(key)
+			return 1
+		}),
+	}
+	const channel = {
+		id: 'recap-channel',
+		send: vi.fn(async () => ({ id: 'message-1' })),
+	} as unknown as TextChannel
+	const channelResolver = {
+		getBettingChannel: vi.fn(async () => channel),
+	}
+	const recapApi = {
+		getWeeklyRecap: vi.fn(async () => recap),
+	}
+
+	return { cache, channel, channelResolver, recapApi }
+}
+
+describe('RecapCronService', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('posts once and skips the same guild/week after a restart', async () => {
+		const harness = makeHarness()
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1'] },
+		)
+
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		})
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 0,
+			skipped: 1,
+			failed: 0,
+		})
+		expect(harness.channel.send).toHaveBeenCalledTimes(1)
+		expect(harness.cache.set).toHaveBeenCalledWith(
+			'recap:posted:guild-1:2026:19',
+			true,
+			691200,
+		)
+	})
+
+	it('isolates Khronos or Discord failures per guild', async () => {
+		const harness = makeHarness()
+		harness.recapApi.getWeeklyRecap
+			.mockRejectedValueOnce(new Error('Khronos 503'))
+			.mockResolvedValueOnce(recap)
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1', 'guild-2'] },
+		)
+
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 1,
+			skipped: 0,
+			failed: 1,
+		})
+		expect(harness.channel.send).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not call Khronos when disabled', async () => {
+		const harness = makeHarness()
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1'], enabled: false },
+		)
+
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 0,
+			skipped: 0,
+			failed: 0,
+		})
+		expect(harness.recapApi.getWeeklyRecap).not.toHaveBeenCalled()
+	})
+
+	it('retains a sent marker lease when the first dedup write fails', async () => {
+		const harness = makeHarness()
+		harness.cache.set
+			.mockResolvedValueOnce(true)
+			.mockRejectedValueOnce(new Error('Redis write failed'))
+			.mockResolvedValueOnce(true)
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1'] },
+		)
+
+		expect(await service.runWeeklyRecap()).toEqual({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		})
+		expect(harness.cache.set).toHaveBeenLastCalledWith(
+			'recap:posted:guild-1:2026:19',
+			{ status: 'sent' },
+			691200,
+		)
+	})
+
+	it('reclaims a processing marker during startup catch-up', async () => {
+		const harness = makeHarness()
+		await harness.cache.set('recap:posted:guild-1:2026:19', {
+			status: 'processing',
+		})
+		const service = new RecapCronService(
+			harness.recapApi,
+			harness.cache,
+			harness.channelResolver,
+			{ guildIds: ['guild-1'] },
+		)
+
+		expect(
+			await service.runWeeklyRecap(
+				new Date('2026-07-13T10:15:00.000Z'),
+				true,
+			),
+		).toEqual({
+			posted: 1,
+			skipped: 0,
+			failed: 0,
+		})
+		expect(harness.cache.del).toHaveBeenCalledWith(
+			'recap:posted:guild-1:2026:19',
+		)
+		expect(harness.channel.send).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/utils/cron/index.ts
+++ b/src/utils/cron/index.ts
@@ -2,14 +2,19 @@
 // Cron Job Initialization - Export and initialize cron services
 // ============================================================================
 
+import env from '../../lib/startup/env.js'
+import GuildWrapper from '../api/Khronos/guild/guild-wrapper.js'
 import PredictionApiWrapper from '../api/Khronos/prediction/predictionApiWrapper.js'
 import PropsApiWrapper from '../api/Khronos/props/props-api-wrapper.js'
+import RecapWrapper from '../api/Khronos/recap/recap-wrapper.js'
 import { Cache } from '../cache/cache-manager.js'
 import { logger } from '../logging/WinstonLogger.js'
 import { ActivePropsService } from '../props/ActivePropsService.js'
 import { PropsCacheService } from '../props/PropCacheService.js'
 import { PropsCronScheduler } from './PropsCronScheduler.js'
 import { PropsCronService } from './PropsCronService.js'
+import { RecapCronScheduler } from './RecapCronScheduler.js'
+import { RecapCronService } from './RecapCronService.js'
 
 /**
  * Initialize and start the props cron scheduler
@@ -68,12 +73,83 @@ export function setPropsCronScheduler(scheduler: PropsCronScheduler): void {
 	propsCronScheduler = scheduler
 }
 
+/**
+ * Initialize the weekly recap digest. Recap remains opt-out by default but
+ * only starts when at least one guild is configured and Khronos has shipped
+ * the generated RecapApi client.
+ */
+export async function initializeRecapCron(): Promise<RecapCronScheduler | null> {
+	const guildIds = (env.RECAP_GUILD_IDS || process.env.GUILD_ID || '')
+		.split(',')
+		.map((guildId) => guildId.trim())
+		.filter(Boolean)
+
+	if (
+		env.USE_MOCK_DATA ||
+		env.RECAP_ENABLED === false ||
+		guildIds.length === 0
+	) {
+		await logger.info({
+			message: 'weekly_recap_skipped',
+			metadata: {
+				reason: env.USE_MOCK_DATA
+					? 'mock_data'
+					: env.RECAP_ENABLED === false
+						? 'disabled'
+						: 'no_guilds_configured',
+			},
+		})
+		return null
+	}
+
+	try {
+		const service = new RecapCronService(
+			new RecapWrapper(),
+			Cache(),
+			new GuildWrapper(),
+			{
+				guildIds,
+				enabled: env.RECAP_ENABLED,
+				channelId: env.RECAP_CHANNEL_ID,
+				weekOffset: -1,
+			},
+		)
+		const scheduler = new RecapCronScheduler(service, env.RECAP_CRON)
+		scheduler.start()
+		await logger.info({
+			message: 'Weekly recap scheduler initialized and started',
+			metadata: {
+				guild_count: guildIds.length,
+				expression: env.RECAP_CRON,
+			},
+		})
+		return scheduler
+	} catch (error) {
+		await logger.error({
+			message: 'weekly_recap_skipped',
+			metadata: {
+				reason: 'client_unavailable',
+				error: error instanceof Error ? error.message : String(error),
+			},
+		})
+		return null
+	}
+}
+
+let recapCronScheduler: RecapCronScheduler | null = null
+
+export function getRecapCronScheduler(): RecapCronScheduler | null {
+	return recapCronScheduler
+}
+
 // Auto-initialize when module is imported (after cache is ready)
 // We use a slight delay to ensure all dependencies are loaded
 setTimeout(async () => {
 	try {
 		const scheduler = await initializePropsCron()
 		setPropsCronScheduler(scheduler)
+		const recapScheduler = await initializeRecapCron()
+		recapCronScheduler = recapScheduler
 	} catch (error) {
 		await logger.error({
 			message: 'Failed to initialize props cron scheduler',

--- a/src/utils/dev/__tests__/mock-backend-parlays.test.ts
+++ b/src/utils/dev/__tests__/mock-backend-parlays.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../lib/startup/env.js', () => ({
+	default: {
+		NODE_ENV: 'development',
+		MOCK_GUILD_SPORT: 'nba',
+		MOCK_GUILD_BETTING_CHAN_ID: '123456789012345678',
+		DEV_GUILD_GAMES_CATEGORY_ID: '123456789012345678',
+	},
+}))
+
+const { MockBackend } = await import('../mock-backend.js')
+
+describe('MockBackend parlay lifecycle', () => {
+	it('preserves spread and totals market metadata in mock parlays', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		const game = backend.seedGames('nba', 1).matches[0]
+		if (!game?.id) throw new Error('mock game did not have an id')
+
+		const preview = backend.initParlay({
+			legs: [
+				{
+					event_id: game.id,
+					outcome_uuid: `${game.id}-spread-home`,
+				},
+				{
+					event_id: game.id,
+					outcome_uuid: `${game.id}-total-over`,
+				},
+			],
+			stake: 10,
+			guild_id: 'guild-1',
+			user_id: 'user-1',
+		})
+
+		expect(preview.legs.map((leg) => leg.market_key)).toEqual([
+			'spreads',
+			'totals',
+		])
+		expect(backend.placeParlay(preview.init_token).legs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ market_key: 'spreads' }),
+				expect.objectContaining({ market_key: 'totals' }),
+			]),
+		)
+	})
+})

--- a/src/utils/dev/__tests__/mock-backend-parlays.test.ts
+++ b/src/utils/dev/__tests__/mock-backend-parlays.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { InitParlayRequest } from '../../api/Khronos/parlays/ParlayApiWrapper.js'
 
 vi.mock('../../../lib/startup/env.js', () => ({
 	default: {
@@ -12,11 +13,30 @@ vi.mock('../../../lib/startup/env.js', () => ({
 const { MockBackend } = await import('../mock-backend.js')
 
 describe('MockBackend parlay lifecycle', () => {
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	function request(overrides: Partial<InitParlayRequest> = {}) {
+		return {
+			legs: [
+				{ event_id: 'event-1', outcome_uuid: 'event-1-home' },
+				{ event_id: 'event-2', outcome_uuid: 'event-2-away' },
+			],
+			stake: 10,
+			guild_id: 'guild-1',
+			user_id: 'user-1',
+			...overrides,
+		}
+	}
+
 	it('preserves spread and totals market metadata in mock parlays', () => {
 		const backend = MockBackend.instance()
 		backend.reset()
-		const game = backend.seedGames('nba', 1).matches[0]
-		if (!game?.id) throw new Error('mock game did not have an id')
+		const games = backend.seedGames('nba', 2).matches
+		const game = games[0]
+		const secondGame = games[1]
+		if (!game?.id || !secondGame?.id) throw new Error('mock games missing')
 
 		const preview = backend.initParlay({
 			legs: [
@@ -25,8 +45,8 @@ describe('MockBackend parlay lifecycle', () => {
 					outcome_uuid: `${game.id}-spread-home`,
 				},
 				{
-					event_id: game.id,
-					outcome_uuid: `${game.id}-total-over`,
+					event_id: secondGame.id,
+					outcome_uuid: `${secondGame.id}-total-over`,
 				},
 			],
 			stake: 10,
@@ -45,4 +65,163 @@ describe('MockBackend parlay lifecycle', () => {
 			]),
 		)
 	})
+
+	it('rejects same-event legs, unsupported markets, and out-of-range requests', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+
+		expect(() =>
+			backend.initParlay(
+				request({
+					legs: [
+						{ event_id: 'event-1', outcome_uuid: 'event-1-home' },
+						{ event_id: 'event-1', outcome_uuid: 'event-1-away' },
+					],
+				}),
+			),
+		).toThrow('distinct events')
+		expect(() =>
+			backend.initParlay({
+				...request(),
+				legs: [
+					...request().legs,
+					{
+						event_id: 'event-3',
+						outcome_uuid: 'event-3-player-points',
+					},
+				],
+			}),
+		).toThrow('supported')
+		expect(() => backend.initParlay({ ...request(), legs: [] })).toThrow(
+			'between 2 and 6',
+		)
+		expect(() =>
+			backend.initParlay({
+				...request(),
+				legs: Array.from({ length: 7 }, (_, index) => ({
+					event_id: `event-${index + 1}`,
+					outcome_uuid: `event-${index + 1}-home`,
+				})),
+			}),
+		).toThrow('between 2 and 6')
+		expect(() => backend.initParlay({ ...request(), stake: 0 })).toThrow(
+			'between 1 and 10000',
+		)
+		expect(() =>
+			backend.initParlay({ ...request(), stake: 10_001 }),
+		).toThrow('between 1 and 10000')
+	})
+
+	it('uses a 15-minute one-time token and rejects it at the expiry boundary', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		const now = new Date('2026-07-15T12:00:00.000Z')
+		vi.useFakeTimers({ now })
+
+		const preview = backend.initParlay(request())
+		expect(preview.expires_at).toBe('2026-07-15T12:15:00.000Z')
+		vi.advanceTimersByTime(15 * 60 * 1000 - 1)
+		const placed = backend.placeParlay(preview.init_token)
+		expect(placed.status).toBe('pending')
+		vi.setSystemTime(now)
+		const expired = backend.initParlay(request({ user_id: 'user-2' }))
+		vi.advanceTimersByTime(15 * 60 * 1000)
+		expect(() => backend.placeParlay(expired.init_token)).toThrow('expired')
+	})
+
+	it('debits once for a token and does not debit on replay', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		backend.setBalance('user-1', 100)
+		const preview = backend.initParlay(request({ stake: 80 }))
+
+		backend.placeParlay(preview.init_token)
+		expect(backend.getAccountBalance('user-1').balance).toBe(20)
+		expect(() => backend.placeParlay(preview.init_token)).toThrow('expired')
+		expect(backend.getAccountBalance('user-1').balance).toBe(20)
+	})
+
+	it('refunds cancellation once and closes cancellation at first commence time', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		backend.setBalance('user-1', 100)
+		const preview = backend.initParlay(request({ stake: 25 }))
+		const placed = backend.placeParlay(preview.init_token)
+
+		const cancelled = backend.cancelParlay(placed.id, 'user-1')
+		expect(cancelled.status).toBe('cancelled')
+		expect(cancelled.actual_payout).toBe(25)
+		expect(backend.getAccountBalance('user-1').balance).toBe(100)
+		expect(() => backend.cancelParlay(placed.id, 'user-1')).toThrow(
+			'no longer cancellable',
+		)
+		expect(backend.getAccountBalance('user-1').balance).toBe(100)
+
+		const future = backend.placeParlay(
+			backend.initParlay(request()).init_token,
+		)
+		vi.setSystemTime(new Date(future.legs[0]?.commence_time ?? now()))
+		expect(() => backend.cancelParlay(future.id, 'user-1')).toThrow(
+			'cancellation window has closed',
+		)
+	})
+
+	it('settles terminal states, credits winnings, and notifies exactly once', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		backend.setBalance('user-1', 100)
+		const notifications: string[] = []
+		const unsubscribe = backend.onParlayTerminal((parlay) => {
+			notifications.push(`${parlay.id}:${parlay.status}`)
+		})
+		const preview = backend.initParlay(request({ stake: 10 }))
+		const placed = backend.placeParlay(preview.init_token)
+
+		const pending = backend.settleParlayLeg(
+			placed.id,
+			'event-1-home',
+			'won',
+		)
+		expect(pending.status).toBe('pending')
+		const settled = backend.settleParlayLeg(
+			placed.id,
+			'event-2-away',
+			'won',
+		)
+		expect(settled.status).toBe('won')
+		expect(settled.actual_payout).toBe(preview.potential_payout)
+		expect(backend.getAccountBalance('user-1').balance).toBe(
+			100 - 10 + preview.potential_payout,
+		)
+		expect(notifications).toEqual([`${placed.id}:won`])
+		expect(() =>
+			backend.settleParlayLeg(placed.id, 'event-2-away', 'lost'),
+		).toThrow('terminal')
+		unsubscribe()
+	})
+
+	it('refunds all-push/void parlays and rejects illegal leg transitions', () => {
+		const backend = MockBackend.instance()
+		backend.reset()
+		backend.setBalance('user-1', 100)
+		const preview = backend.initParlay(request({ stake: 10 }))
+		const placed = backend.placeParlay(preview.init_token)
+
+		backend.settleParlayLeg(placed.id, 'event-1-home', 'push')
+		const refunded = backend.settleParlayLeg(
+			placed.id,
+			'event-2-away',
+			'void',
+		)
+		expect(refunded.status).toBe('push_refunded')
+		expect(refunded.actual_payout).toBe(10)
+		expect(backend.getAccountBalance('user-1').balance).toBe(100)
+		expect(() =>
+			backend.settleParlayLeg(placed.id, 'event-1-home', 'won'),
+		).toThrow('terminal')
+	})
 })
+
+function now(): string {
+	return new Date().toISOString()
+}

--- a/src/utils/dev/mock-backend.ts
+++ b/src/utils/dev/mock-backend.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type {
 	Account,
 	CancelBetslipRequest,
@@ -26,6 +27,13 @@ import {
 import { DEV_IDS } from '../../lib/configs/constants.js'
 import env from '../../lib/startup/env.js'
 import { DiscordConfigEnums } from '../api/common/interfaces/kh-pluto/kh-pluto.interface.js'
+import type {
+	EventOutcome,
+	InitParlayRequest,
+	InitParlayResponse,
+	ParlayResponse,
+	UserParlaysResponse,
+} from '../api/Khronos/parlays/ParlayApiWrapper.js'
 import {
 	makeBetslipWithAggregation,
 	makePlacedBetslip,
@@ -42,6 +50,12 @@ export class MockBackend {
 		GetAllMatchesDto['matches']
 	>()
 	private nextBetId = 10_000
+	private nextParlayId = 20_000
+	private readonly pendingParlays = new Map<
+		string,
+		{ request: InitParlayRequest; preview: InitParlayResponse }
+	>()
+	private readonly parlays = new Map<string, ParlayResponse>()
 
 	private constructor() {
 		if (env.NODE_ENV === 'production') {
@@ -178,6 +192,187 @@ export class MockBackend {
 		return this.store.getBets(request.userid)
 	}
 
+	initParlay(request: InitParlayRequest): InitParlayResponse {
+		const legs = request.legs.map((leg) => {
+			const market_key = leg.outcome_uuid.includes('-spread-')
+				? ('spreads' as const)
+				: leg.outcome_uuid.includes('-total-')
+					? ('totals' as const)
+					: ('h2h' as const)
+			const isHome = leg.outcome_uuid.endsWith('-home')
+			const isOver = leg.outcome_uuid.endsWith('-over')
+			return {
+				event_id: leg.event_id,
+				outcome_uuid: leg.outcome_uuid,
+				market_key,
+				selection_display:
+					market_key === 'totals'
+						? isOver
+							? 'Over 220.5'
+							: 'Under 220.5'
+						: `Mock ${isHome ? 'home' : 'away'} selection`,
+				odds_american: -110,
+				point:
+					market_key === 'spreads'
+						? isHome
+							? -1.5
+							: 1.5
+						: market_key === 'totals'
+							? 220.5
+							: null,
+				commence_time: new Date(
+					Date.now() + 6 * 3_600_000,
+				).toISOString(),
+			}
+		})
+		const decimal = Math.pow(210 / 110, legs.length)
+		const preview: InitParlayResponse = {
+			init_token: randomUUID(),
+			combined_odds_american: Math.round((decimal - 1) * 100),
+			potential_payout: Math.round(request.stake * decimal * 100) / 100,
+			legs,
+			expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+		}
+		this.pendingParlays.set(preview.init_token, { request, preview })
+		return preview
+	}
+
+	placeParlay(initToken: string): ParlayResponse {
+		const pending = this.pendingParlays.get(initToken)
+		if (!pending) throw new Error('Mock parlay initialization expired.')
+		this.pendingParlays.delete(initToken)
+		const { request, preview } = pending
+		const id = `mock-parlay-${this.nextParlayId++}`
+		const parlay: ParlayResponse = {
+			id,
+			user_id: request.user_id,
+			guild_id: request.guild_id,
+			stake: request.stake,
+			combined_odds_american: preview.combined_odds_american,
+			potential_payout: preview.potential_payout,
+			actual_payout: null,
+			status: 'pending',
+			leg_count: preview.legs.length,
+			created_at: new Date().toISOString(),
+			settled_at: null,
+			legs: preview.legs.map((leg, index) => ({
+				...leg,
+				id: `${id}-leg-${index + 1}`,
+				result: 'pending',
+				settled_at: null,
+			})),
+		}
+		this.parlays.set(id, parlay)
+		return parlay
+	}
+
+	getUserParlays(
+		userId: string,
+		options: { page?: number; limit?: number; status?: string } = {},
+	): UserParlaysResponse {
+		const limit = options.limit ?? 10
+		const page = options.page ?? 1
+		const all = [...this.parlays.values()].filter(
+			(parlay) =>
+				parlay.user_id === userId &&
+				(!options.status || parlay.status === options.status),
+		)
+		const start = (page - 1) * limit
+		return {
+			parlays: all.slice(start, start + limit),
+			page,
+			limit,
+			total: all.length,
+			total_pages: Math.max(1, Math.ceil(all.length / limit)),
+		}
+	}
+
+	cancelParlay(parlayId: string, userId: string): ParlayResponse {
+		const parlay = this.parlays.get(parlayId)
+		if (!parlay || parlay.user_id !== userId) {
+			throw new Error('Mock parlay was not found for this user.')
+		}
+		if (parlay.status !== 'pending') {
+			throw new Error('Mock parlay is no longer cancellable.')
+		}
+		const cancelled = { ...parlay, status: 'cancelled' as const }
+		this.parlays.set(parlayId, cancelled)
+		return cancelled
+	}
+
+	getEventOutcomes(sport: string, eventId: string): EventOutcome[] {
+		const game = this.findGameById(eventId)
+		if (!game?.home_team || !game.away_team) return []
+		const context = {
+			home_team: game.home_team,
+			away_team: game.away_team,
+		}
+		return [
+			{
+				uuid: `${eventId}-home`,
+				event_id: eventId,
+				market_key: 'h2h',
+				name: game.home_team,
+				price: -110,
+				position: 'home',
+				outcome_type: 'team_home',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-away`,
+				event_id: eventId,
+				market_key: 'h2h',
+				name: game.away_team,
+				price: 100,
+				position: 'away',
+				outcome_type: 'team_away',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-spread-home`,
+				event_id: eventId,
+				market_key: 'spreads',
+				name: game.home_team,
+				price: -110,
+				point: -1.5,
+				position: 'home',
+				outcome_type: 'team_home',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-spread-away`,
+				event_id: eventId,
+				market_key: 'spreads',
+				name: game.away_team,
+				price: 100,
+				point: 1.5,
+				position: 'away',
+				outcome_type: 'team_away',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-total-over`,
+				event_id: eventId,
+				market_key: 'totals',
+				name: 'Over',
+				price: -110,
+				point: 220.5,
+				outcome_type: 'over',
+				event_context: context,
+			},
+			{
+				uuid: `${eventId}-total-under`,
+				event_id: eventId,
+				market_key: 'totals',
+				name: 'Under',
+				price: -110,
+				point: 220.5,
+				outcome_type: 'under',
+				event_context: context,
+			},
+		]
+	}
+
 	clearPendingBets(request: ClearPendingBetsRequest) {
 		this.store.clearPending(request.userid)
 		return { statusCode: 200, message: 'Mock pending bet cleared' }
@@ -275,6 +470,9 @@ export class MockBackend {
 		this.store.reset()
 		this.matchesBySport.clear()
 		this.nextBetId = 10_000
+		this.nextParlayId = 20_000
+		this.pendingParlays.clear()
+		this.parlays.clear()
 	}
 
 	private findGameForBet(

--- a/src/utils/dev/mock-backend.ts
+++ b/src/utils/dev/mock-backend.ts
@@ -32,6 +32,7 @@ import type {
 	InitParlayRequest,
 	InitParlayResponse,
 	ParlayResponse,
+	PlacedParlayLeg,
 	UserParlaysResponse,
 } from '../api/Khronos/parlays/ParlayApiWrapper.js'
 import {
@@ -42,6 +43,28 @@ import { makeMatchesForSport, makeUpcomingGame } from './factories/games.js'
 import { asMockSport, MOCK_SPORTS, type MockSport } from './factories/teams.js'
 import { MockStore } from './mock-store.js'
 
+const PARLAY_INIT_TTL_MS = 15 * 60 * 1000
+const PARLAY_MIN_LEGS = 2
+const PARLAY_MAX_LEGS = 6
+const PARLAY_MIN_STAKE = 1
+const PARLAY_MAX_STAKE = 10_000
+const PARLAY_MAX_PAYOUT = 1_000_000
+
+type PendingParlay = {
+	request: InitParlayRequest
+	preview: InitParlayResponse
+	expiresAt: number
+}
+
+type TerminalParlayResult = Exclude<PlacedParlayLeg['result'], 'pending'>
+const TERMINAL_RESULTS = new Set<TerminalParlayResult>([
+	'won',
+	'lost',
+	'push',
+	'void',
+])
+export type MockParlayTerminalListener = (parlay: ParlayResponse) => void
+
 export class MockBackend {
 	private static backend: MockBackend | undefined
 	private readonly store = new MockStore()
@@ -51,11 +74,9 @@ export class MockBackend {
 	>()
 	private nextBetId = 10_000
 	private nextParlayId = 20_000
-	private readonly pendingParlays = new Map<
-		string,
-		{ request: InitParlayRequest; preview: InitParlayResponse }
-	>()
+	private readonly pendingParlays = new Map<string, PendingParlay>()
 	private readonly parlays = new Map<string, ParlayResponse>()
+	private readonly terminalListeners = new Set<MockParlayTerminalListener>()
 
 	private constructor() {
 		if (env.NODE_ENV === 'production') {
@@ -193,12 +214,9 @@ export class MockBackend {
 	}
 
 	initParlay(request: InitParlayRequest): InitParlayResponse {
+		this.validateParlayRequest(request)
 		const legs = request.legs.map((leg) => {
-			const market_key = leg.outcome_uuid.includes('-spread-')
-				? ('spreads' as const)
-				: leg.outcome_uuid.includes('-total-')
-					? ('totals' as const)
-					: ('h2h' as const)
+			const market_key = this.marketKeyForOutcome(leg.outcome_uuid)
 			const isHome = leg.outcome_uuid.endsWith('-home')
 			const isOver = leg.outcome_uuid.endsWith('-over')
 			return {
@@ -225,23 +243,40 @@ export class MockBackend {
 				).toISOString(),
 			}
 		})
-		const decimal = Math.pow(210 / 110, legs.length)
+		const decimal = legs.reduce(
+			(product, leg) => product * this.decimalOdds(leg.odds_american),
+			1,
+		)
+		const expiresAt = Date.now() + PARLAY_INIT_TTL_MS
 		const preview: InitParlayResponse = {
 			init_token: randomUUID(),
 			combined_odds_american: Math.round((decimal - 1) * 100),
 			potential_payout: Math.round(request.stake * decimal * 100) / 100,
 			legs,
-			expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+			expires_at: new Date(expiresAt).toISOString(),
 		}
-		this.pendingParlays.set(preview.init_token, { request, preview })
+		if (preview.potential_payout > PARLAY_MAX_PAYOUT) {
+			throw new Error(
+				`Parlay potential payout cannot exceed ${PARLAY_MAX_PAYOUT}.`,
+			)
+		}
+		this.pendingParlays.set(preview.init_token, {
+			request,
+			preview,
+			expiresAt,
+		})
 		return preview
 	}
 
 	placeParlay(initToken: string): ParlayResponse {
 		const pending = this.pendingParlays.get(initToken)
-		if (!pending) throw new Error('Mock parlay initialization expired.')
+		if (!pending || pending.expiresAt <= Date.now()) {
+			this.pendingParlays.delete(initToken)
+			throw new Error('Mock parlay initialization expired.')
+		}
 		this.pendingParlays.delete(initToken)
 		const { request, preview } = pending
+		this.store.debit(request.user_id, request.stake)
 		const id = `mock-parlay-${this.nextParlayId++}`
 		const parlay: ParlayResponse = {
 			id,
@@ -295,9 +330,97 @@ export class MockBackend {
 		if (parlay.status !== 'pending') {
 			throw new Error('Mock parlay is no longer cancellable.')
 		}
-		const cancelled = { ...parlay, status: 'cancelled' as const }
+		const earliestCommence = parlay.legs.reduce(
+			(earliest, leg) =>
+				new Date(leg.commence_time).getTime() < earliest
+					? new Date(leg.commence_time).getTime()
+					: earliest,
+			Number.POSITIVE_INFINITY,
+		)
+		if (earliestCommence <= Date.now()) {
+			throw new Error('Mock parlay cancellation window has closed.')
+		}
+		const cancelled = {
+			...parlay,
+			status: 'cancelled' as const,
+			actual_payout: parlay.stake,
+			settled_at: new Date().toISOString(),
+		}
+		this.store.credit(userId, parlay.stake)
 		this.parlays.set(parlayId, cancelled)
+		this.notifyTerminal(cancelled)
 		return cancelled
+	}
+
+	/** Register the in-process sink used by hermetic notification tests. */
+	onParlayTerminal(listener: MockParlayTerminalListener): () => void {
+		this.terminalListeners.add(listener)
+		return () => this.terminalListeners.delete(listener)
+	}
+
+	/** Apply one immutable outcome result and resolve the parlay when terminal. */
+	settleParlayLeg(
+		parlayId: string,
+		outcomeUuid: string,
+		result: TerminalParlayResult,
+	): ParlayResponse {
+		const parlay = this.parlays.get(parlayId)
+		if (!parlay) throw new Error('Mock parlay was not found.')
+		if (parlay.status !== 'pending') {
+			throw new Error('Mock parlay is already terminal.')
+		}
+		if (!TERMINAL_RESULTS.has(result)) {
+			throw new Error(`Unsupported mock parlay result: ${result}.`)
+		}
+		const leg = parlay.legs.find(
+			(candidate) => candidate.outcome_uuid === outcomeUuid,
+		)
+		if (!leg) throw new Error('Mock parlay leg was not found.')
+		if (leg.result !== 'pending') {
+			throw new Error('Mock parlay leg is already settled.')
+		}
+
+		const legs = parlay.legs.map((candidate) =>
+			candidate.outcome_uuid === outcomeUuid
+				? { ...candidate, result, settled_at: new Date().toISOString() }
+				: candidate,
+		)
+		const next: ParlayResponse = { ...parlay, legs }
+		if (legs.some((candidate) => candidate.result === 'lost')) {
+			next.status = 'lost'
+			next.actual_payout = 0
+			next.settled_at = new Date().toISOString()
+		} else if (legs.some((candidate) => candidate.result === 'pending')) {
+			this.parlays.set(parlayId, next)
+			return next
+		} else {
+			const winningLegs = legs.filter(
+				(candidate) => candidate.result === 'won',
+			)
+			next.status = winningLegs.length > 0 ? 'won' : 'push_refunded'
+			next.actual_payout =
+				winningLegs.length > 0
+					? this.roundCurrency(
+							parlay.stake *
+								winningLegs.reduce(
+									(product, candidate) =>
+										product *
+										this.decimalOdds(
+											candidate.odds_american,
+										),
+									1,
+								),
+						)
+					: parlay.stake
+			next.settled_at = new Date().toISOString()
+		}
+
+		if ((next.actual_payout ?? 0) > 0) {
+			this.store.credit(parlay.user_id, next.actual_payout ?? 0)
+		}
+		this.parlays.set(parlayId, next)
+		this.notifyTerminal(next)
+		return next
 	}
 
 	getEventOutcomes(sport: string, eventId: string): EventOutcome[] {
@@ -473,6 +596,62 @@ export class MockBackend {
 		this.nextParlayId = 20_000
 		this.pendingParlays.clear()
 		this.parlays.clear()
+		this.terminalListeners.clear()
+	}
+
+	private validateParlayRequest(request: InitParlayRequest): void {
+		if (
+			!Array.isArray(request.legs) ||
+			request.legs.length < PARLAY_MIN_LEGS ||
+			request.legs.length > PARLAY_MAX_LEGS
+		) {
+			throw new Error(
+				`Parlays must contain between ${PARLAY_MIN_LEGS} and ${PARLAY_MAX_LEGS} legs.`,
+			)
+		}
+		if (
+			!Number.isFinite(request.stake) ||
+			request.stake < PARLAY_MIN_STAKE ||
+			request.stake > PARLAY_MAX_STAKE
+		) {
+			throw new Error(
+				`Parlay stake must be between ${PARLAY_MIN_STAKE} and ${PARLAY_MAX_STAKE}.`,
+			)
+		}
+		if (
+			new Set(request.legs.map((leg) => leg.event_id)).size !==
+			request.legs.length
+		) {
+			throw new Error('Parlay legs must reference distinct events.')
+		}
+	}
+
+	private marketKeyForOutcome(
+		outcomeUuid: string,
+	): 'h2h' | 'spreads' | 'totals' {
+		if (outcomeUuid.includes('-spread-')) return 'spreads'
+		if (outcomeUuid.includes('-total-')) return 'totals'
+		if (outcomeUuid.endsWith('-home') || outcomeUuid.endsWith('-away')) {
+			return 'h2h'
+		}
+		throw new Error(`Market in outcome ${outcomeUuid} is not supported.`)
+	}
+
+	private decimalOdds(american: number): number {
+		return american >= 0 ? 1 + american / 100 : 1 + 100 / Math.abs(american)
+	}
+
+	private roundCurrency(value: number): number {
+		return Math.round((value + Number.EPSILON) * 100) / 100
+	}
+
+	private notifyTerminal(parlay: ParlayResponse): void {
+		for (const listener of this.terminalListeners) {
+			listener({
+				...parlay,
+				legs: parlay.legs.map((leg) => ({ ...leg })),
+			})
+		}
 	}
 
 	private findGameForBet(

--- a/src/utils/embeds/__tests__/weekly-recap.embed.test.ts
+++ b/src/utils/embeds/__tests__/weekly-recap.embed.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+	buildWeeklyRecapEmbeds,
+	formatRecapUser,
+} from '../weekly-recap.embed.js'
+
+const recap = {
+	window: {
+		start_date: '2026-07-06T00:00:00.000Z',
+		end_date: '2026-07-12T23:59:59.999Z',
+		week_number: 19,
+		season_year: 2026,
+	},
+	total_predictions: 12,
+	correct_predictions: 9,
+	incorrect_predictions: 3,
+	accuracy: 75,
+	accuracy_delta: 12.5,
+	top_predictors: [
+		{
+			user_id: '123456789012345678',
+			correct_predictions: 8,
+			incorrect_predictions: 1,
+			success_rate: 88.888,
+			display_name: 'Top predictor',
+		},
+	],
+	biggest_single_win: {
+		user_id: '123456789012345678',
+		payout: 125.5,
+	},
+	biggest_parlay_win: null,
+}
+
+describe('buildWeeklyRecapEmbeds', () => {
+	it('renders week metadata, predictor standings, highlights, and totals', () => {
+		const [embed] = buildWeeklyRecapEmbeds(recap)
+		const json = embed.toJSON()
+
+		expect(json.title).toBe('📊 Week 19 Recap')
+		expect(json.description).toContain('Jul 6')
+		expect(json.fields?.map((field) => field.name)).toEqual([
+			'Top predictors',
+			'Highlights',
+			'Totals',
+		])
+		expect(json.fields?.[0]?.value).toContain('Top predictor')
+		expect(json.fields?.[1]?.value).toContain('125.50')
+		expect(json.fields?.[2]?.value).toContain('75.0%')
+	})
+
+	it('renders a friendly quiet-week state', () => {
+		const [embed] = buildWeeklyRecapEmbeds({
+			...recap,
+			total_predictions: 0,
+			correct_predictions: 0,
+			incorrect_predictions: 0,
+			accuracy: 0,
+			accuracy_delta: 0,
+			top_predictors: [],
+			biggest_single_win: null,
+			biggest_parlay_win: null,
+		})
+		const json = embed.toJSON()
+
+		expect(json.fields?.[0]?.value).toContain(
+			'No predictors recorded this week',
+		)
+		expect(json.fields?.[1]?.value).toContain('No wins recorded this week')
+	})
+})
+
+describe('formatRecapUser', () => {
+	it('truncates long display names without dropping the identity fallback', () => {
+		const formatted = formatRecapUser('123', 'a'.repeat(80))
+		expect(formatted).toHaveLength(32)
+		expect(formatted.endsWith('…')).toBe(true)
+	})
+})

--- a/src/utils/embeds/weekly-recap.embed.ts
+++ b/src/utils/embeds/weekly-recap.embed.ts
@@ -1,0 +1,116 @@
+import { EmbedBuilder } from 'discord.js'
+import embedColors from '../../lib/colorsConfig.js'
+import type { WeeklyRecapResponse } from '../api/Khronos/recap/recap-wrapper.js'
+
+const MAX_PREDICTORS = 5
+const MAX_DISPLAY_NAME_LENGTH = 32
+
+export type WeeklyRecapEmbedData = WeeklyRecapResponse
+
+/**
+ * Truncate user-provided display names before inserting them into Discord
+ * embed text. IDs remain available as a mention fallback when no name exists.
+ */
+export function formatRecapUser(userId: string, displayName?: string): string {
+	const candidate = displayName?.trim() || `<@${userId}>`
+	if (candidate.length <= MAX_DISPLAY_NAME_LENGTH) return candidate
+	return `${candidate.slice(0, MAX_DISPLAY_NAME_LENGTH - 1)}…`
+}
+
+function formatPayout(payout: number): string {
+	return Number.isFinite(payout) ? payout.toFixed(2) : '0.00'
+}
+
+function formatDelta(delta: number): string {
+	if (!Number.isFinite(delta) || delta === 0) return '0.0 pp'
+	return `${delta > 0 ? '+' : ''}${delta.toFixed(1)} pp`
+}
+
+function formatDateRange(data: WeeklyRecapEmbedData): string {
+	const start = new Date(data.window.start_date)
+	const end = new Date(data.window.end_date)
+	if (Number.isNaN(start.valueOf()) || Number.isNaN(end.valueOf())) {
+		return 'Sleeper-aligned weekly window'
+	}
+
+	return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })} – ${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })}`
+}
+
+function buildPredictorLines(data: WeeklyRecapEmbedData): string {
+	const predictors = data.top_predictors.slice(0, MAX_PREDICTORS)
+	if (predictors.length === 0) return 'No predictors recorded this week.'
+
+	return predictors
+		.map((predictor, index) => {
+			const total =
+				predictor.correct_predictions + predictor.incorrect_predictions
+			const rate = Number.isFinite(predictor.success_rate)
+				? predictor.success_rate
+				: total > 0
+					? (predictor.correct_predictions / total) * 100
+					: 0
+			return `${index + 1}. ${formatRecapUser(predictor.user_id, predictor.display_name)} — **${predictor.correct_predictions}/${total}** (${rate.toFixed(1)}%)`
+		})
+		.join('\n')
+}
+
+function buildWinLines(data: WeeklyRecapEmbedData): string {
+	const lines: string[] = []
+	if (data.biggest_single_win) {
+		lines.push(
+			`🎯 Single: ${formatRecapUser(data.biggest_single_win.user_id)} — **${formatPayout(data.biggest_single_win.payout)}**`,
+		)
+	}
+	if (data.biggest_parlay_win) {
+		lines.push(
+			`🎲 Parlay: ${formatRecapUser(data.biggest_parlay_win.user_id)} — **${formatPayout(data.biggest_parlay_win.payout)}**`,
+		)
+	}
+	return lines.length > 0
+		? lines.join('\n')
+		: 'No wins recorded this week — next week is yours.'
+}
+
+/**
+ * Build the weekly digest embeds posted by the recap cron.
+ *
+ * The digest intentionally caps predictor rows at five and keeps each section
+ * in a single field, staying below Discord's field and message limits while
+ * preserving the complete aggregate totals from Khronos.
+ */
+export function buildWeeklyRecapEmbeds(
+	data: WeeklyRecapEmbedData,
+): EmbedBuilder[] {
+	const weekLabel = data.window.week_number
+		? `Week ${data.window.week_number}`
+		: 'Weekly Recap'
+	const accuracy = Number.isFinite(data.accuracy) ? data.accuracy : 0
+
+	const embed = new EmbedBuilder()
+		.setTitle(`📊 ${weekLabel} Recap`)
+		.setColor(embedColors.PlutoBlue)
+		.setDescription(
+			`Sleeper-aligned window: **${formatDateRange(data)}**${data.window.season_year ? ` · Season ${data.window.season_year}` : ''}`,
+		)
+		.addFields(
+			{
+				name: 'Top predictors',
+				value: buildPredictorLines(data),
+			},
+			{
+				name: 'Highlights',
+				value: buildWinLines(data),
+			},
+			{
+				name: 'Totals',
+				value: [
+					`Predictions: **${data.total_predictions}**`,
+					`Correct: **${data.correct_predictions}** · Incorrect: **${data.incorrect_predictions}**`,
+					`Accuracy: **${accuracy.toFixed(1)}%** (${formatDelta(data.accuracy_delta)})`,
+				].join('\n'),
+			},
+		)
+		.setFooter({ text: 'Khronos weekly recap · Pluto' })
+
+	return [embed]
+}

--- a/src/utils/predictions/streak-display.ts
+++ b/src/utils/predictions/streak-display.ts
@@ -1,0 +1,20 @@
+export type StreakBadgeTier = 3 | 5 | 10 | null
+
+/** Format a compact, text-accessible badge marker for leaderboard rows. */
+export function formatBadge(tier: StreakBadgeTier): string {
+	return tier === null ? '' : ` 🔥${tier}`
+}
+
+/** Format the personal streak summary used by prediction stats embeds. */
+export function formatStreakLine(
+	current: number | null,
+	best: number | null,
+): string {
+	if (current === null || best === null) {
+		return 'Current Streak: **Unavailable** · Best: **Unavailable**'
+	}
+
+	const currentCopy =
+		current > 0 ? `**${current}**` : '**0** (No active streak)'
+	return `Current Streak: ${currentCopy} · Best: **${best}**`
+}

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import type { ProcessedPropDto } from '@pluto-khronos/api-client'
 import { format } from 'date-fns'
 import {
@@ -152,6 +153,19 @@ export class PropPostingHandler {
 				})
 				continue
 			}
+			if (deliveryState.status === 'unknown') {
+				result.failed++
+				result.failures.push({
+					guild_id: guildId,
+					channel_id: channelId,
+					outcome_uuids: [
+						prop.over.outcome_uuid,
+						prop.under.outcome_uuid,
+					],
+					error: 'Unknown legacy delivery marker; manual reconciliation required',
+				})
+				continue
+			}
 
 			try {
 				const embed = await this.createPropEmbed(prop, sport)
@@ -197,8 +211,7 @@ export class PropPostingHandler {
 						outcome_uuids: references.map(
 							(reference) => reference.outcome_uuid,
 						),
-						error:
-							'Discord message posted but durable delivery marker was unavailable',
+						error: 'Discord message posted but durable delivery marker was unavailable',
 					})
 				}
 			} catch (error) {
@@ -228,6 +241,42 @@ export class PropPostingHandler {
 		return result
 	}
 
+	/**
+	 * Posts one prop pair for the durable prop-post worker. The queue has
+	 * already persisted the delivery envelope before this method is called.
+	 * Discord's nonce makes a retry after an ambiguous send return the original
+	 * message instead of creating a second one.
+	 */
+	async postPropPair(
+		guildId: string,
+		channelId: string,
+		prop: ProcessedPropDto,
+		sport: 'nba' | 'nfl',
+		deliveryId: string,
+		destinationId: string,
+	): Promise<PostedPropReference[]> {
+		const embed = await this.createPropEmbed(prop, sport)
+		const buttons = this.createPropButtons(prop)
+		const message = await this.guildWrapper.sendToChannel(
+			channelId,
+			{
+				embeds: [embed],
+				components: [buttons],
+				nonce: createDeliveryNonce(deliveryId, destinationId),
+				enforceNonce: true,
+			},
+			guildId,
+		)
+		return [prop.over.outcome_uuid, prop.under.outcome_uuid].map(
+			(outcome_uuid) => ({
+				outcome_uuid,
+				guild_id: guildId,
+				channel_id: channelId,
+				message_id: message.id,
+			}),
+		)
+	}
+
 	private getDeliveryKey(
 		guildId: string,
 		channelId: string | undefined,
@@ -249,6 +298,7 @@ export class PropPostingHandler {
 		| { status: 'sent'; results: PostedPropReference[] }
 		| { status: 'claimed' }
 		| { status: 'unavailable' }
+		| { status: 'unknown' }
 	> {
 		try {
 			const existing = await redisCache.get(deliveryKey)
@@ -256,22 +306,13 @@ export class PropPostingHandler {
 			if (existing === 'processing') return { status: 'claimed' }
 			if (existing === 'retry') {
 				try {
-					const redis = redisCache as unknown as {
-						eval?: (
-							script: string,
-							numKeys: number,
-							...args: Array<string | number>
-						) => Promise<unknown>
-					}
-					if (!redis.eval) return { status: 'claimed' }
-					const reclaimed = await redis.eval(
-						"if redis.call('get', KEYS[1]) == 'retry' then return redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2]) else return nil end",
-						1,
+					const reclaimed = await redisCache.transitionIfValue(
 						deliveryKey,
+						'retry',
 						'processing',
 						PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
 					)
-					return reclaimed === 'OK'
+					return reclaimed
 						? { status: 'available' }
 						: { status: 'claimed' }
 				} catch {
@@ -283,14 +324,15 @@ export class PropPostingHandler {
 					const marker = JSON.parse(existing) as DeliveredMarker
 					if (
 						marker.status === 'sent' &&
-						Array.isArray(marker.results)
+						Array.isArray(marker.results) &&
+						marker.results.every(isPostedPropReference)
 					) {
 						return { status: 'sent', results: marker.results }
 					}
 				} catch {
-					// An unknown marker is treated as available for compatibility
-					// with older deployments that stored a plain status value.
+					return { status: 'unknown' }
 				}
+				return { status: 'unknown' }
 			}
 
 			const lock = await redisCache.set(
@@ -498,4 +540,25 @@ export class PropPostingHandler {
 			underButton,
 		)
 	}
+}
+
+function isPostedPropReference(value: unknown): value is PostedPropReference {
+	if (!value || typeof value !== 'object') return false
+	const candidate = value as Record<string, unknown>
+	return (
+		typeof candidate.outcome_uuid === 'string' &&
+		typeof candidate.guild_id === 'string' &&
+		typeof candidate.channel_id === 'string' &&
+		typeof candidate.message_id === 'string'
+	)
+}
+
+function createDeliveryNonce(
+	deliveryId: string,
+	destinationId: string,
+): string {
+	return createHash('sha256')
+		.update(`${deliveryId}:${destinationId}`)
+		.digest('hex')
+		.slice(0, 25)
 }

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -8,6 +8,7 @@ import {
 } from 'discord.js'
 import { MarketKeyTranslations } from '../api/common/interfaces/market-translations.js'
 import GuildWrapper from '../api/Khronos/guild/guild-wrapper.js'
+import redisCache from '../cache/redis-instance.js'
 import StringUtils from '../common/string-utils.js'
 import TeamInfo from '../common/TeamInfo.js'
 import { logger } from '../logging/WinstonLogger.js'
@@ -46,6 +47,9 @@ export interface PostingResult {
  * ```
  */
 export class PropPostingHandler {
+	private static readonly DELIVERY_TTL_SECONDS = 7 * 24 * 60 * 60
+	private static readonly DELIVERY_CLAIM_TTL_SECONDS = 5 * 60
+	private static readonly DELIVERY_RELEASE_RETRY_TTL_SECONDS = 5
 	private guildWrapper: GuildWrapper
 
 	constructor() {
@@ -69,6 +73,7 @@ export class PropPostingHandler {
 		guildId: string,
 		props: ProcessedPropDto[],
 		sport: 'nfl' | 'nba',
+		channelId?: string,
 	): Promise<PostingResult> {
 		const result: PostingResult = {
 			posted: 0,
@@ -79,15 +84,45 @@ export class PropPostingHandler {
 
 		// 1 Embed:1 Pair
 		for (const prop of props) {
+			const deliveryKey = this.getDeliveryKey(guildId, channelId, prop)
+			const deliveryState = await this.claimDelivery(deliveryKey)
+			if (deliveryState === 'sent' || deliveryState === 'claimed') {
+				result.filtered++
+				continue
+			}
+			if (deliveryState === 'unavailable') {
+				result.failed++
+				continue
+			}
+
 			try {
+				// Reserve the durable sent state before Discord delivery. This
+				// closes the crash window between Discord accepting a message and
+				// the marker write; the workflow is intentionally at-most-once.
+				if (!(await this.markDelivered(deliveryKey))) {
+					result.failed++
+					await this.releaseDeliveryClaim(deliveryKey)
+					continue
+				}
 				const embed = await this.createPropEmbed(prop, sport)
 				const buttons = this.createPropButtons(prop)
 
-				await this.guildWrapper.sendToPredictionChannel(guildId, {
+				const messageOptions = {
 					embeds: [embed],
 					components: [buttons],
-				})
-
+				}
+				if (channelId) {
+					await this.guildWrapper.sendToChannel(
+						channelId,
+						messageOptions,
+						guildId,
+					)
+				} else {
+					await this.guildWrapper.sendToPredictionChannel(
+						guildId,
+						messageOptions,
+					)
+				}
 				result.posted++
 			} catch (error) {
 				logger.error('Failed to post prop pair', {
@@ -99,10 +134,137 @@ export class PropPostingHandler {
 					error,
 				})
 				result.failed++
+				await this.releaseDeliveryClaim(deliveryKey)
 			}
 		}
 
 		return result
+	}
+
+	private getDeliveryKey(
+		guildId: string,
+		channelId: string | undefined,
+		prop: ProcessedPropDto,
+	): string {
+		const destination = channelId ?? 'configured'
+		return [
+			'props:delivery',
+			guildId,
+			destination,
+			prop.over.outcome_uuid,
+			prop.under.outcome_uuid,
+		].join(':')
+	}
+
+	private async claimDelivery(
+		deliveryKey: string,
+	): Promise<'available' | 'sent' | 'claimed' | 'unavailable'> {
+		try {
+			const existing = await redisCache.get(deliveryKey)
+			if (existing === 'sent') return 'sent'
+			if (existing === 'processing') return 'claimed'
+			if (existing === 'retry') {
+				try {
+					const redis = redisCache as unknown as {
+						eval?: (
+							script: string,
+							numKeys: number,
+							...args: Array<string | number>
+						) => Promise<unknown>
+					}
+					if (!redis.eval) return 'claimed'
+					const reclaimed = await redis.eval(
+						"if redis.call('get', KEYS[1]) == 'retry' then return redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2]) else return nil end",
+						1,
+						deliveryKey,
+						'processing',
+						PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
+					)
+					return reclaimed === 'OK' ? 'available' : 'claimed'
+				} catch {
+					return 'claimed'
+				}
+			}
+
+			const lock = await redisCache.set(
+				deliveryKey,
+				'processing',
+				'EX',
+				PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
+				'NX',
+			)
+			return lock === 'OK' ? 'available' : 'claimed'
+		} catch (error) {
+			logger.warn({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_idempotency_unavailable',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return 'unavailable'
+		}
+	}
+
+	private async markDelivered(deliveryKey: string): Promise<boolean> {
+		try {
+			await redisCache.setex(
+				deliveryKey,
+				PropPostingHandler.DELIVERY_TTL_SECONDS,
+				'sent',
+			)
+			return true
+		} catch (error) {
+			logger.error({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_marker_write_failed',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return false
+		}
+	}
+
+	private async releaseDeliveryClaim(deliveryKey: string): Promise<void> {
+		try {
+			await redisCache.del(deliveryKey)
+		} catch (error) {
+			logger.warn({
+				method: 'PropPostingHandler',
+				event: 'props_delivery_claim_release_failed',
+				deliveryKey,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			try {
+				await redisCache.setex(
+					deliveryKey,
+					PropPostingHandler.DELIVERY_RELEASE_RETRY_TTL_SECONDS,
+					'retry',
+				)
+			} catch (fallbackError) {
+				try {
+					await redisCache.set(deliveryKey, 'retry')
+				} catch (lastError) {
+					logger.error({
+						method: 'PropPostingHandler',
+						event: 'props_delivery_claim_cleanup_failed',
+						deliveryKey,
+						error:
+							lastError instanceof Error
+								? lastError.message
+								: String(lastError),
+					})
+				}
+				logger.warn({
+					method: 'PropPostingHandler',
+					event: 'props_delivery_claim_retry_marker_failed',
+					deliveryKey,
+					error:
+						fallbackError instanceof Error
+							? fallbackError.message
+							: String(fallbackError),
+				})
+			}
+		}
 	}
 
 	/**

--- a/src/utils/props/PropPostingHandler.ts
+++ b/src/utils/props/PropPostingHandler.ts
@@ -25,6 +25,29 @@ export interface PostingResult {
 	failed: number
 	/** Total props processed */
 	total: number
+	/** One ledger reference for each successfully posted outcome */
+	results: PostedPropReference[]
+	/** Per-pair failures kept explicit for route observability and retries */
+	failures: PostingFailure[]
+}
+
+export interface PostedPropReference {
+	outcome_uuid: string
+	guild_id: string
+	channel_id: string
+	message_id: string
+}
+
+export interface PostingFailure {
+	guild_id: string
+	channel_id?: string
+	outcome_uuids: string[]
+	error: string
+}
+
+interface DeliveredMarker {
+	status: 'sent'
+	results: PostedPropReference[]
 }
 
 /**
@@ -48,7 +71,11 @@ export interface PostingResult {
  */
 export class PropPostingHandler {
 	private static readonly DELIVERY_TTL_SECONDS = 7 * 24 * 60 * 60
-	private static readonly DELIVERY_CLAIM_TTL_SECONDS = 5 * 60
+	// Keep the claim for the full idempotency window. Discord does not provide
+	// a transaction that atomically commits a message and its Redis marker, so
+	// a crash after Discord accepts a send must remain conservatively claimed.
+	private static readonly DELIVERY_CLAIM_TTL_SECONDS =
+		PropPostingHandler.DELIVERY_TTL_SECONDS
 	private static readonly DELIVERY_RELEASE_RETRY_TTL_SECONDS = 5
 	private guildWrapper: GuildWrapper
 
@@ -80,30 +107,53 @@ export class PropPostingHandler {
 			filtered: 0,
 			failed: 0,
 			total: props.length,
+			results: [],
+			failures: [],
 		}
 
 		// 1 Embed:1 Pair
 		for (const prop of props) {
 			const deliveryKey = this.getDeliveryKey(guildId, channelId, prop)
 			const deliveryState = await this.claimDelivery(deliveryKey)
-			if (deliveryState === 'sent' || deliveryState === 'claimed') {
-				result.filtered++
+			if (deliveryState.status === 'sent') {
+				if (deliveryState.results.length > 0) {
+					result.results.push(...deliveryState.results)
+					result.posted++
+				} else {
+					// Legacy markers predate the durable reference ledger. Keep
+					// their at-most-once behavior while new markers are recoverable.
+					result.filtered++
+				}
 				continue
 			}
-			if (deliveryState === 'unavailable') {
+			if (deliveryState.status === 'claimed') {
 				result.failed++
+				result.failures.push({
+					guild_id: guildId,
+					channel_id: channelId,
+					outcome_uuids: [
+						prop.over.outcome_uuid,
+						prop.under.outcome_uuid,
+					],
+					error: 'Delivery is already being processed; retry later',
+				})
+				continue
+			}
+			if (deliveryState.status === 'unavailable') {
+				result.failed++
+				result.failures.push({
+					guild_id: guildId,
+					channel_id: channelId,
+					outcome_uuids: [
+						prop.over.outcome_uuid,
+						prop.under.outcome_uuid,
+					],
+					error: 'Delivery idempotency unavailable',
+				})
 				continue
 			}
 
 			try {
-				// Reserve the durable sent state before Discord delivery. This
-				// closes the crash window between Discord accepting a message and
-				// the marker write; the workflow is intentionally at-most-once.
-				if (!(await this.markDelivered(deliveryKey))) {
-					result.failed++
-					await this.releaseDeliveryClaim(deliveryKey)
-					continue
-				}
 				const embed = await this.createPropEmbed(prop, sport)
 				const buttons = this.createPropButtons(prop)
 
@@ -111,19 +161,46 @@ export class PropPostingHandler {
 					embeds: [embed],
 					components: [buttons],
 				}
-				if (channelId) {
-					await this.guildWrapper.sendToChannel(
-						channelId,
-						messageOptions,
-						guildId,
-					)
+				const message = channelId
+					? await this.guildWrapper.sendToChannel(
+							channelId,
+							messageOptions,
+							guildId,
+						)
+					: await this.guildWrapper.sendToPredictionChannel(
+							guildId,
+							messageOptions,
+						)
+
+				const postedChannelId = channelId ?? message.channelId
+				const references = [
+					prop.over.outcome_uuid,
+					prop.under.outcome_uuid,
+				].map((outcome_uuid) => ({
+					outcome_uuid,
+					guild_id: guildId,
+					channel_id: postedChannelId,
+					message_id: message.id,
+				}))
+				const markerPersisted = await this.markDelivered(
+					deliveryKey,
+					references,
+				)
+				if (markerPersisted) {
+					result.results.push(...references)
+					result.posted++
 				} else {
-					await this.guildWrapper.sendToPredictionChannel(
-						guildId,
-						messageOptions,
-					)
+					result.failed++
+					result.failures.push({
+						guild_id: guildId,
+						channel_id: postedChannelId,
+						outcome_uuids: references.map(
+							(reference) => reference.outcome_uuid,
+						),
+						error:
+							'Discord message posted but durable delivery marker was unavailable',
+					})
 				}
-				result.posted++
 			} catch (error) {
 				logger.error('Failed to post prop pair', {
 					event_id: prop.event_id,
@@ -134,6 +211,16 @@ export class PropPostingHandler {
 					error,
 				})
 				result.failed++
+				result.failures.push({
+					guild_id: guildId,
+					channel_id: channelId,
+					outcome_uuids: [
+						prop.over.outcome_uuid,
+						prop.under.outcome_uuid,
+					],
+					error:
+						error instanceof Error ? error.message : String(error),
+				})
 				await this.releaseDeliveryClaim(deliveryKey)
 			}
 		}
@@ -146,11 +233,10 @@ export class PropPostingHandler {
 		channelId: string | undefined,
 		prop: ProcessedPropDto,
 	): string {
-		const destination = channelId ?? 'configured'
 		return [
 			'props:delivery',
 			guildId,
-			destination,
+			channelId ?? 'configured',
 			prop.over.outcome_uuid,
 			prop.under.outcome_uuid,
 		].join(':')
@@ -158,11 +244,16 @@ export class PropPostingHandler {
 
 	private async claimDelivery(
 		deliveryKey: string,
-	): Promise<'available' | 'sent' | 'claimed' | 'unavailable'> {
+	): Promise<
+		| { status: 'available' }
+		| { status: 'sent'; results: PostedPropReference[] }
+		| { status: 'claimed' }
+		| { status: 'unavailable' }
+	> {
 		try {
 			const existing = await redisCache.get(deliveryKey)
-			if (existing === 'sent') return 'sent'
-			if (existing === 'processing') return 'claimed'
+			if (existing === 'sent') return { status: 'sent', results: [] }
+			if (existing === 'processing') return { status: 'claimed' }
 			if (existing === 'retry') {
 				try {
 					const redis = redisCache as unknown as {
@@ -172,7 +263,7 @@ export class PropPostingHandler {
 							...args: Array<string | number>
 						) => Promise<unknown>
 					}
-					if (!redis.eval) return 'claimed'
+					if (!redis.eval) return { status: 'claimed' }
 					const reclaimed = await redis.eval(
 						"if redis.call('get', KEYS[1]) == 'retry' then return redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2]) else return nil end",
 						1,
@@ -180,9 +271,25 @@ export class PropPostingHandler {
 						'processing',
 						PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
 					)
-					return reclaimed === 'OK' ? 'available' : 'claimed'
+					return reclaimed === 'OK'
+						? { status: 'available' }
+						: { status: 'claimed' }
 				} catch {
-					return 'claimed'
+					return { status: 'claimed' }
+				}
+			}
+			if (existing) {
+				try {
+					const marker = JSON.parse(existing) as DeliveredMarker
+					if (
+						marker.status === 'sent' &&
+						Array.isArray(marker.results)
+					) {
+						return { status: 'sent', results: marker.results }
+					}
+				} catch {
+					// An unknown marker is treated as available for compatibility
+					// with older deployments that stored a plain status value.
 				}
 			}
 
@@ -193,7 +300,9 @@ export class PropPostingHandler {
 				PropPostingHandler.DELIVERY_CLAIM_TTL_SECONDS,
 				'NX',
 			)
-			return lock === 'OK' ? 'available' : 'claimed'
+			return lock === 'OK'
+				? { status: 'available' }
+				: { status: 'claimed' }
 		} catch (error) {
 			logger.warn({
 				method: 'PropPostingHandler',
@@ -201,16 +310,22 @@ export class PropPostingHandler {
 				deliveryKey,
 				error: error instanceof Error ? error.message : String(error),
 			})
-			return 'unavailable'
+			return { status: 'unavailable' }
 		}
 	}
 
-	private async markDelivered(deliveryKey: string): Promise<boolean> {
+	private async markDelivered(
+		deliveryKey: string,
+		results: PostedPropReference[],
+	): Promise<boolean> {
 		try {
 			await redisCache.setex(
 				deliveryKey,
 				PropPostingHandler.DELIVERY_TTL_SECONDS,
-				'sent',
+				JSON.stringify({
+					status: 'sent',
+					results,
+				} satisfies DeliveredMarker),
 			)
 			return true
 		} catch (error) {
@@ -220,7 +335,30 @@ export class PropPostingHandler {
 				deliveryKey,
 				error: error instanceof Error ? error.message : String(error),
 			})
-			return false
+			try {
+				// Some Redis-compatible test/degraded clients do not implement
+				// SETEX. A plain SET still records the durable sent ledger and is
+				// preferable to leaving a processing claim that can later replay.
+				await redisCache.set(
+					deliveryKey,
+					JSON.stringify({
+						status: 'sent',
+						results,
+					} satisfies DeliveredMarker),
+				)
+				return true
+			} catch (fallbackError) {
+				logger.error({
+					method: 'PropPostingHandler',
+					event: 'props_delivery_marker_fallback_failed',
+					deliveryKey,
+					error:
+						fallbackError instanceof Error
+							? fallbackError.message
+							: String(fallbackError),
+				})
+				return false
+			}
 		}
 	}
 
@@ -235,18 +373,31 @@ export class PropPostingHandler {
 				error: error instanceof Error ? error.message : String(error),
 			})
 			try {
+				// If DEL failed, shorten the failed-send claim so a retry can
+				// recover promptly instead of remaining blocked for seven days.
 				await redisCache.setex(
 					deliveryKey,
 					PropPostingHandler.DELIVERY_RELEASE_RETRY_TTL_SECONDS,
-					'retry',
+					'processing',
 				)
 			} catch (fallbackError) {
+				logger.warn({
+					method: 'PropPostingHandler',
+					event: 'props_delivery_claim_fallback_failed',
+					deliveryKey,
+					error:
+						fallbackError instanceof Error
+							? fallbackError.message
+							: String(fallbackError),
+				})
 				try {
+					// Last-resort retry marker for clients where DEL and SETEX are
+					// unavailable. A recovered client removes it before re-claiming.
 					await redisCache.set(deliveryKey, 'retry')
 				} catch (lastError) {
 					logger.error({
 						method: 'PropPostingHandler',
-						event: 'props_delivery_claim_cleanup_failed',
+						event: 'props_delivery_claim_last_resort_failed',
 						deliveryKey,
 						error:
 							lastError instanceof Error
@@ -254,19 +405,9 @@ export class PropPostingHandler {
 								: String(lastError),
 					})
 				}
-				logger.warn({
-					method: 'PropPostingHandler',
-					event: 'props_delivery_claim_retry_marker_failed',
-					deliveryKey,
-					error:
-						fallbackError instanceof Error
-							? fallbackError.message
-							: String(fallbackError),
-				})
 			}
 		}
 	}
-
 	/**
 	 * Creates a formatted embed for a player prop pair
 	 *

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -64,7 +64,25 @@ const prop = {
 	},
 } as ProcessedPropDto
 
-describe('PropPostingHandler delivery idempotency', () => {
+const sentMessage = { id: 'message-1', channelId: 'channel-1' }
+const deliveryKey =
+	'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001'
+const references = [
+	{
+		outcome_uuid: prop.over.outcome_uuid,
+		guild_id: 'guild-1',
+		channel_id: 'channel-1',
+		message_id: 'message-1',
+	},
+	{
+		outcome_uuid: prop.under.outcome_uuid,
+		guild_id: 'guild-1',
+		channel_id: 'channel-1',
+		message_id: 'message-1',
+	},
+]
+
+describe('PropPostingHandler message references and idempotency', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		mocks.get.mockResolvedValue(null)
@@ -72,11 +90,34 @@ describe('PropPostingHandler delivery idempotency', () => {
 		mocks.setex.mockResolvedValue('OK')
 		mocks.eval.mockResolvedValue('OK')
 		mocks.del.mockResolvedValue(1)
-		mocks.sendToChannel.mockResolvedValue(undefined)
+		mocks.sendToChannel.mockResolvedValue(sentMessage)
+		mocks.sendToPredictionChannel.mockResolvedValue(sentMessage)
 		mocks.getTeamInfo.mockResolvedValue({
 			color: 0x123456,
 			resolvedTeamData: { abbrev: 'HOM' },
 		})
+	})
+
+	it('returns both outcome refs for one posted Discord message', async () => {
+		const result = await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toMatchObject({
+			posted: 1,
+			filtered: 0,
+			failed: 0,
+			total: 1,
+		})
+		expect(result.results).toEqual(references)
+		expect(mocks.sendToChannel).toHaveBeenCalledWith(
+			'channel-1',
+			expect.objectContaining({ embeds: expect.any(Array) }),
+			'guild-1',
+		)
 	})
 
 	it('does not repost a prop already delivered to the same destination', async () => {
@@ -96,27 +137,89 @@ describe('PropPostingHandler delivery idempotency', () => {
 			'channel-1',
 		)
 
-		expect(first).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
-		expect(second).toEqual({ posted: 0, filtered: 1, failed: 0, total: 1 })
+		expect(first.posted).toBe(1)
+		expect(first.results).toEqual(references)
+		expect(second).toMatchObject({
+			posted: 0,
+			filtered: 1,
+			failed: 0,
+			total: 1,
+		})
+		expect(second.results).toEqual([])
 		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
 	})
 
-	it('releases the delivery claim when posting fails so a retry can proceed', async () => {
-		const handler = new PropPostingHandler()
-		mocks.sendToChannel.mockRejectedValueOnce(
-			new Error('Discord unavailable'),
+	it('recovers durable outcome references for a sent pair', async () => {
+		mocks.get.mockResolvedValue(
+			JSON.stringify({ status: 'sent', results: references }),
 		)
 
-		const result = await handler.postPropsToChannel(
+		const result = await new PropPostingHandler().postPropsToChannel(
 			'guild-1',
 			[prop],
 			'nba',
 			'channel-1',
 		)
 
-		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
-		expect(mocks.del).toHaveBeenCalledWith(
-			'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+		expect(result).toMatchObject({ posted: 1, filtered: 0, failed: 0 })
+		expect(result.results).toEqual(references)
+		expect(mocks.sendToChannel).not.toHaveBeenCalled()
+	})
+
+	it('records an in-flight claim as a retryable failure and allows a later retry', async () => {
+		const handler = new PropPostingHandler()
+		mocks.get.mockResolvedValueOnce('processing')
+
+		const inFlight = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		mocks.get.mockResolvedValueOnce(null)
+		const retry = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(inFlight).toMatchObject({
+			posted: 0,
+			filtered: 0,
+			failed: 1,
+			total: 1,
+		})
+		expect(inFlight.failures).toEqual([
+			expect.objectContaining({
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				error: 'Delivery is already being processed; retry later',
+			}),
+		])
+		expect(retry.posted).toBe(1)
+		expect(retry.results).toEqual(references)
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+	})
+
+	it('reclaims a retry marker with an atomic Redis transition', async () => {
+		mocks.get.mockResolvedValueOnce('retry')
+
+		const result = await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result.posted).toBe(1)
+		expect(result.results).toEqual(references)
+		expect(mocks.eval).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('get', KEYS[1]) == 'retry'"),
+			1,
+			deliveryKey,
+			'processing',
+			7 * 24 * 60 * 60,
 		)
 	})
 
@@ -138,8 +241,9 @@ describe('PropPostingHandler delivery idempotency', () => {
 			'channel-1',
 		)
 
-		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
-		expect(retry).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(result).toMatchObject({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(retry.posted).toBe(1)
+		expect(retry.results).toEqual(references)
 		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
 		expect(mocks.logger.warn).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -148,71 +252,99 @@ describe('PropPostingHandler delivery idempotency', () => {
 		)
 	})
 
-	it('allows an interrupted processing claim to retry after its lease expires', async () => {
-		const handler = new PropPostingHandler()
-		mocks.get.mockResolvedValueOnce('processing')
+	it('keeps partial failures explicit and releases failed claims', async () => {
+		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
 
-		const inFlight = await handler.postPropsToChannel(
-			'guild-1',
-			[prop],
-			'nba',
-			'channel-1',
-		)
-		mocks.get.mockResolvedValueOnce(null)
-		const retry = await handler.postPropsToChannel(
+		const result = await new PropPostingHandler().postPropsToChannel(
 			'guild-1',
 			[prop],
 			'nba',
 			'channel-1',
 		)
 
-		expect(inFlight).toEqual({
-			posted: 0,
-			filtered: 1,
-			failed: 0,
-			total: 1,
-		})
-		expect(retry).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
-		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
-	})
-
-	it('reclaims a retry marker with an atomic Redis transition', async () => {
-		const handler = new PropPostingHandler()
-		mocks.get.mockResolvedValueOnce('retry')
-
-		const result = await handler.postPropsToChannel(
-			'guild-1',
-			[prop],
-			'nba',
-			'channel-1',
-		)
-
-		expect(result).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
-		expect(mocks.eval).toHaveBeenCalledWith(
-			expect.stringContaining("redis.call('get', KEYS[1]) == 'retry'"),
-			1,
-			expect.stringContaining('props:delivery:guild-1:channel-1'),
-			'processing',
-			300,
-		)
-	})
-
-	it('does not send when the durable sent reservation cannot be persisted', async () => {
-		const handler = new PropPostingHandler()
-		mocks.setex.mockRejectedValue(new Error('Redis unavailable'))
-
-		const result = await handler.postPropsToChannel(
-			'guild-1',
-			[prop],
-			'nba',
-			'channel-1',
-		)
-		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
-		expect(mocks.sendToChannel).not.toHaveBeenCalled()
-		expect(mocks.logger.error).toHaveBeenCalledWith(
+		expect(result).toMatchObject({ posted: 0, filtered: 0, failed: 1 })
+		expect(result.failures).toEqual([
 			expect.objectContaining({
-				event: 'props_delivery_marker_write_failed',
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				outcome_uuids: [prop.over.outcome_uuid, prop.under.outcome_uuid],
+				error: 'Discord unavailable',
 			}),
+		])
+		expect(mocks.del).toHaveBeenCalledWith(deliveryKey)
+	})
+
+	it('shortens a failed claim when Redis release fails', async () => {
+		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
+		mocks.del.mockRejectedValueOnce(new Error('Redis unavailable'))
+
+		await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
 		)
+
+		expect(mocks.setex).toHaveBeenLastCalledWith(deliveryKey, 5, 'processing')
+	})
+
+	it('persists a sent ledger with plain SET when SETEX fails', async () => {
+		mocks.set.mockReset()
+		mocks.set.mockResolvedValueOnce('OK').mockResolvedValueOnce('OK')
+		mocks.setex.mockRejectedValueOnce(new Error('Redis command unavailable'))
+
+		await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(mocks.set).toHaveBeenLastCalledWith(
+			deliveryKey,
+			expect.stringContaining('"status":"sent"'),
+		)
+	})
+
+	it('leaves a retry marker when claim release commands fail', async () => {
+		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
+		mocks.del.mockRejectedValueOnce(new Error('Redis unavailable'))
+		mocks.setex.mockRejectedValueOnce(new Error('Redis unavailable'))
+
+		await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(mocks.set).toHaveBeenLastCalledWith(deliveryKey, 'retry')
+	})
+
+	it('reports a marker persistence failure after Discord accepts the message', async () => {
+		mocks.set.mockReset()
+		mocks.set.mockResolvedValueOnce('OK').mockRejectedValueOnce(new Error('Redis unavailable'))
+		mocks.setex.mockRejectedValueOnce(new Error('Redis unavailable'))
+
+		const result = await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toMatchObject({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(result.results).toEqual([])
+		expect(result.failures).toEqual([
+			expect.objectContaining({
+				guild_id: 'guild-1',
+				channel_id: 'channel-1',
+				outcome_uuids: [prop.over.outcome_uuid, prop.under.outcome_uuid],
+				error:
+					'Discord message posted but durable delivery marker was unavailable',
+			}),
+		])
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+		expect(mocks.del).not.toHaveBeenCalled()
 	})
 })

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -1,0 +1,218 @@
+import type { ProcessedPropDto } from '@pluto-khronos/api-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	get: vi.fn(),
+	set: vi.fn(),
+	setex: vi.fn(),
+	del: vi.fn(),
+	eval: vi.fn(),
+	sendToChannel: vi.fn(),
+	sendToPredictionChannel: vi.fn(),
+	getTeamInfo: vi.fn(),
+	logger: { error: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('../../api/Khronos/guild/guild-wrapper.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return {
+			sendToChannel: mocks.sendToChannel,
+			sendToPredictionChannel: mocks.sendToPredictionChannel,
+		}
+	}),
+}))
+
+vi.mock('../../common/TeamInfo.js', () => ({
+	default: vi.fn().mockImplementation(function () {
+		return { getTeamInfo: mocks.getTeamInfo }
+	}),
+}))
+
+vi.mock('../../cache/redis-instance.js', () => ({
+	default: {
+		get: mocks.get,
+		set: mocks.set,
+		setex: mocks.setex,
+		del: mocks.del,
+		eval: mocks.eval,
+	},
+}))
+
+vi.mock('../../logging/WinstonLogger.js', () => ({ logger: mocks.logger }))
+
+const { PropPostingHandler } = await import('../PropPostingHandler.js')
+
+const prop = {
+	event_id: 'event-1',
+	commence_time: '2026-07-11T00:00:00Z',
+	home_team: 'Home',
+	away_team: 'Away',
+	sport_title: 'NBA',
+	market_key: 'player_points',
+	bookmaker_key: 'draftkings',
+	description: 'Player',
+	point: 20.5,
+	over: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440000',
+		outcome_name: 'Over',
+		price: -110,
+	},
+	under: {
+		outcome_uuid: '550e8400-e29b-41d4-a716-446655440001',
+		outcome_name: 'Under',
+		price: -110,
+	},
+} as ProcessedPropDto
+
+describe('PropPostingHandler delivery idempotency', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.get.mockResolvedValue(null)
+		mocks.set.mockResolvedValue('OK')
+		mocks.setex.mockResolvedValue('OK')
+		mocks.eval.mockResolvedValue('OK')
+		mocks.del.mockResolvedValue(1)
+		mocks.sendToChannel.mockResolvedValue(undefined)
+		mocks.getTeamInfo.mockResolvedValue({
+			color: 0x123456,
+			resolvedTeamData: { abbrev: 'HOM' },
+		})
+	})
+
+	it('does not repost a prop already delivered to the same destination', async () => {
+		const handler = new PropPostingHandler()
+
+		const first = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		mocks.get.mockResolvedValue('sent')
+		const second = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(first).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(second).toEqual({ posted: 0, filtered: 1, failed: 0, total: 1 })
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+	})
+
+	it('releases the delivery claim when posting fails so a retry can proceed', async () => {
+		const handler = new PropPostingHandler()
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(mocks.del).toHaveBeenCalledWith(
+			'props:delivery:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+		)
+	})
+
+	it('does not send when a durable delivery claim cannot be created', async () => {
+		const handler = new PropPostingHandler()
+		mocks.set.mockRejectedValueOnce(new Error('Redis unavailable'))
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		mocks.set.mockResolvedValue('OK')
+		const retry = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(retry).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+		expect(mocks.logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'props_delivery_idempotency_unavailable',
+			}),
+		)
+	})
+
+	it('allows an interrupted processing claim to retry after its lease expires', async () => {
+		const handler = new PropPostingHandler()
+		mocks.get.mockResolvedValueOnce('processing')
+
+		const inFlight = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		mocks.get.mockResolvedValueOnce(null)
+		const retry = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(inFlight).toEqual({
+			posted: 0,
+			filtered: 1,
+			failed: 0,
+			total: 1,
+		})
+		expect(retry).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
+	})
+
+	it('reclaims a retry marker with an atomic Redis transition', async () => {
+		const handler = new PropPostingHandler()
+		mocks.get.mockResolvedValueOnce('retry')
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toEqual({ posted: 1, filtered: 0, failed: 0, total: 1 })
+		expect(mocks.eval).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('get', KEYS[1]) == 'retry'"),
+			1,
+			expect.stringContaining('props:delivery:guild-1:channel-1'),
+			'processing',
+			300,
+		)
+	})
+
+	it('does not send when the durable sent reservation cannot be persisted', async () => {
+		const handler = new PropPostingHandler()
+		mocks.setex.mockRejectedValue(new Error('Redis unavailable'))
+
+		const result = await handler.postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+		expect(result).toEqual({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(mocks.sendToChannel).not.toHaveBeenCalled()
+		expect(mocks.logger.error).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: 'props_delivery_marker_write_failed',
+			}),
+		)
+	})
+})

--- a/src/utils/props/__tests__/PropPostingHandler.test.ts
+++ b/src/utils/props/__tests__/PropPostingHandler.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
 	set: vi.fn(),
 	setex: vi.fn(),
 	del: vi.fn(),
-	eval: vi.fn(),
+	transitionIfValue: vi.fn(),
 	sendToChannel: vi.fn(),
 	sendToPredictionChannel: vi.fn(),
 	getTeamInfo: vi.fn(),
@@ -34,7 +34,7 @@ vi.mock('../../cache/redis-instance.js', () => ({
 		set: mocks.set,
 		setex: mocks.setex,
 		del: mocks.del,
-		eval: mocks.eval,
+		transitionIfValue: mocks.transitionIfValue,
 	},
 }))
 
@@ -88,7 +88,7 @@ describe('PropPostingHandler message references and idempotency', () => {
 		mocks.get.mockResolvedValue(null)
 		mocks.set.mockResolvedValue('OK')
 		mocks.setex.mockResolvedValue('OK')
-		mocks.eval.mockResolvedValue('OK')
+		mocks.transitionIfValue.mockResolvedValue(true)
 		mocks.del.mockResolvedValue(1)
 		mocks.sendToChannel.mockResolvedValue(sentMessage)
 		mocks.sendToPredictionChannel.mockResolvedValue(sentMessage)
@@ -117,6 +117,36 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'channel-1',
 			expect.objectContaining({ embeds: expect.any(Array) }),
 			'guild-1',
+		)
+	})
+
+	it('uses a deterministic Discord nonce for durable prop-post retries', async () => {
+		const result = await new PropPostingHandler().postPropPair(
+			'guild-1',
+			'channel-1',
+			prop,
+			'nba',
+			'550e8400-e29b-41d4-a716-446655440010',
+			'prop-post:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+		)
+
+		expect(result).toEqual(references)
+		const firstOptions = mocks.sendToChannel.mock.calls[0][1]
+		expect(firstOptions).toMatchObject({
+			enforceNonce: true,
+			nonce: expect.stringMatching(/^[0-9a-f]{25}$/),
+		})
+		mocks.sendToChannel.mockClear()
+		await new PropPostingHandler().postPropPair(
+			'guild-1',
+			'channel-1',
+			prop,
+			'nba',
+			'550e8400-e29b-41d4-a716-446655440010',
+			'prop-post:guild-1:channel-1:550e8400-e29b-41d4-a716-446655440000:550e8400-e29b-41d4-a716-446655440001',
+		)
+		expect(mocks.sendToChannel.mock.calls[0][1].nonce).toBe(
+			firstOptions.nonce,
 		)
 	})
 
@@ -163,6 +193,23 @@ describe('PropPostingHandler message references and idempotency', () => {
 
 		expect(result).toMatchObject({ posted: 1, filtered: 0, failed: 0 })
 		expect(result.results).toEqual(references)
+		expect(mocks.sendToChannel).not.toHaveBeenCalled()
+	})
+
+	it('fails closed on an unknown legacy marker instead of reposting', async () => {
+		mocks.get.mockResolvedValue(JSON.stringify({ status: 'complete' }))
+
+		const result = await new PropPostingHandler().postPropsToChannel(
+			'guild-1',
+			[prop],
+			'nba',
+			'channel-1',
+		)
+
+		expect(result).toMatchObject({ posted: 0, failed: 1, filtered: 0 })
+		expect(result.failures[0]?.error).toMatch(
+			/unknown legacy delivery marker/i,
+		)
 		expect(mocks.sendToChannel).not.toHaveBeenCalled()
 	})
 
@@ -214,10 +261,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 
 		expect(result.posted).toBe(1)
 		expect(result.results).toEqual(references)
-		expect(mocks.eval).toHaveBeenCalledWith(
-			expect.stringContaining("redis.call('get', KEYS[1]) == 'retry'"),
-			1,
+		expect(mocks.transitionIfValue).toHaveBeenCalledWith(
 			deliveryKey,
+			'retry',
 			'processing',
 			7 * 24 * 60 * 60,
 		)
@@ -241,7 +287,12 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'channel-1',
 		)
 
-		expect(result).toMatchObject({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(result).toMatchObject({
+			posted: 0,
+			filtered: 0,
+			failed: 1,
+			total: 1,
+		})
 		expect(retry.posted).toBe(1)
 		expect(retry.results).toEqual(references)
 		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)
@@ -253,7 +304,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 	})
 
 	it('keeps partial failures explicit and releases failed claims', async () => {
-		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
 
 		const result = await new PropPostingHandler().postPropsToChannel(
 			'guild-1',
@@ -267,7 +320,10 @@ describe('PropPostingHandler message references and idempotency', () => {
 			expect.objectContaining({
 				guild_id: 'guild-1',
 				channel_id: 'channel-1',
-				outcome_uuids: [prop.over.outcome_uuid, prop.under.outcome_uuid],
+				outcome_uuids: [
+					prop.over.outcome_uuid,
+					prop.under.outcome_uuid,
+				],
 				error: 'Discord unavailable',
 			}),
 		])
@@ -275,7 +331,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 	})
 
 	it('shortens a failed claim when Redis release fails', async () => {
-		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
 		mocks.del.mockRejectedValueOnce(new Error('Redis unavailable'))
 
 		await new PropPostingHandler().postPropsToChannel(
@@ -285,13 +343,19 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'channel-1',
 		)
 
-		expect(mocks.setex).toHaveBeenLastCalledWith(deliveryKey, 5, 'processing')
+		expect(mocks.setex).toHaveBeenLastCalledWith(
+			deliveryKey,
+			5,
+			'processing',
+		)
 	})
 
 	it('persists a sent ledger with plain SET when SETEX fails', async () => {
 		mocks.set.mockReset()
 		mocks.set.mockResolvedValueOnce('OK').mockResolvedValueOnce('OK')
-		mocks.setex.mockRejectedValueOnce(new Error('Redis command unavailable'))
+		mocks.setex.mockRejectedValueOnce(
+			new Error('Redis command unavailable'),
+		)
 
 		await new PropPostingHandler().postPropsToChannel(
 			'guild-1',
@@ -307,7 +371,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 	})
 
 	it('leaves a retry marker when claim release commands fail', async () => {
-		mocks.sendToChannel.mockRejectedValueOnce(new Error('Discord unavailable'))
+		mocks.sendToChannel.mockRejectedValueOnce(
+			new Error('Discord unavailable'),
+		)
 		mocks.del.mockRejectedValueOnce(new Error('Redis unavailable'))
 		mocks.setex.mockRejectedValueOnce(new Error('Redis unavailable'))
 
@@ -323,7 +389,9 @@ describe('PropPostingHandler message references and idempotency', () => {
 
 	it('reports a marker persistence failure after Discord accepts the message', async () => {
 		mocks.set.mockReset()
-		mocks.set.mockResolvedValueOnce('OK').mockRejectedValueOnce(new Error('Redis unavailable'))
+		mocks.set
+			.mockResolvedValueOnce('OK')
+			.mockRejectedValueOnce(new Error('Redis unavailable'))
 		mocks.setex.mockRejectedValueOnce(new Error('Redis unavailable'))
 
 		const result = await new PropPostingHandler().postPropsToChannel(
@@ -333,15 +401,22 @@ describe('PropPostingHandler message references and idempotency', () => {
 			'channel-1',
 		)
 
-		expect(result).toMatchObject({ posted: 0, filtered: 0, failed: 1, total: 1 })
+		expect(result).toMatchObject({
+			posted: 0,
+			filtered: 0,
+			failed: 1,
+			total: 1,
+		})
 		expect(result.results).toEqual([])
 		expect(result.failures).toEqual([
 			expect.objectContaining({
 				guild_id: 'guild-1',
 				channel_id: 'channel-1',
-				outcome_uuids: [prop.over.outcome_uuid, prop.under.outcome_uuid],
-				error:
-					'Discord message posted but durable delivery marker was unavailable',
+				outcome_uuids: [
+					prop.over.outcome_uuid,
+					prop.under.outcome_uuid,
+				],
+				error: 'Discord message posted but durable delivery marker was unavailable',
 			}),
 		])
 		expect(mocks.sendToChannel).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Promote parlays audit remediation into `main`

Merges `dev/parlays-props` (including squash of #579) into `main` with conflict resolution against recent Alloy/Loki observability changes (#581).

- Keeps optional Loki env (Alloy stdout path)
- Keeps hermetic `PLUTO_SYSTEM_MODE` / `PLUTO_SYSTEM_ALLOW` gates

Cross-links: Khronos #692 / #699, Goracle #50 / #54, TF-1036.

No production worker enablement beyond landing code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b6a26ad-2dd3-42c2-b071-17e21b581870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b6a26ad-2dd3-42c2-b071-17e21b581870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

