### PR TITLE
fix(ci): tag :latest on release deploys so Watchtower updates

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -143,7 +143,10 @@ jobs:
 
           # 3. Fallback (should never happen)
           VERSION="${VERSION:-0.0.0}"
-          ENABLE_LATEST="${{ github.ref == 'refs/heads/main' }}"
+          # Release events run on the tag ref (refs/tags/vX.Y.Z), not
+          # refs/heads/main — without the release clause, release deploys
+          # never move :latest and Watchtower on the VPS never updates.
+          ENABLE_LATEST="${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Release-event deploys run on the tag ref, so \ENABLE_LATEST\ (\github.ref == 'refs/heads/main'\) was always false — v4.6.5/v4.6.6 images published without \:latest\, and Watchtower (which tracks \pluto-betting-bot:latest\ on the VPS) never deployed them. Adds \|| github.event_name == 'release'\.