### PR TITLE
docs: durable notification ADRs + Khronos client-update CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Pluto powers the betting experience for some of Discord's largest sports communi
 
 Pluto's autonomous betting lifecycle — from odds ingestion to bet settlement — is powered by a distributed microservices architecture:
 
+For current architecture notes and cross-service context, start with the [Pluto docs hub](docs/README.md) and the [Khronos cross-service overview](https://github.com/fearandesire/khronos/blob/main/docs/architecture/cross-service-overview.md).
+
 ```mermaid
 flowchart LR
     subgraph Client ["Pluto Client (Open Source)"]
@@ -132,6 +134,13 @@ flowchart LR
 
 > [!NOTE]
 > This repository contains only the open-source Discord bot client; backend services remain private.
+
+Architecture references:
+
+- [ADR 001: Durable notification receiver](docs/architecture/decisions/001-durable-notification-receiver.md)
+- [ADR 002: Atomic cache operations](docs/architecture/decisions/002-atomic-cache-operations.md)
+- [Durable notification receiver feature guide](docs/features/durable-notification-receiver.md)
+- [Khronos client update CI](docs/ci-cd-khronos-client-update.md)
 
 ## Tech Stack
 
@@ -255,9 +264,13 @@ The script tars `assets/matchupimages/`, uploads to `s3://pluto-assets/matchupim
 
 ## Documentation
 
-For comprehensive guides, API references, and configuration details:
-
-**[Pluto Documentation](https://docs.pluto.fearandesire.com)**
+- [Pluto docs hub](docs/README.md)
+- [ADR 001: Durable notification receiver](docs/architecture/decisions/001-durable-notification-receiver.md)
+- [ADR 002: Atomic cache operations](docs/architecture/decisions/002-atomic-cache-operations.md)
+- [Durable notification receiver feature guide](docs/features/durable-notification-receiver.md)
+- [Khronos client update CI](docs/ci-cd-khronos-client-update.md)
+- [Khronos cross-service overview](https://github.com/fearandesire/khronos/blob/main/docs/architecture/cross-service-overview.md)
+- [Hosted Pluto Documentation](https://docs.pluto.fearandesire.com)
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Pluto documentation
+
+This docs tree captures Pluto client architecture notes, operational guides, and cross-service release details that are too specific for the root README.
+
+## Architecture decisions
+
+- [ADR 001: Durable notification receiver](architecture/decisions/001-durable-notification-receiver.md)
+- [ADR 002: Atomic cache operations](architecture/decisions/002-atomic-cache-operations.md)
+
+## Feature guides
+
+- [Durable notification receiver](features/durable-notification-receiver.md)
+
+## CI/CD
+
+- [Khronos client update workflow](ci-cd-khronos-client-update.md)
+- [Khronos release cascade](https://github.com/fearandesire/khronos/blob/main/docs/ci-cd-release-cascade.md)
+
+## Cross-service context
+
+- [Khronos cross-service overview](https://github.com/fearandesire/khronos/blob/main/docs/architecture/cross-service-overview.md)

--- a/docs/architecture/decisions/001-durable-notification-receiver.md
+++ b/docs/architecture/decisions/001-durable-notification-receiver.md
@@ -1,0 +1,38 @@
+# ADR 001: Durable notification receiver
+
+- Status: Accepted
+- Date: 2026-07-15
+- Source: `src/utils/api/routes/notifications/delivery-store.ts`, `src/utils/api/routes/notifications/delivery-queue.ts`
+
+## Context
+
+Khronos sends notification callbacks to Pluto for Discord fanout. The receiver has to be safe when Khronos retries a callback, Pluto restarts, Redis/BullMQ acknowledge ambiguously, or Discord is temporarily unavailable.
+
+The important requirement is durability before fanout: Pluto must remember that a delivery was accepted and enqueue work before returning success to Khronos. Discord delivery then happens asynchronously from the durable queue.
+
+## Decision
+
+Pluto stores every delivery under Redis key prefix `pluto:delivery:v1:` with a 180 day TTL and enqueues accepted delivery envelopes to BullMQ queue `notification-delivery-v1`.
+
+For a new `delivery_id`, Pluto:
+
+1. Builds a delivery record with state `queued` and per-destination state `queued`.
+2. Writes the record to Redis with `NX` and `EX` retention.
+3. Adds a BullMQ job named `deliver` using `delivery_id` as the stable `jobId`.
+4. Returns HTTP `202` after the durable store/queue accept path completes, before Discord fanout.
+
+This is not fire-and-forget after Discord. The HTTP response acknowledges durable acceptance into Pluto, not final Discord delivery.
+
+For a repeated `delivery_id`, Pluto compares a stable SHA-256 payload hash:
+
+- Same payload hash: treat as duplicate and return the existing delivery record.
+- Different payload hash: reject with conflict (`DELIVERY_PAYLOAD_MISMATCH`, HTTP `409`).
+
+If an accepted or duplicate record is still `queued` or `retryable_failed`, the receiver may re-enqueue the BullMQ job. This is safe because BullMQ uses `delivery_id` as the stable job id.
+
+## Consequences
+
+- Khronos can retry callbacks with the same delivery id without causing duplicate Discord fanout for already completed destinations.
+- A reused delivery id with a different payload fails loudly instead of overwriting history.
+- Operators can inspect delivery state for up to 180 days.
+- HTTP `202` means "accepted for durable delivery", not "all Discord messages are delivered".

--- a/docs/architecture/decisions/002-atomic-cache-operations.md
+++ b/docs/architecture/decisions/002-atomic-cache-operations.md
@@ -1,0 +1,34 @@
+# ADR 002: Atomic cache operations
+
+- Status: Accepted
+- Date: 2026-07-15
+- Source: `src/utils/cache/redis-instance.ts`, `src/utils/cache/__tests__/redis-atomic-contract.ts`
+
+## Context
+
+Pluto uses Redis for coordination primitives such as reservations, ownership checks, and lock-like delivery state transitions. These operations must be correct under concurrency; the point is not merely to cache values for performance.
+
+A naive read-then-write sequence can remove another worker's lock, refresh a lease no longer owned by the caller, or overwrite a state that changed between commands.
+
+## Decision
+
+`src/utils/cache/redis-instance.ts` exposes typed atomic operations on `RedisCacheClient`:
+
+- `compareAndRemove(key, expectedValue)`: delete a key only when the current value still matches the expected owner/value.
+- `refreshIfOwned(key, expectedValue, seconds)`: extend expiry only when the caller still owns the value.
+- `transitionIfValue(key, expectedValue, nextValue, seconds?)`: move a value to the next state only if it is still in the expected state, preserving TTL unless a replacement TTL is supplied.
+
+The production Redis implementation uses Lua scripts so each operation is evaluated atomically by Redis. The in-memory implementation mirrors the same contract for tests and mock mode.
+
+## Verification
+
+`src/utils/cache/__tests__/redis-atomic-contract.ts` defines the shared contract. It is run against both implementations:
+
+- Real Redis through `createAtomicRedisClient` in `src/utils/cache/__tests__/redis-atomic.integration.test.ts`.
+- In-memory Redis in `src/utils/cache/__tests__/redis-instance.test.ts`.
+
+## Consequences
+
+- Reservation and lock correctness does not depend on timing between separate `GET`, `DEL`, `EXPIRE`, or `SET` calls.
+- Test fixtures exercise the same behavioral contract as production Redis.
+- Callers should use these typed operations for ownership-sensitive state changes instead of raw Redis command sequences.

--- a/docs/ci-cd-khronos-client-update.md
+++ b/docs/ci-cd-khronos-client-update.md
@@ -1,0 +1,94 @@
+# Khronos client update workflow
+
+Pluto updates `@pluto-khronos/api-client` and `@pluto-khronos/types` through `.github/workflows/khronos-client-update.yml`.
+
+Related Khronos docs:
+
+- [Khronos release cascade](https://github.com/fearandesire/khronos/blob/main/docs/ci-cd-release-cascade.md)
+
+## Trigger
+
+The workflow runs on `repository_dispatch` with event type `khronos-release`.
+
+Expected dispatch payload:
+
+- `client_payload.khronos_version`: required npm version for both packages.
+- `client_payload.sha`: Khronos source commit, linked in the generated PR body.
+
+Khronos sends this dispatch after publishing the matching `@pluto-khronos/api-client` and `@pluto-khronos/types` packages.
+
+## Branch and PR behavior
+
+The workflow always uses the static branch `deps/khronos-update`.
+
+That static branch is intentional: if Khronos publishes again while an earlier update PR is still open, re-dispatch updates the same branch and PR instead of opening duplicate dependency PRs.
+
+If `package.json` and `pnpm-lock.yaml` do not change, the workflow logs that Pluto is already on the requested version and does not open a PR.
+
+## Verification gate
+
+The workflow bumps both Khronos packages in lockstep, installs dependencies, then runs:
+
+```bash
+pnpm typecheck
+pnpm build
+pnpm test:run
+```
+
+The verify step is `continue-on-error: true` so the workflow can still open a PR when consumer fixes are needed.
+
+PR state depends on the verify outcome:
+
+- Verify failed: open or update the PR as a draft.
+- Verify green: open or update the PR ready for review.
+
+There is no auto-merge. A human reviews the dependency diff, checks API/schema impact, and merges manually.
+
+## Finding and reviewing the PR
+
+Find the active update PR:
+
+```bash
+gh pr list --head deps/khronos-update --state open
+```
+
+Read the PR and changed files:
+
+```bash
+gh pr view <number>
+gh pr diff <number>
+```
+
+Read workflow status and logs:
+
+```bash
+gh pr view <number> --json isDraft,body,statusCheckRollup
+gh run list --workflow "Khronos client update" --branch deps/khronos-update
+gh run view <run-id> --log
+```
+
+Review checklist:
+
+1. Confirm both `@pluto-khronos/api-client` and `@pluto-khronos/types` moved to the same Khronos version.
+2. Check the linked Khronos commit and release notes for API or schema changes.
+3. Inspect Pluto compile/test failures if the PR is draft.
+4. Look for generated client API changes that require call-site updates in Pluto.
+5. Merge manually only after the dependency diff and verification result are acceptable.
+
+## Release-please commit override
+
+The generated PR body includes:
+
+```text
+BEGIN_COMMIT_OVERRIDE
+fix(khronos): bump @pluto-khronos/* to <version>
+END_COMMIT_OVERRIDE
+```
+
+This tells release-please to classify the eventual squash merge as `fix(khronos)` instead of `deps(khronos)`, producing a patch release and a changelog entry under fixes/updates.
+
+## Recovery
+
+If Pluto did not receive or process a Khronos release dispatch, recover from Khronos by rerunning or repairing the dispatch workflow in `.github/workflows/pluto-dispatch.yml`.
+
+After redispatch, confirm that Pluto updated the static `deps/khronos-update` branch and that the PR body points at the expected Khronos version and commit.

--- a/docs/features/durable-notification-receiver.md
+++ b/docs/features/durable-notification-receiver.md
@@ -1,0 +1,114 @@
+# Durable notification receiver
+
+Pluto accepts Khronos notification delivery envelopes, persists their delivery state in Redis, and fans out to Discord from BullMQ workers. The HTTP receiver returns `202 Accepted` once the delivery is durably stored and queued; Discord fanout happens after that response.
+
+All routes are mounted without an additional API prefix. The Koa app-level API key middleware requires `X-API-Key` or `apiKey` unless a route is explicitly exempted.
+
+## Hard values
+
+| Value | Setting | Source |
+| --- | --- | --- |
+| Redis key prefix | `pluto:delivery:v1:` | `src/utils/api/routes/notifications/delivery-store.ts` |
+| Retention | 180 days (`180 * 24 * 60 * 60` seconds) | `src/utils/api/routes/notifications/delivery-store.ts` |
+| BullMQ queue | `notification-delivery-v1` | `src/utils/api/routes/notifications/delivery-queue.ts` |
+| BullMQ job name | `deliver` | `src/utils/api/routes/notifications/delivery-queue.ts` |
+| BullMQ job id | `delivery_id` | `src/utils/api/routes/notifications/delivery-queue.ts` |
+
+## Delivery envelope
+
+Durable receivers expect `schema_version: 1`, a UUID `delivery_id`, an RFC 3339 `occurred_at`, a `kind`, and a kind-specific payload.
+
+Supported durable kinds:
+
+- `parlay_result`
+- `prop_settled`
+- `prop_post`
+
+A stable payload hash is computed from `schema_version`, `kind`, `occurred_at`, and `payload`. Reusing a `delivery_id` with a different hash returns `409 DELIVERY_PAYLOAD_MISMATCH`.
+
+## Endpoints
+
+All mounted endpoints can return `401` from the app-level API-key middleware when `X-API-Key` or `apiKey` is missing or invalid.
+
+### `POST /notifications/parlays/results`
+
+Accepts durable `parlay_result` envelopes.
+
+| Status | Meaning |
+| --- | --- |
+| `202` | Delivery was stored and queued. Response body includes `delivery_id` and `status`. |
+| `409` | The same `delivery_id` already exists for a different payload (`DELIVERY_PAYLOAD_MISMATCH`). |
+| `422` | A request containing `delivery_id` failed delivery envelope validation. Legacy non-envelope validation failures also return `422`. |
+| `503` | Pluto could not persist or enqueue the delivery. |
+
+Legacy non-envelope parlay payloads are still processed synchronously by the route.
+
+### `POST /notifications/props/settled`
+
+Accepts durable `prop_settled` envelopes and has a route-local API-key guard in addition to the app-level middleware.
+
+| Status | Meaning |
+| --- | --- |
+| `202` | Delivery was stored and queued. Response body includes `delivery_id` and `status`. |
+| `409` | The same `delivery_id` already exists for a different payload (`DELIVERY_PAYLOAD_MISMATCH`). |
+| `422` | A request containing `delivery_id` failed delivery envelope validation. Legacy non-envelope validation failures also return `422`. |
+| `503` | Pluto could not persist or enqueue the delivery. |
+
+Legacy non-envelope prop settlement payloads are still processed synchronously by the route.
+
+### `POST /props/daily`
+
+Accepts durable `prop_post` envelopes for daily prop posting.
+
+| Status | Meaning |
+| --- | --- |
+| `202` | Delivery was stored and queued. Response body includes `accepted`, `duplicate`, `delivery_id`, `kind`, `status`, and any prop-post `receipts` already present. |
+| `409` | The same `delivery_id` already exists for a different payload (`DELIVERY_PAYLOAD_MISMATCH`). |
+| `422` | Envelope or daily props payload validation failed, props/guilds were empty, or a guild sport was unsupported. |
+| `503` | Pluto could not persist or enqueue the prop-post delivery. |
+
+### `GET /deliveries/:delivery_id`
+
+Looks up a delivery by UUID and returns the persisted status view.
+
+| Status | Meaning |
+| --- | --- |
+| `200` | Delivery found. Response includes `delivery_id`, `kind`, `status`, `attempts`, `destinations`, optional prop-post `receipts`, and `delivered_at`. |
+| `404` | No delivery record exists for that id. |
+| `422` | `delivery_id` is missing or is not a UUID. |
+
+## States
+
+Delivery records and destinations use the same state vocabulary:
+
+| State | Meaning |
+| --- | --- |
+| `queued` | Accepted and waiting for BullMQ worker processing. |
+| `processing` | A worker is attempting delivery. |
+| `delivered` | All required destinations are delivered. For `prop_post`, required receipts must also be exact. |
+| `retryable_failed` | At least one destination failed transiently and BullMQ should retry. |
+| `permanent_failed` | Delivery cannot complete because one or more destinations failed permanently. |
+
+Destination ids are derived by kind:
+
+- `parlay_result`: `dm:<user_id>`
+- `prop_settled`: `prop:<guild_id>:<channel_id>:<message_id>`
+- `prop_post`: `prop-post:<guild_id>:<channel_id>:<over_outcome_uuid>:<under_outcome_uuid>`
+
+## Looking up a delivery
+
+Use the status endpoint when possible:
+
+```bash
+curl -sS \
+  -H "X-API-Key: $PLUTO_API_KEY" \
+  "https://<pluto-host>/deliveries/<delivery_id>"
+```
+
+For low-level Redis inspection, records are stored as JSON at:
+
+```text
+pluto:delivery:v1:<delivery_id>
+```
+
+A `202` receiver response only confirms durable acceptance. Use `GET /deliveries/:delivery_id` to verify final Discord delivery state.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Docs-only. Creates the in-repo `docs/` tree for durable notification receiving, atomic Redis cache ops, a feature guide, and the Khronos client-update cascade (`deps/khronos-update`, draft-vs-ready, **no auto-merge**). README now links Architecture + Documentation.

## Review focus
1. `docs/architecture/decisions/001-durable-notification-receiver.md` + `002-atomic-cache-operations.md`
2. `docs/features/durable-notification-receiver.md` — endpoints, Redis `pluto:delivery:v1:`, 180d, BullMQ `notification-delivery-v1`
3. `docs/ci-cd-khronos-client-update.md` — how to find/accept the bump PR

## Sibling docs PRs
- Khronos https://github.com/fearandesire/khronos/pull/703
- Goracle https://github.com/fearandesire/goracle/pull/55

## Out of scope
No package bump, no worker enablement. Links to Khronos hub/cascade may 404 on `main` until that docs PR merges (branch paths are already pushed).

## Linear
Living doc + TF-1036 refreshed; implementation children Done; XR-01/02/03 left open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b6a26ad-2dd3-42c2-b071-17e21b581870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b6a26ad-2dd3-42c2-b071-17e21b581870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

