### PR TITLE
fix(build): exclude tests from production image

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -94,6 +94,45 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Verify production dist
+        run: pnpm verify:dist
+
+      - name: Build production image for packaging smoke
+        run: |
+          mkdir -p assets
+          docker build \
+            --target production \
+            --tag "pluto-production-smoke:${GITHUB_SHA}" \
+            .
+
+      - name: Verify production image packaging
+        run: |
+          docker run --rm \
+            --entrypoint /bin/sh \
+            "pluto-production-smoke:${GITHUB_SHA}" \
+            -c '
+              set -eu
+              test -f /app/dist/index.js
+
+              leaked="$(find /app/dist -type f \( \
+                -path "*/__tests__/*" \
+                -o -name "*.test.*" \
+                -o -name "*.spec.*" \
+              \) -print)"
+
+              if [ -n "$leaked" ]; then
+                printf "Compiled test artifacts found in production image:\n%s\n" "$leaked" >&2
+                exit 1
+              fi
+
+              if node --input-type=module \
+                -e "await import(\"vitest\")" >/dev/null 2>&1
+              then
+                echo "vitest is importable in the production image" >&2
+                exit 1
+              fi
+            '
+
   # ===========================================================================
   # DEPLOY - Build and push Docker image to GHCR
   # Triggers: release event (release-please) | workflow_dispatch with force_build

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 	"main": "./dist/index.js",
 	"scripts": {
 		"clean": "rimraf ./dist",
-		"build": "swc src -d dist --strip-leading-paths && tsc-alias -p tsconfig.json --resolve-full-paths",
+		"build": "rimraf dist && swc src -d dist --strip-leading-paths --ignore \"**/__tests__/**,**/*.test.ts,**/*.spec.ts\" && tsc-alias -p tsconfig.json --resolve-full-paths",
+		"verify:dist": "node scripts/verify-production-dist.mjs",
 		"lint": "biome check --write . --unsafe",
 		"start": "node --env-file-if-exists=.env ./dist/index.js",
 		"dev": "pnpm build && pnpm start",

--- a/scripts/verify-production-dist.mjs
+++ b/scripts/verify-production-dist.mjs
@@ -1,0 +1,41 @@
+import { readdir } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+
+const distDirectory = path.resolve('dist')
+const forbiddenFiles = []
+
+async function inspectDirectory(directory) {
+	const entries = await readdir(directory, { withFileTypes: true })
+
+	for (const entry of entries) {
+		const entryPath = path.join(directory, entry.name)
+		const relativePath = path.relative(distDirectory, entryPath)
+		const pathSegments = relativePath.split(path.sep)
+
+		if (entry.isDirectory()) {
+			if (pathSegments.includes('__tests__')) {
+				forbiddenFiles.push(`${relativePath}${path.sep}`)
+				continue
+			}
+
+			await inspectDirectory(entryPath)
+			continue
+		}
+
+		if (/\.(?:test|spec)\./u.test(entry.name)) {
+			forbiddenFiles.push(relativePath)
+		}
+	}
+}
+
+await inspectDirectory(distDirectory)
+
+if (forbiddenFiles.length > 0) {
+	forbiddenFiles.sort()
+	console.error('Production dist contains test artifacts:')
+	for (const file of forbiddenFiles) console.error(`- ${file}`)
+	process.exitCode = 1
+} else {
+	console.log('Production dist contains no test artifacts.')
+}


### PR DESCRIPTION
## Summary
- exclude test and spec sources from SWC production output
- fail CI if compiled test artifacts appear in \dist\
- build and inspect the final production image without secrets, proving its entrypoint exists and Vitest is not shipped

## Verification
- \pnpm install --frozen-lockfile\
- \pnpm typecheck\
- Redis-backed suite: 42 files / 241 tests
- \pnpm build && pnpm verify:dist\
- final Docker production-stage build and in-image packaging smoke
- \git diff --check\

## Production evidence
The current v4.6.7 container starts successfully but logs four \ERR_MODULE_NOT_FOUND: vitest\ errors because compiled test pieces are recursively discovered. This removes those files instead of adding Vitest to production dependencies.