### PR TITLE
ci: zero-touch cascade — Pluto side

### DIFF
--- a/.github/workflows/auto-merge-release-pr.yml
+++ b/.github/workflows/auto-merge-release-pr.yml
@@ -1,0 +1,48 @@
+# Auto-merge release-please PRs
+#
+# release-please (in release.yml) opens a `release-please--*` PR that bumps the
+# version + CHANGELOG. This workflow enables GitHub auto-merge (squash) on that
+# PR so it merges itself once the required `Verify` check passes — the second
+# half of the zero-touch cascade (the first half is khronos-client-update.yml).
+#
+# Merging the release PR to main fires release.yml's release-please step again,
+# which publishes the GitHub release, which triggers the Deploy job. No human
+# click is needed anywhere in the release path.
+#
+# Scope guard: only same-repo `release-please--*` head branches. Forks and
+# regular feature PRs are ignored. `pull_request` (not `_target`) is safe here
+# because release-please branches are always same-repo and need repo secrets.
+
+name: Auto-merge release PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.head_ref, 'release-please--') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Mint App token
+        uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.CASCADE_APP_ID }}
+          private-key: ${{ secrets.CASCADE_APP_PRIVATE_KEY }}
+          owner: fearandesire
+          repositories: Pluto-Betting-Bot
+
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -306,6 +306,7 @@ jobs:
       # (skips dry runs). Skipped silently if the webhook secret is not set.
       - name: Notify Discord — image pushed
         if: steps.deploy_mode.outputs.push == 'true'
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -333,6 +334,7 @@ jobs:
 
       - name: Notify Discord — failure
         if: failure()
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -342,6 +344,9 @@ jobs:
             echo "::notice::DISCORD_CICD_WEBHOOK not set — skipping notification"
             exit 0
           fi
+          # Version step may not have run if the job failed early; default it so
+          # the embed field is never empty (an empty value is a Discord 400).
+          VERSION="${VERSION:-unknown}"
           payload=$(jq -n \
             --arg version "$VERSION" \
             --arg runurl "$RUN_URL" \
@@ -350,7 +355,7 @@ jobs:
               color:15158332,fields:[
                {name:"Service",value:"Pluto",inline:true},
                {name:"Stage",value:"Deploy",inline:true},
-               {name:"Version",value:($version // "unknown"),inline:true},
+               {name:"Version",value:$version,inline:true},
                {name:"Run",value:$runurl,inline:false}
              ]}]}')
           curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -112,6 +112,11 @@ jobs:
       contents: read
       attestations: write
       id-token: write
+      # Required so GITHUB_TOKEN can push the image to GHCR (replaces the
+      # package-push scope that previously came from PLUTO_BOT_PAT). This ALSO
+      # requires the pluto-betting-bot GHCR package to grant this repo's Actions
+      # write access (human prereq H3) — otherwise the push 403s.
+      packages: write
 
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -175,8 +180,11 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.PLUTO_BOT_PAT }}
+          username: ${{ github.actor }}
+          # GITHUB_TOKEN (with packages: write above) replaces PLUTO_BOT_PAT.
+          # REQUIRES the pluto-betting-bot GHCR package to have granted this
+          # repo's Actions write access (human prereq H3).
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set lowercase image name
         run: |
@@ -293,3 +301,56 @@ jobs:
             echo "$QUICK_PULL"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Discord C3: green embed when the image was actually pushed to GHCR
+      # (skips dry runs). Skipped silently if the webhook secret is not set.
+      - name: Notify Discord — image pushed
+        if: steps.deploy_mode.outputs.push == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
+          VERSION: ${{ steps.version.outputs.version }}
+          IMAGE_TAG: ${{ steps.version.outputs.version }}-${{ steps.version.outputs.short_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ -z "$DISCORD_WEBHOOK" ]]; then
+            echo "::notice::DISCORD_CICD_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg version "$VERSION" \
+            --arg imagetag "$IMAGE_TAG" \
+            --arg runurl "$RUN_URL" \
+            '{embeds:[{title:"🟢 Pluto image pushed to GHCR",
+              description:"Deploy built and pushed a new image.",
+              color:3066993,fields:[
+               {name:"Service",value:"Pluto",inline:true},
+               {name:"Stage",value:"Deploy",inline:true},
+               {name:"Version",value:$version,inline:true},
+               {name:"Image tag",value:("`" + $imagetag + "`"),inline:false},
+               {name:"Run",value:$runurl,inline:false}
+             ]}]}')
+          curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
+
+      - name: Notify Discord — failure
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
+          VERSION: ${{ steps.version.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ -z "$DISCORD_WEBHOOK" ]]; then
+            echo "::notice::DISCORD_CICD_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg version "$VERSION" \
+            --arg runurl "$RUN_URL" \
+            '{embeds:[{title:"🔴 Pluto deploy failed",
+              description:"The Deploy job errored before pushing the image.",
+              color:15158332,fields:[
+               {name:"Service",value:"Pluto",inline:true},
+               {name:"Stage",value:"Deploy",inline:true},
+               {name:"Version",value:($version // "unknown"),inline:true},
+               {name:"Run",value:$runurl,inline:false}
+             ]}]}')
+          curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/khronos-client-update.yml
+++ b/.github/workflows/khronos-client-update.yml
@@ -165,16 +165,21 @@ jobs:
         if: steps.diff.outputs.has_changes == 'true' && steps.verify.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          gh pr merge --auto --squash \
-            -R "${{ github.repository }}" \
-            "${{ steps.cpr.outputs.pull-request-number }}"
+          # A prior verify-failed dispatch may have left this static-branch PR
+          # in draft; create-pull-request does not un-draft on update. Mark it
+          # ready first (no-op if already ready) so --auto doesn't error on a
+          # draft.
+          gh pr ready "$PR" -R "${{ github.repository }}"
+          gh pr merge --auto --squash -R "${{ github.repository }}" "$PR"
 
       # Discord C3: one embed announcing the bump PR. Green = auto-merging,
       # yellow = draft awaiting a human. Skipped silently if the webhook secret
       # is not populated yet.
       - name: Notify Discord — bump PR
         if: steps.diff.outputs.has_changes == 'true'
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
           VERIFY: ${{ steps.verify.outcome }}
@@ -215,6 +220,7 @@ jobs:
       # PR creation failed, etc.) — distinct from a controlled verify failure.
       - name: Notify Discord — failure
         if: failure()
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
           VERSION: ${{ github.event.client_payload.khronos_version }}
@@ -224,6 +230,9 @@ jobs:
             echo "::notice::DISCORD_CICD_WEBHOOK not set — skipping notification"
             exit 0
           fi
+          # Shell default guards the empty-string case (jq's // only catches
+          # null/false); an empty embed field value is a Discord 400.
+          VERSION="${VERSION:-unknown}"
           payload=$(jq -n \
             --arg version "$VERSION" \
             --arg runurl "$RUN_URL" \
@@ -232,7 +241,7 @@ jobs:
               color:15158332,fields:[
                {name:"Service",value:"Pluto",inline:true},
                {name:"Stage",value:"Khronos bump",inline:true},
-               {name:"Version",value:($version // "unknown"),inline:true},
+               {name:"Version",value:$version,inline:true},
                {name:"Run",value:$runurl,inline:false}
              ]}]}')
           curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/khronos-client-update.yml
+++ b/.github/workflows/khronos-client-update.yml
@@ -11,7 +11,17 @@
 #   2. Bump BOTH @pluto-khronos/api-client AND @pluto-khronos/types in lockstep
 #   3. Verify: pnpm typecheck && pnpm build && pnpm test:run
 #   4. Open PR — DRAFT if verify failed; ready-for-review if green
-#   5. Human reviews + clicks merge (NO auto-merge)
+#   5a. Verify green: enable GitHub auto-merge (squash). The PR merges itself
+#       once the required checks pass (Verify + Validate PR title). No human
+#       click required — this is the "zero-touch" happy path.
+#   5b. Verify red: PR stays DRAFT and is NEVER auto-merged. A human fixes the
+#       consumers in the branch, marks ready, and merges manually.
+#
+# All git-writing steps (checkout, create-pull-request, gh pr merge) use a
+# short-lived GitHub App token minted from the `fnx-cascade-bot` App
+# (CASCADE_APP_ID / CASCADE_APP_PRIVATE_KEY) instead of PLUTO_BOT_PAT. An
+# App-token-created PR still fires normal `pull_request` events, so the
+# required checks run and gate the auto-merge.
 #
 # Re-dispatch behavior: uses a static branch name (`deps/khronos-update`),
 # so a newer release updates the existing PR rather than opening a duplicate
@@ -55,10 +65,19 @@ jobs:
           echo "📦 Bumping @pluto-khronos/api-client + @pluto-khronos/types to $KHRONOS_VERSION"
           echo "🔗 Khronos commit: $KHRONOS_SHA"
 
+      - name: Mint App token
+        uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.CASCADE_APP_ID }}
+          private-key: ${{ secrets.CASCADE_APP_PRIVATE_KEY }}
+          owner: fearandesire
+          repositories: Pluto-Betting-Bot
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PLUTO_BOT_PAT }}
+          token: ${{ steps.app.outputs.token }}
           fetch-depth: 0
 
       - name: Install pnpm
@@ -107,7 +126,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PLUTO_BOT_PAT }}
+          token: ${{ steps.app.outputs.token }}
           branch: deps/khronos-update
           delete-branch: false
           title: "deps(khronos): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}"
@@ -128,7 +147,7 @@ jobs:
             ## Quality gate
             **Verify (typecheck + build + test):** `${{ steps.verify.outcome }}`
 
-            ${{ steps.verify.outcome == 'failure' && '⚠️ Opened as DRAFT — fix consumers in this branch before marking ready. Then merge manually.' || '✅ All checks passed — ready for review. Click merge when you''ve scanned the diff.' }}
+            ${{ steps.verify.outcome == 'failure' && '⚠️ Opened as DRAFT — fix consumers in this branch before marking ready. Then merge manually.' || '✅ Verify passed — auto-merge (squash) is enabled. This PR merges itself once the required checks (Verify + Validate PR title) are green.' }}
 
             BEGIN_COMMIT_OVERRIDE
             fix(khronos): bump @pluto-khronos/* to ${{ github.event.client_payload.khronos_version }}
@@ -137,3 +156,83 @@ jobs:
             dependencies
             automated
             khronos-bump
+
+      # Zero-touch happy path: verify green ⇒ let GitHub squash-merge the PR
+      # once the required checks pass. Draft (verify-failed) PRs are excluded
+      # by the verify.outcome guard, and GitHub refuses --auto on a draft
+      # anyway, so a red bump can never auto-merge.
+      - name: Enable auto-merge on green
+        if: steps.diff.outputs.has_changes == 'true' && steps.verify.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+        run: |
+          gh pr merge --auto --squash \
+            -R "${{ github.repository }}" \
+            "${{ steps.cpr.outputs.pull-request-number }}"
+
+      # Discord C3: one embed announcing the bump PR. Green = auto-merging,
+      # yellow = draft awaiting a human. Skipped silently if the webhook secret
+      # is not populated yet.
+      - name: Notify Discord — bump PR
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
+          VERIFY: ${{ steps.verify.outcome }}
+          VERSION: ${{ github.event.client_payload.khronos_version }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ -z "$DISCORD_WEBHOOK" ]]; then
+            echo "::notice::DISCORD_CICD_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          if [[ "$VERIFY" == "success" ]]; then
+            COLOR=3066993   # green 0x2ecc71
+            TITLE="🟢 Khronos bump — auto-merging"
+            DESC="Verify passed. Auto-merge (squash) is enabled; the PR merges once required checks are green."
+          else
+            COLOR=15844367  # yellow 0xf1c40f
+            TITLE="🟡 Khronos bump — DRAFT, needs you"
+            DESC="Verify failed. PR opened as a draft — fix the consumers, mark ready, and merge manually."
+          fi
+          payload=$(jq -n \
+            --arg title "$TITLE" \
+            --arg desc "$DESC" \
+            --arg version "$VERSION" \
+            --arg prurl "$PR_URL" \
+            --arg runurl "$RUN_URL" \
+            --argjson color "$COLOR" \
+            '{embeds:[{title:$title,description:$desc,color:$color,fields:[
+               {name:"Service",value:"Pluto",inline:true},
+               {name:"Stage",value:"Khronos bump",inline:true},
+               {name:"Version",value:$version,inline:true},
+               {name:"Pull Request",value:$prurl,inline:false},
+               {name:"Run",value:$runurl,inline:false}
+             ]}]}')
+          curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
+
+      # Red embed if the job itself blew up (dispatch invalid, install broken,
+      # PR creation failed, etc.) — distinct from a controlled verify failure.
+      - name: Notify Discord — failure
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
+          VERSION: ${{ github.event.client_payload.khronos_version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ -z "$DISCORD_WEBHOOK" ]]; then
+            echo "::notice::DISCORD_CICD_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg version "$VERSION" \
+            --arg runurl "$RUN_URL" \
+            '{embeds:[{title:"🔴 Khronos bump — workflow failed",
+              description:"The khronos-client-update workflow errored before completing.",
+              color:15158332,fields:[
+               {name:"Service",value:"Pluto",inline:true},
+               {name:"Stage",value:"Khronos bump",inline:true},
+               {name:"Version",value:($version // "unknown"),inline:true},
+               {name:"Run",value:$runurl,inline:false}
+             ]}]}')
+          curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       # secret is not populated yet.
       - name: Notify Discord — release
         if: steps.release.outputs.release_created == 'true'
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
           VERSION: ${{ steps.release.outputs.tag_name }}
@@ -72,6 +73,7 @@ jobs:
 
       - name: Notify Discord — failure
         if: failure()
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,80 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Mint App token
+        uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.CASCADE_APP_ID }}
+          private-key: ${{ secrets.CASCADE_APP_PRIVATE_KEY }}
+          owner: fearandesire
+          repositories: Pluto-Betting-Bot
+
       - name: Release Please
         uses: googleapis/release-please-action@v5
+        id: release
         with:
-          # Must be a PAT, not GITHUB_TOKEN. GitHub does not trigger new
-          # workflow runs from events created with the default GITHUB_TOKEN,
-          # so a release published with it would never fire the
-          # `release: published` trigger in ci-cd-deployment.yml and Deploy
-          # would never run. PLUTO_BOT_PAT lets the release event cascade.
-          token: ${{ secrets.PLUTO_BOT_PAT }}
+          # Must NOT be GITHUB_TOKEN. GitHub does not trigger new workflow runs
+          # from events created with the default GITHUB_TOKEN, so a release
+          # published with it would never fire the `release: published` trigger
+          # in ci-cd-deployment.yml and Deploy would never run.
+          #
+          # A GitHub App token (fnx-cascade-bot) behaves like a PAT for this:
+          # events it creates DO trigger downstream workflows, so the release
+          # cascades into Deploy. It replaces PLUTO_BOT_PAT here as part of the
+          # PAT → App migration (short-lived, least-privilege, no human account).
+          token: ${{ steps.app.outputs.token }}
           release-type: node
           config-file: .github/release-please-config.json
+
+      # Discord C3: green embed when release-please actually cuts a release
+      # (i.e. it merged/promoted a release PR). Skipped silently if the webhook
+      # secret is not populated yet.
+      - name: Notify Discord — release
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
+          VERSION: ${{ steps.release.outputs.tag_name }}
+          RELEASE_URL: ${{ steps.release.outputs.html_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ -z "$DISCORD_WEBHOOK" ]]; then
+            echo "::notice::DISCORD_CICD_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg version "$VERSION" \
+            --arg relurl "$RELEASE_URL" \
+            --arg runurl "$RUN_URL" \
+            '{embeds:[{title:"🟢 Pluto release published",
+              description:"release-please cut a new release. Deploy will build and push the image.",
+              color:3066993,fields:[
+               {name:"Service",value:"Pluto",inline:true},
+               {name:"Stage",value:"Release",inline:true},
+               {name:"Version",value:$version,inline:true},
+               {name:"Release",value:$relurl,inline:false},
+               {name:"Run",value:$runurl,inline:false}
+             ]}]}')
+          curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
+
+      - name: Notify Discord — failure
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ -z "$DISCORD_WEBHOOK" ]]; then
+            echo "::notice::DISCORD_CICD_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg runurl "$RUN_URL" \
+            '{embeds:[{title:"🔴 Pluto release workflow failed",
+              description:"release-please errored on push to main.",
+              color:15158332,fields:[
+               {name:"Service",value:"Pluto",inline:true},
+               {name:"Stage",value:"Release",inline:true},
+               {name:"Run",value:$runurl,inline:false}
+             ]}]}')
+          curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/README.md
+++ b/README.md
@@ -239,6 +239,32 @@ pnpm dev:unlink-khronos
 
 A pre-commit hook aborts the commit if `yalc.lock` is present — prevents accidentally committing a linked state. If you see it fire, run `pnpm dev:unlink-khronos` first.
 
+## CI/CD — zero-touch cascade
+
+The Khronos → Pluto → deploy path is automated end to end. Human review is only
+required when something is red.
+
+| Stage | Workflow | Behavior |
+|-------|----------|----------|
+| Khronos bump | `khronos-client-update.yml` | On a Khronos release, bumps `@pluto-khronos/*`, runs verify, opens the `deps/khronos-update` PR. **Verify green → GitHub auto-merge (squash).** Verify red → stays a draft for a human. |
+| Release | `release.yml` | release-please opens a `release-please--*` PR on `main`. |
+| Auto-merge release | `auto-merge-release-pr.yml` | Enables auto-merge (squash) on `release-please--*` PRs; they merge once `Verify` passes. |
+| Deploy | `ci-cd-deployment.yml` | On the published release, builds and pushes the Docker image to GHCR. |
+
+**Auth (App token).** The git-writing steps in `khronos-client-update.yml` and
+`release.yml` authenticate with a short-lived token minted from the
+`fnx-cascade-bot` GitHub App (`CASCADE_APP_ID` / `CASCADE_APP_PRIVATE_KEY`),
+replacing `PLUTO_BOT_PAT`. App-token-created PRs and releases still fire the
+downstream `pull_request` / `release: published` events (unlike `GITHUB_TOKEN`),
+so the cascade keeps flowing. The GHCR image push uses `GITHUB_TOKEN` with
+`packages: write`.
+
+**Notifications.** Each stage posts a Discord embed to `DISCORD_CICD_WEBHOOK`
+(green = success/auto-merging, yellow = draft needing a human, red = failure).
+
+Required repo secrets: `CASCADE_APP_ID`, `CASCADE_APP_PRIVATE_KEY`,
+`DISCORD_CICD_WEBHOOK`.
+
 ## Assets
 
 Matchup images under `assets/matchupimages/` are proprietary and **not committed to git** (`assets/` is gitignored). The source of truth is a private Cloudflare R2 bucket: `pluto-assets`, key `matchupimages.tar.gz`.

--- a/docs/ci-cd-khronos-client-update.md
+++ b/docs/ci-cd-khronos-client-update.md
@@ -39,10 +39,30 @@ The verify step is `continue-on-error: true` so the workflow can still open a PR
 
 PR state depends on the verify outcome:
 
-- Verify failed: open or update the PR as a draft.
-- Verify green: open or update the PR ready for review.
+- Verify failed: open or update the PR as a **draft**. Draft PRs are never
+  auto-merged — a human fixes the consumers in the branch, marks it ready, and
+  merges manually.
+- Verify green: open or update the PR and **enable GitHub auto-merge (squash)**.
+  The PR merges itself once the required checks pass (`Verify` and
+  `Validate PR title`). This is the zero-touch happy path — no human click.
 
-There is no auto-merge. A human reviews the dependency diff, checks API/schema impact, and merges manually.
+The bump PR title is `deps(khronos): …`. `deps` is an allowed type in
+`.github/workflows/pr-title.yml`, so the required `Validate PR title` check
+passes and does not block auto-merge. (The eventual squash still lands as
+`fix(khronos)` via the `BEGIN_COMMIT_OVERRIDE` block below.)
+
+## Auth: GitHub App token
+
+The workflow's git-writing steps (checkout, create-pull-request, and the
+`gh pr merge --auto` call) authenticate with a short-lived token minted from
+the `fnx-cascade-bot` GitHub App (`CASCADE_APP_ID` /
+`CASCADE_APP_PRIVATE_KEY`), replacing the older `PLUTO_BOT_PAT`. An App-token
+PR still fires normal `pull_request` events, so the required checks run and
+gate the auto-merge.
+
+A Discord embed is posted to `DISCORD_CICD_WEBHOOK` when the PR is opened —
+green ("auto-merging") when verify passed, yellow ("DRAFT, needs you") when it
+failed.
 
 ## Finding and reviewing the PR
 
@@ -73,7 +93,10 @@ Review checklist:
 2. Check the linked Khronos commit and release notes for API or schema changes.
 3. Inspect Pluto compile/test failures if the PR is draft.
 4. Look for generated client API changes that require call-site updates in Pluto.
-5. Merge manually only after the dependency diff and verification result are acceptable.
+5. A green PR auto-merges once required checks pass — no manual merge needed. If
+   you want to stop it, disable auto-merge on the PR or convert it to a draft
+   before the checks finish. Only a **draft** (verify-failed) PR requires a
+   manual merge after you fix the consumers.
 
 ## Release-please commit override
 


### PR DESCRIPTION
## Zero-Touch Cascade — Pluto side

Automates the Khronos → Pluto → deploy path so human review is only required when something is **red**. GitHub App token (`fnx-cascade-bot`) replaces `PLUTO_BOT_PAT` on the git-writing steps, and each stage posts a Discord embed.

> [!NOTE]
> **Draft** — this stays draft until the blocking dependency below (H3) and the secrets are confirmed. Do not enable auto-merge on this PR.

### Work packages

| WP | Change | File |
|----|--------|------|
| P1 | Auto-merge the Khronos bump PR when verify is green (draft-on-red unchanged); migrate checkout + create-pull-request tokens → App token; Discord embed on PR opened | `.github/workflows/khronos-client-update.yml` |
| P2 | Auto-merge same-repo `release-please--*` PRs into `main` | `.github/workflows/auto-merge-release-pr.yml` (new) |
| P3 | release-please token `PLUTO_BOT_PAT` → App token; GHCR login `PLUTO_BOT_PAT` → `GITHUB_TOKEN` + `packages: write` | `.github/workflows/release.yml`, `.github/workflows/ci-cd-deployment.yml` |
| P4 | Discord embeds (green/yellow/red) on bump PR, release, image push, and failures | P1/P3 workflows |
| P5 | Docs: auto-merge + App token behavior | `docs/ci-cd-khronos-client-update.md`, `README.md` |

### pr-title `deps` finding (WP-P1 pre-check)

**`deps` is ALREADY in `pr-title.yml`'s allowed types** (`.github/workflows/pr-title.yml`, line 36). The bump PR title `deps(khronos): …` therefore passes the required **Validate PR title** check as-is — it does **not** block auto-merge. **Resolution: no change needed** to either `pr-title.yml` or the bump PR title (the smaller correct change is zero change). The eventual squash still lands as `fix(khronos)` via the existing `BEGIN_COMMIT_OVERRIDE` block, so the release classification is unaffected.

### ⚠️ Blocking dependency — H3 (WP-P3, GHCR grant)

`ci-cd-deployment.yml`'s Deploy job now logs into GHCR with `GITHUB_TOKEN` (+ newly-added `packages: write` on the job). **This 403s at push time unless the `pluto-betting-bot` GHCR package has granted this repo's Actions write access** (human prereq H3). Two things were required and both are in this PR *except* the org-side grant:

1. ✅ `packages: write` added to the Deploy job permissions (was implicitly provided by `PLUTO_BOT_PAT` before).
2. ❌ **H3 — GHCR package → Settings → Actions access → add `fearandesire/Pluto-Betting-Bot` with Write.** Not something this PR can do. **This is why the PR is kept draft.**

`PLUTO_BOT_PAT` is intentionally **not deleted** anywhere — it remains as a rollback for the GHCR login if the grant isn't in place.

### Required secrets (may not be populated yet)

- `CASCADE_APP_ID`, `CASCADE_APP_PRIVATE_KEY` — App token minting (all workflows fail to mint without these).
- `DISCORD_CICD_WEBHOOK` — Discord embeds. Every notify step **skips silently** (`::notice::`) if this is empty, so an unpopulated webhook does not fail any run.

### Confirm before merge — App must be an allowed merger

Auto-merge merges **as the `fnx-cascade-bot` App**. If `main`'s branch protection restricts *who* may merge (a "Restrict who can push / merge" allowlist), the App must be on it — otherwise auto-merge stalls at merge time even with all checks green. Repo-level "allow auto-merge" being on does **not** guarantee the App is a permitted merger. Please confirm.

### Verification done in this PR

- **WP-P2 branch prefix confirmed against ground truth:** merged release-please PR #588's head branch is `release-please--branches--main--components--pluto-betting`, which matches `startsWith(github.head_ref, 'release-please--')`. The gate is live, not dead-on-arrival.
- **Notifications are non-fatal:** every Discord step is `continue-on-error: true` and skips silently when the webhook secret is empty, so an unpopulated/misbehaving webhook can never fail a run or trip a spurious failure embed.
- **Draft edge case handled:** the khronos auto-merge step runs `gh pr ready` before `gh pr merge --auto`, so a green dispatch following an earlier verify-failed (draft) dispatch on the static branch doesn't error.

### Notes / context

- Base `main` already has required checks **Verify** + **Validate PR title** and auto-merge is enabled on the repo — so `gh pr merge --auto` will wait for those and merge on green.
- App-token-created PRs/releases fire normal `pull_request` / `release: published` events (unlike `GITHUB_TOKEN`), so the cascade keeps flowing.

### Git hygiene note

The main working tree was on another agent's branch (`agent/docs-durable-cascade-1870`) with uncommitted changes. `git checkout -b … origin/main` refused because `origin/main` diverges from the working tree on `.remember/remember.md`. Rather than a hard stop (or stashing/discarding the other agent's dirt), this branch was built from an **isolated `git worktree` off `origin/main`**, leaving all pre-existing dirt byte-for-byte untouched. The PR content is unaffected — its base is `origin/main` regardless.
