### PR TITLE
fix(ci): confirm Khronos bumps only after landing

### DIFF
--- a/.github/workflows/khronos-client-update.yml
+++ b/.github/workflows/khronos-client-update.yml
@@ -256,14 +256,12 @@ jobs:
           curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
 
   # A lockfile push alone is not sufficient proof: unrelated dependency work
-  # can also change pnpm-lock.yaml. Match the exact generated squash subject,
-  # then verify both installed Khronos packages are present at one version
-  # before reporting the landed state.
+  # can also change pnpm-lock.yaml. Compare package.json before and after the
+  # push, then require both installed Khronos packages to have changed to one
+  # version before reporting the landed state.
   notify_landed:
     name: Notify Khronos bump landed
-    if: >-
-      github.event_name == 'push' &&
-      startsWith(github.event.head_commit.message, 'deps(khronos): bump @pluto-khronos/* to ')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -273,9 +271,13 @@ jobs:
     steps:
       - name: Checkout landed commit
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Verify landed package versions
         id: versions
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
           API_CLIENT_VERSION=$(jq -r '.dependencies["@pluto-khronos/api-client"] // empty' package.json)
@@ -291,10 +293,27 @@ jobs:
             exit 1
           fi
 
+          BEFORE_PACKAGE=$(git show "${BEFORE_SHA}:package.json" 2>/dev/null || true)
+          if [[ -z "$BEFORE_PACKAGE" ]]; then
+            echo "::notice::Could not read package.json at the before SHA; skipping landed notification"
+            echo "landed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PREVIOUS_API_CLIENT_VERSION=$(jq -r '.dependencies["@pluto-khronos/api-client"] // empty' <<<"$BEFORE_PACKAGE")
+          PREVIOUS_TYPES_VERSION=$(jq -r '.dependencies["@pluto-khronos/types"] // empty' <<<"$BEFORE_PACKAGE")
+
+          if [[ "$API_CLIENT_VERSION" == "$PREVIOUS_API_CLIENT_VERSION" || "$TYPES_VERSION" == "$PREVIOUS_TYPES_VERSION" ]]; then
+            echo "::notice::This lockfile push did not change both Khronos package versions; skipping landed notification"
+            echo "landed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "landed=true" >> "$GITHUB_OUTPUT"
           echo "version=$API_CLIENT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Notify Discord — bump landed
-        if: env.DISCORD_WEBHOOK != ''
+        if: steps.versions.outputs.landed == 'true' && env.DISCORD_WEBHOOK != ''
         continue-on-error: true
         env:
           VERSION: ${{ steps.versions.outputs.version }}

--- a/.github/workflows/khronos-client-update.yml
+++ b/.github/workflows/khronos-client-update.yml
@@ -16,6 +16,9 @@
 #       click required — this is the "zero-touch" happy path.
 #   5b. Verify red: PR stays DRAFT and is NEVER auto-merged. A human fixes the
 #       consumers in the branch, marks ready, and merges manually.
+#   6. When the generated `deps(khronos): bump ...` squash commit lands on
+#      main, emit the green confirmation. PR-open notifications stay yellow
+#      because auto-merge being armed is still an in-flight state.
 #
 # All git-writing steps (checkout, create-pull-request, gh pr merge) use a
 # short-lived GitHub App token minted from the `fnx-cascade-bot` App
@@ -42,6 +45,11 @@ name: Khronos client update
 on:
   repository_dispatch:
     types: [khronos-release]
+  push:
+    branches: [main]
+    # Every generated lockstep Khronos bump changes the lockfile. Restricting
+    # this trigger avoids runs for release-please's package.json-only commits.
+    paths: [pnpm-lock.yaml]
 
 permissions:
   contents: write
@@ -50,6 +58,7 @@ permissions:
 jobs:
   bump:
     name: Bump @pluto-khronos/* packages
+    if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
 
     steps:
@@ -174,9 +183,9 @@ jobs:
           gh pr ready "$PR" -R "${{ github.repository }}"
           gh pr merge --auto --squash -R "${{ github.repository }}" "$PR"
 
-      # Discord C3: one embed announcing the bump PR. Green = auto-merging,
-      # yellow = draft awaiting a human. Skipped silently if the webhook secret
-      # is not populated yet.
+      # Discord C3: a PR is still in flight even when verification passed and
+      # auto-merge is armed, so both outcomes are yellow. The push-triggered
+      # notify_landed job emits green only after the generated bump lands.
       - name: Notify Discord — bump PR
         if: steps.diff.outputs.has_changes == 'true'
         continue-on-error: true
@@ -192,9 +201,9 @@ jobs:
             exit 0
           fi
           if [[ "$VERIFY" == "success" ]]; then
-            COLOR=3066993   # green 0x2ecc71
-            TITLE="🟢 Khronos bump — auto-merging"
-            DESC="Verify passed. Auto-merge (squash) is enabled; the PR merges once required checks are green."
+            COLOR=15844367  # yellow 0xf1c40f
+            TITLE="🟡 Khronos bump — auto-merge in flight"
+            DESC="Verify passed. Auto-merge (squash) is armed; green confirmation follows only after the bump lands on main."
           else
             COLOR=15844367  # yellow 0xf1c40f
             TITLE="🟡 Khronos bump — DRAFT, needs you"
@@ -242,6 +251,67 @@ jobs:
                {name:"Service",value:"Pluto",inline:true},
                {name:"Stage",value:"Khronos bump",inline:true},
                {name:"Version",value:$version,inline:true},
+               {name:"Run",value:$runurl,inline:false}
+             ]}]}')
+          curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
+
+  # A lockfile push alone is not sufficient proof: unrelated dependency work
+  # can also change pnpm-lock.yaml. Match the exact generated squash subject,
+  # then verify both installed Khronos packages are present at one version
+  # before reporting the landed state.
+  notify_landed:
+    name: Notify Khronos bump landed
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.event.head_commit.message, 'deps(khronos): bump @pluto-khronos/* to ')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_CICD_WEBHOOK }}
+
+    steps:
+      - name: Checkout landed commit
+        uses: actions/checkout@v6
+
+      - name: Verify landed package versions
+        id: versions
+        run: |
+          set -euo pipefail
+          API_CLIENT_VERSION=$(jq -r '.dependencies["@pluto-khronos/api-client"] // empty' package.json)
+          TYPES_VERSION=$(jq -r '.dependencies["@pluto-khronos/types"] // empty' package.json)
+
+          if [[ -z "$API_CLIENT_VERSION" || -z "$TYPES_VERSION" ]]; then
+            echo "::error::The landed commit does not contain both @pluto-khronos dependencies"
+            exit 1
+          fi
+
+          if [[ "$API_CLIENT_VERSION" != "$TYPES_VERSION" ]]; then
+            echo "::error::The landed Khronos packages are not in lockstep: api-client=$API_CLIENT_VERSION types=$TYPES_VERSION"
+            exit 1
+          fi
+
+          echo "version=$API_CLIENT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Discord — bump landed
+        if: env.DISCORD_WEBHOOK != ''
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.versions.outputs.version }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload=$(jq -n \
+            --arg version "$VERSION" \
+            --arg commiturl "$COMMIT_URL" \
+            --arg runurl "$RUN_URL" \
+            '{embeds:[{title:"🟢 Khronos bump landed — Pluto up to date",
+              description:"The lockstep @pluto-khronos dependency bump is now on main.",
+              color:3066993,fields:[
+               {name:"Service",value:"Pluto",inline:true},
+               {name:"Stage",value:"Khronos bump",inline:true},
+               {name:"Version",value:$version,inline:true},
+               {name:"Commit",value:$commiturl,inline:false},
                {name:"Run",value:$runurl,inline:false}
              ]}]}')
           curl -sf -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/docs/ci-cd-khronos-client-update.md
+++ b/docs/ci-cd-khronos-client-update.md
@@ -6,9 +6,9 @@ Related Khronos docs:
 
 - [Khronos release cascade](https://github.com/fearandesire/khronos/blob/main/docs/ci-cd-release-cascade.md)
 
-## Trigger
+## Triggers
 
-The workflow runs on `repository_dispatch` with event type `khronos-release`.
+The bump job runs on `repository_dispatch` with event type `khronos-release`.
 
 Expected dispatch payload:
 
@@ -16,6 +16,13 @@ Expected dispatch payload:
 - `client_payload.sha`: Khronos source commit, linked in the generated PR body.
 
 Khronos sends this dispatch after publishing the matching `@pluto-khronos/api-client` and `@pluto-khronos/types` packages.
+
+A separate confirmation job watches pushes to `main` that change
+`pnpm-lock.yaml`. It runs only when the landed squash subject starts with the
+exact generated prefix `deps(khronos): bump @pluto-khronos/* to `. Before it
+posts a confirmation, it reads `package.json` and requires both Khronos
+packages to be present at the same version. This prevents unrelated lockfile
+changes from producing false green notifications.
 
 ## Branch and PR behavior
 
@@ -60,9 +67,17 @@ the `fnx-cascade-bot` GitHub App (`CASCADE_APP_ID` /
 PR still fires normal `pull_request` events, so the required checks run and
 gate the auto-merge.
 
-A Discord embed is posted to `DISCORD_CICD_WEBHOOK` when the PR is opened —
-green ("auto-merging") when verify passed, yellow ("DRAFT, needs you") when it
-failed.
+Discord notifications use state-based colors:
+
+- Yellow, auto-merge in flight: verification passed and squash auto-merge is
+  armed, but the bump has not landed on `main` yet.
+- Yellow, action needed: verification failed and the PR remains a draft.
+- Green, landed: the generated bump squash commit is on `main`, and both
+  `@pluto-khronos` dependencies are present at the same version.
+- Red, failed: the dispatch/bump job failed unexpectedly.
+
+Notification delivery remains `continue-on-error`; a missing webhook noops and
+does not block the dependency workflow.
 
 ## Finding and reviewing the PR
 
@@ -93,10 +108,11 @@ Review checklist:
 2. Check the linked Khronos commit and release notes for API or schema changes.
 3. Inspect Pluto compile/test failures if the PR is draft.
 4. Look for generated client API changes that require call-site updates in Pluto.
-5. A green PR auto-merges once required checks pass — no manual merge needed. If
-   you want to stop it, disable auto-merge on the PR or convert it to a draft
-   before the checks finish. Only a **draft** (verify-failed) PR requires a
-   manual merge after you fix the consumers.
+5. A verified PR auto-merges once required checks pass — no manual merge needed.
+   Yellow means that merge is still in flight; green arrives only after the
+   bump lands on `main`. To stop it, disable auto-merge on the PR or convert it
+   to a draft before the checks finish. Only a **draft** (verify-failed) PR
+   requires a manual merge after you fix the consumers.
 
 ## Release-please commit override
 

--- a/docs/ci-cd-khronos-client-update.md
+++ b/docs/ci-cd-khronos-client-update.md
@@ -18,11 +18,11 @@ Expected dispatch payload:
 Khronos sends this dispatch after publishing the matching `@pluto-khronos/api-client` and `@pluto-khronos/types` packages.
 
 A separate confirmation job watches pushes to `main` that change
-`pnpm-lock.yaml`. It runs only when the landed squash subject starts with the
-exact generated prefix `deps(khronos): bump @pluto-khronos/* to `. Before it
-posts a confirmation, it reads `package.json` and requires both Khronos
-packages to be present at the same version. This prevents unrelated lockfile
-changes from producing false green notifications.
+`pnpm-lock.yaml`. It compares `package.json` at the push's before and after
+commits, requires both Khronos dependencies to have changed, and requires the
+new versions to match. This prevents unrelated lockfile changes from producing
+false green notifications and does not depend on repository squash-message
+settings.
 
 ## Branch and PR behavior
 


### PR DESCRIPTION
## Summary
- keep successful Khronos bump PRs yellow while auto-merge is still in flight
- emit green only after the generated squash commit lands on main
- guard landed confirmation with the exact generated subject and lockstep dependency versions
- document the dual-trigger and color contract

## Verification
- `actionlint`
- YAML structure assertions
- `git diff --check`
- historical replay: real v3.8.0 bump matched; v4.6.8 release commit excluded
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fearandesire/pluto-betting-bot/pull/599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->